### PR TITLE
Core 1185: Ethereum identity uniqueness

### DIFF
--- a/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
+++ b/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
@@ -20,7 +20,8 @@ class IntegrationKey implements Serializable {
 	static mapping = {
 		id generator: IdGenerator.name // Note: doesn't apply in unit tests
 		json type: 'text'
-		idInService(index: "id_in_service_idx")
+		idInService(index: "id_in_service_and_service_idx")
+		service(index: "id_in_service_and_service_idx")
 	}
 
 	static constraints = {

--- a/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
+++ b/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
@@ -12,6 +12,7 @@ class IntegrationKey implements Serializable {
 	String name
 	Service service
 	String json
+	String idInService
 
 	Date dateCreated
 	Date lastUpdated
@@ -19,6 +20,7 @@ class IntegrationKey implements Serializable {
 	static mapping = {
 		id generator: IdGenerator.name // Note: doesn't apply in unit tests
 		json type: 'text'
+		idInService(index: "id_in_service_idx")
 	}
 
 	static constraints = {

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -91,4 +91,5 @@ databaseChangeLog = {
 	include file: 'core/2018-01-29-remove-mongodb-and-twitter-feeds.groovy'
 	include file: 'core/2018-01-31-mqtt-help-text-update.groovy'
 	include file: 'core/2018-02-12-add-anonymous-index-to-permission.groovy'
+	include file: 'core/2018-02-27-add-id-in-service-to-integration-key.groovy'
 }

--- a/grails-app/migrations/core/2018-02-27-add-id-in-service-to-integration-key.groovy
+++ b/grails-app/migrations/core/2018-02-27-add-id-in-service-to-integration-key.groovy
@@ -27,8 +27,9 @@ databaseChangeLog = {
 	}
 
 	changeSet(author: "eric", id: "add-id-in-service-to-integration-key-3") {
-		createIndex(indexName: "id_in_service_idx", tableName: "integration_key") {
+		createIndex(indexName: "id_in_service_and_service_idx", tableName: "integration_key") {
 			column(name: "id_in_service")
+			column(name: "service")
 		}
 	}
 }

--- a/grails-app/migrations/core/2018-02-27-add-id-in-service-to-integration-key.groovy
+++ b/grails-app/migrations/core/2018-02-27-add-id-in-service-to-integration-key.groovy
@@ -1,0 +1,34 @@
+package core
+
+import groovy.json.JsonSlurper
+
+databaseChangeLog = {
+
+	changeSet(author: "eric", id: "add-id-in-service-to-integration-key-1") {
+		addColumn(tableName: "integration_key") {
+			column(name: "id_in_service", type: "varchar(255)") {
+				constraints(nullable: "false")
+			}
+		}
+	}
+
+	changeSet(author: "eric", id: "add-id-in-service-to-integration-key-2") {
+		grailsChange {
+			change {
+				sql.eachRow('SELECT id, json FROM integration_key WHERE service = "ETHEREUM" OR service = "ETHEREUM_ID"') { row ->
+					String keyId = row['id']
+					String json = row['json']
+
+					Map<String, String> jsonMap = new JsonSlurper().parseText(json)
+					sql.execute('UPDATE integration_key SET id_in_service = ? WHERE id = ?', jsonMap.address, keyId)
+				}
+			}
+		}
+	}
+
+	changeSet(author: "eric", id: "add-id-in-service-to-integration-key-3") {
+		createIndex(indexName: "id_in_service_idx", tableName: "integration_key") {
+			column(name: "id_in_service")
+		}
+	}
+}

--- a/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
+++ b/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
@@ -1,6 +1,7 @@
 package com.unifina.service
 
 import com.unifina.api.ApiException
+import com.unifina.api.DuplicateNotAllowedException
 import com.unifina.crypto.ECRecover
 import com.unifina.domain.security.Challenge
 import com.unifina.domain.security.IntegrationKey
@@ -91,6 +92,11 @@ class EthereumIntegrationKeyService {
 		} catch (SignatureException | DecoderException e) {
 			throw new ApiException(400, "ADDRESS_RECOVERY_ERROR", e.message)
 		}
+
+		if (IntegrationKey.findByServiceAndIdInService(IntegrationKey.Service.ETHEREUM_ID, address) != null) {
+			throw new DuplicateNotAllowedException("Ethereum ID already taken.")
+		}
+
 		return new IntegrationKey(
 				name: name,
 				user: user,

--- a/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
+++ b/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
@@ -94,7 +94,7 @@ class EthereumIntegrationKeyService {
 		}
 
 		if (IntegrationKey.findByServiceAndIdInService(IntegrationKey.Service.ETHEREUM_ID, address) != null) {
-			throw new DuplicateNotAllowedException("Ethereum ID already taken.")
+			throw new DuplicateNotAllowedException("This Ethereum address is already associated with another Streamr user.")
 		}
 
 		return new IntegrationKey(

--- a/src/java/com/unifina/api/DuplicateNotAllowedException.java
+++ b/src/java/com/unifina/api/DuplicateNotAllowedException.java
@@ -1,0 +1,7 @@
+package com.unifina.api;
+
+public class DuplicateNotAllowedException extends ApiException {
+	public DuplicateNotAllowedException(String message) {
+		super(400, "DUPLICATE_NOT_ALLOWED", message);
+	}
+}

--- a/test/unit/com/unifina/controller/api/IntegrationKeyApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/IntegrationKeyApiControllerSpec.groovy
@@ -27,22 +27,25 @@ class IntegrationKeyApiControllerSpec extends Specification {
 		key.save(failOnError: true, validate: true)
 
 		new IntegrationKey(
-			name: "my-integration-key-1",
-			user: me,
-			service: IntegrationKey.Service.ETHEREUM,
-			json: "{ address: '0x0000000000000000000' }"
+				name: "my-integration-key-1",
+				user: me,
+				service: IntegrationKey.Service.ETHEREUM,
+				idInService: "0x0000000000000000000",
+				json: "{ address: '0x0000000000000000000' }"
 		).save(validate: true, failOnError: true)
 		new IntegrationKey(
-			name: "my-integration-key-2",
-			user: me,
-			service: IntegrationKey.Service.ETHEREUM_ID,
-			json: "{ address: '0x0000000000000000000' }"
+				name: "my-integration-key-2",
+				user: me,
+				service: IntegrationKey.Service.ETHEREUM_ID,
+				idInService: "0x0000000000000000000",
+				json: "{ address: '0x0000000000000000000' }"
 		).save(validate: true, failOnError: true)
 		new IntegrationKey(
-			name: "not-my-integration-key",
-			user: someoneElse,
-			service: IntegrationKey.Service.ETHEREUM,
-			json: "{ address: '0x0000000000000000000' }"
+				name: "not-my-integration-key",
+				user: someoneElse,
+				service: IntegrationKey.Service.ETHEREUM,
+				idInService: "0x0000000000000000000",
+				json: "{ address: '0x0000000000000000000' }"
 		).save(validate: true, failOnError: true)
 	}
 

--- a/test/unit/com/unifina/service/EthereumIntegrationKeyServiceSpec.groovy
+++ b/test/unit/com/unifina/service/EthereumIntegrationKeyServiceSpec.groovy
@@ -1,6 +1,7 @@
 package com.unifina.service
 
 import com.unifina.api.ApiException
+import com.unifina.api.DuplicateNotAllowedException
 import com.unifina.domain.security.Challenge
 import com.unifina.domain.security.IntegrationKey
 import com.unifina.domain.security.SecUser
@@ -142,5 +143,19 @@ class EthereumIntegrationKeyServiceSpec extends Specification {
 		then:
 		def e = thrown(ApiException)
 		e.message == "challenge validation failed"
+	}
+
+	void "createEthereumID() checks for duplicate addresses"() {
+		def ch = new Challenge(challenge: "foobar")
+		ch.save(failOnError: true, validate: false)
+		String signature = "0x50ba6f6df25ba593cb8188df29ca27ea0a7cd38fadc4d40ef9fad455117e190f2a7ec880a76b930071205fee19cf55eb415bd33b2f6cb5f7be36f79f740da6e81b"
+		String name = "foobar"
+
+		service.createEthereumID(me, name, ch.id, ch.challenge, signature)
+
+		when:
+		service.createEthereumID(me, name, ch.id, ch.challenge, signature)
+		then:
+		thrown(DuplicateNotAllowedException)
 	}
 }

--- a/test/unit/com/unifina/signalpath/blockchain/EthereumAccountParameterSpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/EthereumAccountParameterSpec.groovy
@@ -64,7 +64,7 @@ class EthereumAccountParameterSpec extends BeanMockingSpecification {
 	void "parseValue() returns integration key given existing Ethereum-service key id"() {
 		setup:
 		SecUser user = new SecUser(name: "name", username: "name@name.com", password: "pass").save(failOnError: true, validate: false)
-		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user)
+		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user, idInService: "0x0")
 		key.id = "account-1"
 		key.json = "{}"
 		key.save(failOnError: true, validate: true)
@@ -76,7 +76,7 @@ class EthereumAccountParameterSpec extends BeanMockingSpecification {
 	void "getPrivateKey() and getAddress() return values from json, after configuration, if logged in as owner"() {
 		setup:
 		SecUser user = new SecUser(name: "name", username: "name@name.com", password: "pass").save(failOnError: true, validate: false, flush: true)
-		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user)
+		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user, idInService: "0xffff")
 
 		key.id = "account-1"
 		key.json = '{ "privateKey": "' + encryptor.encrypt("0000", user.id.byteValue()) + '", "address": "0xffff"}'
@@ -94,7 +94,7 @@ class EthereumAccountParameterSpec extends BeanMockingSpecification {
 	void "getAddress() return values from json, after configuration, even if not logged in as user"() {
 		setup:
 		SecUser user = new SecUser(name: "name", username: "name@name.com", password: "pass").save(failOnError: true, validate: false, flush: true)
-		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user)
+		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user, idInService: "0xffff")
 
 		key.id = "account-1"
 		key.json = '{ "privateKey": "0x0000", "address": "0xffff"}'
@@ -113,7 +113,7 @@ class EthereumAccountParameterSpec extends BeanMockingSpecification {
 	void "getPrivateKey() throws exception, after configuration, if not logged in as user"() {
 		setup:
 		SecUser user = new SecUser(name: "name", username: "name@name.com", password: "pass").save(failOnError: true, validate: false, flush: true)
-		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user)
+		IntegrationKey key = new IntegrationKey(name: "key", service: IntegrationKey.Service.ETHEREUM, user: user, idInService: 0xffff)
 
 		key.id = "account-1"
 		key.json = '{ "privateKey": "0x0000", "address": "0xffff"}'

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityModuleSpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityModuleSpec.groovy
@@ -17,7 +17,7 @@ class SolidityModuleSpec extends ModuleTestingSpecification {
 	def setup() {
 		// mock the key for ethereum account
 		SecUser user = new SecUser(name: "name", username: "name@name.com", password: "pass", timezone: "UTC").save(failOnError: true, validate: false)
-		IntegrationKey key = new IntegrationKey(service: IntegrationKey.Service.ETHEREUM, name: "test key", json: '{"privateKey":"lol","address":"0x1234"}', user: user)
+		IntegrationKey key = new IntegrationKey(service: IntegrationKey.Service.ETHEREUM, name: "test key", json: '{"privateKey":"lol","address":"0x1234"}', user: user, idInService: "0x1234")
 		key.id = "sgKjr1eHQpqTmwz3vK3DqwUK1wFlrfRJa9mnf_xTeFJQ"
 		key.save(failOnError: true, validate: true)
 


### PR DESCRIPTION
- Add database-indexed field `idInService` to `IntegrationKey`. Represents
public identifier of an integration key in the context of the service.
This is equivalent to public wallet address for services ETHEREUM and
ETHEREUM_ID.
- Enforce the uniqueness of public addresses of `IntegrationKey`(s) of type `ETHEREUM_ID` at service level.