### PR TITLE
[CORE-1179] Save Button not visible on Dashboard editor if too many canvases shown

### DIFF
--- a/test/functional/ShareSpec.groovy
+++ b/test/functional/ShareSpec.groovy
@@ -7,7 +7,7 @@ import org.openqa.selenium.Keys
 class ShareSpec extends LoginTester1Spec implements CanvasMixin, DashboardMixin, ListPageMixin, LoginMixin, NotificationMixin, ShareMixin {
 
 	def scrollToAndClickShareButton(name = "ShareSpec") {
-		scrollToRow(name)
+		findRow(name)
 		clickShareButton(name)
 	}
 

--- a/test/functional/mixins/DashboardMixin.groovy
+++ b/test/functional/mixins/DashboardMixin.groovy
@@ -79,6 +79,9 @@ trait DashboardMixin {
 	}
 
 	def saveDashboard() {
+		interact {
+			moveToElement(saveButton)
+		}
 		saveButton.click()
 		waitFor { findSuccessNotification() }
 	}

--- a/test/functional/mixins/ListPageMixin.groovy
+++ b/test/functional/mixins/ListPageMixin.groovy
@@ -3,10 +3,16 @@ package mixins
 trait ListPageMixin {
 
 	def findRow(String name, boolean scroll = true) {
+		def row = $(".table .td", text: name, 0).parents(".tr")
 		if (scroll) {
-			scrollToRow(name)
+			interact {
+				moveToElement(row)
+			}
+			waitFor {
+				row.displayed
+			}
 		}
-		return $(".table .td", text: name, 0).parents(".tr")
+		return row
 	}
 
 	def clickRow(String name) {
@@ -37,18 +43,5 @@ trait ListPageMixin {
 
 	def clickShareButton(String name) {
 		findShareButton(name).click()
-	}
-
-	def scrollToRow(String name) {
-		js.exec("""
-			var element = jQuery(".table .td").filter(function() {
-				return jQuery(this).text().trim() === "$name"
-			}).eq(0)
-			var siteHeaderHeightInPx = 40
-			window.scrollTo(0, element.offset().top - siteHeaderHeightInPx)
-		""")
-		waitFor {
-			findRow(name, false).displayed
-		}
 	}
 }

--- a/web-app/react-app/components/DashboardPage/Sidebar/index.jsx
+++ b/web-app/react-app/components/DashboardPage/Sidebar/index.jsx
@@ -13,7 +13,7 @@ export default class Sidebar extends Component<{}> {
     render() {
         return (
             <div id="main-menu" role="navigation" className={styles.sidebar}>
-                <div id="main-menu-inner">
+                <div id="main-menu-inner" className={styles.sidebarInner}>
                     <div id="sidebar-view" className="scrollable">
                         <NameEditor/>
                         <CanvasList/>

--- a/web-app/react-app/components/DashboardPage/Sidebar/sidebar.pcss
+++ b/web-app/react-app/components/DashboardPage/Sidebar/sidebar.pcss
@@ -2,4 +2,10 @@
 .sidebar {
   background: #23272d;
   overflow-x: hidden !important;
+  height: 100%;
+
+  .sidebarInner {
+    height: 100%;
+    overflow-y: auto;
+  }
 }


### PR DESCRIPTION
 - Dashboard sidebar is now scrollable
 - Functional tests know to scroll to save button when saving a Dashboard
 - Replaced the horrible js hack in ListPageMixin with
```
interact {
    moveToElement(row)
}
```