### PR TITLE
CORE-1172 webpack bundles no longer handled by grails resources plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ node_modules
 .slcache/
 plugin.xml
 hs_err_pid*
-web-app/js/unifina/webpack-bundles/*
+web-app/webpack-bundles/*
 npm-debug.log*
 tomcat.8081

--- a/grails-app/conf/ApplicationResources.groovy
+++ b/grails-app/conf/ApplicationResources.groovy
@@ -100,7 +100,7 @@ modules = {
 	}
 	pnotify {
 		dependsOn 'jquery'
-		resource url:[dir:'js/pnotify-1.2.0', file:'jquery.pnotify.1.2.2-snapshot.js', plugin: 'unifina-core']
+		resource url:[dir:'js/pnotify-1.2.0', file:'jquery.pnotify.1.2.2-snapshot.js'], disposition: 'head' // streamr module depends on this and has disposition: head
 		resource url:[dir:'js/pnotify-1.2.0', file:'jquery.pnotify.default.css', plugin: 'unifina-core']
 	}
 	slimscroll {
@@ -114,7 +114,7 @@ modules = {
 		resource url:[dir:'js/webcomponentsjs', file:'webcomponents.min.js', plugin: 'unifina-core'], disposition:'head'
 	}
 	lodash {
-		resource url:[dir:'js/lodash-3.10.1', file:'lodash.min.js', plugin: 'unifina-core']
+		resource url:[dir:'js/lodash-3.10.1', file:'lodash.min.js'], disposition: 'head' // streamr module depends on this and has disposition: head
 	}
 	backbone {
 		dependsOn 'lodash,jquery'
@@ -161,7 +161,7 @@ modules = {
 	 */
 	streamr {
 		dependsOn 'pnotify, lodash'
-		resource url:[dir:'js/unifina', file:'streamr.js', plugin: 'unifina-core']
+		resource url:[dir:'js/unifina', file:'streamr.js'], disposition: 'head' // disposition: head because some react-based stuff outside grails resource management depend on this
 	}
 	tour {
 		dependsOn 'hopscotch, streamr'
@@ -268,20 +268,6 @@ modules = {
 	}
 	'confirm-button' {
 		resource url:[dir:'js/unifina/confirm-button', file:'confirm-button.js', plugin: 'unifina-core']
-	}
-	'webpack-commons-bundle' {
-		resource url:[dir:'js/unifina/webpack-bundles', file:'commons.bundle.js']
-		resource url:[dir:'js/unifina/webpack-bundles', file:'commons.bundle.css']
-	}
-	'profile-page-webpack-bundle' {
-		dependsOn 'webpack-commons-bundle'
-		resource url: [dir: 'js/unifina/webpack-bundles', file: 'profilePage.bundle.js', plugin: 'unifina-core']
-		resource url: [dir: 'js/unifina/webpack-bundles', file: 'profilePage.bundle.css', plugin: 'unifina-core']
-	}
-	'dashboard-page-webpack-bundle' {
-		dependsOn 'webpack-commons-bundle'
-		resource url: [dir: 'js/unifina/webpack-bundles', file: 'dashboardPage.bundle.js', plugin: 'unifina-core']
-		resource url: [dir: 'js/unifina/webpack-bundles', file: 'dashboardPage.bundle.css', plugin: 'unifina-core']
 	}
 	'signalpath-core' {
 		// Easier to merge if dependencies are one-per-row instead of comma-separated list

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -68,6 +68,11 @@ environments {
 	}
 }
 
+// See WebpackTagLib.groovy
+webpack.bundle.dir = '/webpack-bundles'
+webpack.jsFiles.metadataKey = 'webpack.jsFiles'
+webpack.cssFiles.metadataKey = 'webpack.cssFiles'
+
 environments {
 	test {
 		grails.reload.enabled = true
@@ -385,12 +390,12 @@ grails.plugin.springsecurity.adh.errorPage = null
 grails.plugin.springsecurity.securityConfigType = 'Annotation'
 
 grails.plugin.springsecurity.controllerAnnotations.staticRules = [
-	'/user/**':            ['ROLE_ADMIN'],
-	'/register/**':				 ['IS_AUTHENTICATED_ANONYMOUSLY'],
-	'/webcomponents/*':				 ['IS_AUTHENTICATED_ANONYMOUSLY'],
-	'/*':				 ['IS_AUTHENTICATED_ANONYMOUSLY']
+	'/user/**':           ['ROLE_ADMIN'],
+	'/register/**':       ['IS_AUTHENTICATED_ANONYMOUSLY'],
+	'/webcomponents/*':   ['IS_AUTHENTICATED_ANONYMOUSLY'],
+	'/webpack-bundles/*': ['IS_AUTHENTICATED_ANONYMOUSLY'],
+	'/*':                 ['IS_AUTHENTICATED_ANONYMOUSLY']
 ]
-
 
 /**
  * Email config

--- a/grails-app/taglib/com/unifina/taglibs/WebpackTagLib.groovy
+++ b/grails-app/taglib/com/unifina/taglibs/WebpackTagLib.groovy
@@ -1,0 +1,43 @@
+package com.unifina.taglibs
+
+/**
+ * Helper taglib for including webpack-generated js and css files.
+ * Webpack adds chunk hashes to production versions of bundles. The filenames of
+ * these bundles are inspected and saved to application.properties upon war creation
+ * (in _Events.groovy). The key-value-pairs in application.properties appear as
+ * grailsApplication.metadata, from which they can be read.
+ *
+ * If the filenames are not found in metadata, a fallback name of name.bundle.js is assumed.
+ */
+class WebpackTagLib {
+
+	static namespace = 'webpack'
+
+	/**
+	 * Includes a webpack js bundle.
+	 *
+	 * @attr name REQUIRED the bundle name
+	 */
+	def jsBundle = { attrs ->
+		String name = attrs.name
+		def config = grailsApplication.config
+
+		// Check grailsApplication metadata for a filename that corresponds to this bundle, fallback to name.bundle.js
+		String fileName = grailsApplication.metadata[config.webpack.jsFiles.metadataKey]?.split(',').find {it.startsWith("${name}.")} ?: "${name}.bundle.js"
+		out << r.external(uri: "${config.webpack.bundle.dir}/${fileName}")
+	}
+
+	/**
+	 *  Includes a webpack css bundle.
+	 *
+	 * @attr name REQUIRED the bundle name
+	 */
+	def cssBundle = { attrs ->
+		String name = attrs.name
+		def config = grailsApplication.config
+
+		// Check grailsApplication metadata for a filename that corresponds to this bundle, fallback to name.bundle.js
+		String fileName = grailsApplication.metadata[config.webpack.cssFiles.metadataKey]?.split(',').find {it.startsWith("${name}.")} ?: "${name}.bundle.css"
+		out << r.external(uri: "${config.webpack.bundle.dir}/${fileName}")
+	}
+}

--- a/grails-app/views/dashboard/editor.gsp
+++ b/grails-app/views/dashboard/editor.gsp
@@ -9,7 +9,8 @@
 		<r:require module="streamr-heatmap"/>
 		<r:require module="streamr-table"/>
 
-		<r:require module="dashboard-page-webpack-bundle"/>
+		<webpack:cssBundle name="commons"/>
+		<webpack:cssBundle name="dashboardPage"/>
 
 		<style>
 			body, #dashboardPageRoot {
@@ -24,6 +25,9 @@
 			const keyId = "${key.id}"
 		</script>
 		<div id="dashboardPageRoot"></div>
-	</body>
-</html>
 
+		<webpack:jsBundle name="commons"/>
+		<webpack:jsBundle name="dashboardPage"/>
+	</body>
+
+</html>

--- a/grails-app/views/layouts/_layoutHead.gsp
+++ b/grails-app/views/layouts/_layoutHead.gsp
@@ -10,15 +10,15 @@
 	<%-- Used by Geb GrailsPage abstraction --%>
     <meta name="pageId" content="${controllerName}.${actionName}" />
     
-    <script>
-    	Streamr = {}
+    <r:script disposition="head">
+    	Streamr = Streamr || {}
 		Streamr.projectWebroot = '${createLink(uri:"/", absolute:true)}'
 		Streamr.controller = '${controllerName}'
 		Streamr.action = '${actionName}'
 		<sec:ifLoggedIn>
 		Streamr.user = "${raw(grails.util.Holders.getApplicationContext().getBean("springSecurityService").getCurrentUser().getUsername())}"
 		</sec:ifLoggedIn>
-    </script>
+    </r:script>
     
     <r:require module="streamr"/>
     <r:require module="jquery"/>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -18,7 +18,6 @@
         </div>
                 
 		<r:layoutResources/>
-	
 		<g:render template="/layouts/spinner"/>
     </body>
 </html>

--- a/grails-app/views/profile/edit.gsp
+++ b/grails-app/views/profile/edit.gsp
@@ -7,7 +7,8 @@
 
 	<r:require module="streamr-credentials-control"/>
 
-	<r:require module="profile-page-webpack-bundle"/>
+	<webpack:cssBundle name="commons"/>
+	<webpack:cssBundle name="profilePage"/>
 
 </head>
 <body>
@@ -39,5 +40,9 @@
 			})
 		})
 	</r:script>
+
+	<webpack:jsBundle name="commons"/>
+	<webpack:jsBundle name="profilePage"/>
+
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "unifina-core",
+  "name": "streamr-core",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -3740,6 +3740,15 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "clean-webpack-plugin": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.18.tgz",
+      "integrity": "sha512-Kf1BxQnNy2Zq5TBIgWBTEHrhycOM1QjjBYOoTV5P7WioAPr/sh6fgPwn6xYvTIp3EP+yUqoOL4YFpLQVobeIUg==",
+      "dev": true,
+      "requires": {
+        "rimraf": "2.6.2"
+      }
     },
     "cli-color": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unifina-core",
+  "name": "streamr-core",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
@@ -49,6 +49,7 @@
     "backbone": "file:web-app/js/backbone",
     "backbone-associations": "file:web-app/js/backbone-associations",
     "change-case": "^3.0.1",
+    "clean-webpack-plugin": "^0.1.18",
     "css-loader": "^0.28.1",
     "css-mqpacker": "^6.0.0",
     "draggabilly": "^2.1.1",

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,7 +1,10 @@
 import grails.util.Environment
 
+import java.nio.file.Paths
+import java.util.regex.Pattern
+
 eventTestPhaseStart = { args ->
-	println "eventTestPhaseStart called in unifina-core: $args"
+	println "eventTestPhaseStart called: $args"
 	System.properties["grails.test.phase"] = args
 }
 
@@ -19,6 +22,60 @@ eventPackagingEnd = { args ->
 	int exitValue = process.waitFor()
 	if (exitValue > 0) {
 		throw new RuntimeException("Webpack failed!")
+	}
+}
+
+eventCreateWarStart = {warname, stagingDir ->
+	if (Environment.getCurrent() == Environment.PRODUCTION) {
+		event("AddWebpackFilenamesStart", [warname, stagingDir])
+
+		// Filename patterns include the chunk hash in prod
+		Pattern jsPattern = ~/.*\.bundle\.[0-9a-f]*\.js/
+		Pattern cssPattern = ~/.*\.bundle\.[0-9a-f]*\.css/
+
+		List jsFiles = []
+		List cssFiles = []
+
+		File webpackBundlesDir = Paths.get(Ant.antProject.properties['base.dir'], 'web-app', 'webpack-bundles').toFile()
+		if (!webpackBundlesDir.exists()) {
+			throw new FileNotFoundException("Can't find /web-app/webpack-bundles directory!")
+		}
+
+		webpackBundlesDir.eachFile { File file ->
+			if (file.getName().matches(jsPattern)) {
+				jsFiles << file.getName()
+			} else if (file.getName().matches(cssPattern)) {
+				cssFiles << file.getName()
+			}
+		}
+
+		if (jsFiles.isEmpty()) {
+			throw new FileNotFoundException("Couldn't find webpack js bundles matching regex: ${jsPattern.pattern()} in ${webpackBundlesDir.getAbsolutePath()}")
+		}
+		if (cssFiles.isEmpty()) {
+			throw new FileNotFoundException("Couldn't find webpack css bundles matching regex: ${cssPattern.pattern()} in ${webpackBundlesDir.getAbsolutePath()}")
+		}
+
+		println "Found webpack js files: ${jsFiles}"
+		println "Found webpack css files: ${cssFiles}"
+
+		String applicationPropertiesFilename = "${stagingDir}/WEB-INF/classes/application.properties"
+		println "Adding webpack filenames to ${applicationPropertiesFilename}"
+
+		writeProperties([
+				'webpack.jsFiles': jsFiles.join(','),
+				'webpack.cssFiles': cssFiles.join(',')
+		], applicationPropertiesFilename)
+
+		event("AddWebpackFilenamesEnd", [warname, stagingDir])
+	}
+}
+
+private void writeProperties(Map properties, String propertyFile) {
+	Ant.propertyfile(file: propertyFile) {
+		properties.each { k,v->
+			entry(key: k, value: v)
+		}
 	}
 }
 
@@ -46,4 +103,3 @@ class StreamGobbler extends Thread {
 		}
 	}
 }
-

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const WebpackNotifierPlugin = require('webpack-notifier')
 const WriteFilePlugin = require('write-file-webpack-plugin')
 const FlowtypePlugin = require('flowtype-loader/plugin')
+const CleanWebpackPlugin = require('clean-webpack-plugin')
 
 const postcssConfig = require('./postcss.config.js')
 
@@ -17,9 +18,9 @@ module.exports = {
         dashboardPage: path.resolve(root, 'web-app', 'react-app', 'dashboardPageMain.js')
     },
     output: {
-        path: path.resolve(root, 'web-app', 'js', 'unifina', 'webpack-bundles'),
-        publicPath: '/js/unifina/webpack-bundles/',
-        filename: '[name].bundle.js'
+        path: path.resolve(root, 'web-app', 'webpack-bundles'),
+        publicPath: '/webpack-bundles/',
+        filename: inProduction ? '[name].bundle.[chunkhash].js' : '[name].bundle.js'
     },
     module: {
         rules: [
@@ -83,9 +84,13 @@ module.exports = {
                 postcss: postcssConfig
             }
         }),
-        new ExtractTextPlugin('[name].bundle.css')
+        new ExtractTextPlugin(inProduction ? '[name].bundle.[chunkhash].css' : '[name].bundle.css'),
+        new webpack.optimize.CommonsChunkPlugin('commons')
     ].concat(inProduction ? [
         // Production plugins
+        new CleanWebpackPlugin(['web-app/webpack-bundles/*.js', 'web-app/webpack-bundles/*.css'], {
+            verbose: true
+        }),
         new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.DefinePlugin({
             'process.env': {
@@ -102,8 +107,7 @@ module.exports = {
         new FlowtypePlugin(),
         new webpack.NoEmitOnErrorsPlugin(),
         new WebpackNotifierPlugin(),
-        new WriteFilePlugin(),
-        new webpack.optimize.CommonsChunkPlugin('commons')
+        new WriteFilePlugin()
     ]),
     devtool: !inProduction && 'eval-source-map',
     devServer: {


### PR DESCRIPTION
- Webpack bundles are now served without interference from Grails resources plugin
- No more problems with Grails not detecting changed resources
- In dev mode, bundles are named `bundleName.bundle.js`
- In prod mode, bundles are named `bundleName.bundle.[hash].js`
- For Grails to know the hashed filenames, some magic was added to `_Events.groovy` which persists those war-build-time filenames to `application.properties`. Those properties automatically appear in `grailsApplication.metadata`.
- `WebpackTagLib` has tags for including the webpack resources in a way that abstracts the complexity of detecting the correct filename.