### PR TITLE
CORE-1257: API endpoint for publishing free products

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
@@ -24,7 +24,8 @@ class ProductApiController {
 		setUndeploying: "POST",
 		setUndeployed: "POST",
 		setPricing: "POST",
-		uploadImage: "POST"
+		uploadImage: "POST",
+		deployFree: "POST"
 	]
 
 	ApiService apiService

--- a/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
@@ -25,7 +25,8 @@ class ProductApiController {
 		setUndeployed: "POST",
 		setPricing: "POST",
 		uploadImage: "POST",
-		deployFree: "POST"
+		deployFree: "POST",
+		undeployFree: "POST"
 	]
 
 	ApiService apiService
@@ -91,6 +92,14 @@ class ProductApiController {
 	def deployFree(String id) {
 		Product product = productService.findById(id, loggedInUser(), Permission.Operation.SHARE)
 		freeProductService.deployFreeProduct(product)
+		render(product.toMap() as JSON)
+	}
+
+	@GrailsCompileStatic
+	@StreamrApi(authenticationLevel = AuthLevel.USER)
+	def undeployFree(String id) {
+		Product product = productService.findById(id, loggedInUser(), Permission.Operation.SHARE)
+		freeProductService.undeployFreeProduct(product)
 		render(product.toMap() as JSON)
 	}
 

--- a/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
@@ -7,6 +7,7 @@ import com.unifina.domain.security.SecUser
 import com.unifina.security.AuthLevel
 import com.unifina.security.StreamrApi
 import com.unifina.service.ApiService
+import com.unifina.service.FreeProductService
 import com.unifina.service.ProductImageService
 import com.unifina.service.ProductService
 import grails.compiler.GrailsCompileStatic
@@ -27,6 +28,7 @@ class ProductApiController {
 	]
 
 	ApiService apiService
+	FreeProductService freeProductService
 	ProductService productService
 	ProductImageService productImageService
 
@@ -80,6 +82,14 @@ class ProductApiController {
 	def setDeployed(String id, ProductDeployedCommand command) {
 		Product product = apiService.getByIdAndThrowIfNotFound(Product, id)
 		productService.markAsDeployed(product, command, loggedInUser())
+		render(product.toMap() as JSON)
+	}
+
+	@GrailsCompileStatic
+	@StreamrApi(authenticationLevel = AuthLevel.USER)
+	def deployFree(String id) {
+		Product product = productService.findById(id, loggedInUser(), Permission.Operation.SHARE)
+		freeProductService.deployFreeProduct(product)
 		render(product.toMap() as JSON)
 	}
 

--- a/grails-app/services/com/unifina/service/FreeProductService.groovy
+++ b/grails-app/services/com/unifina/service/FreeProductService.groovy
@@ -4,18 +4,19 @@ import com.unifina.api.InvalidStateTransitionException
 import com.unifina.api.ProductNotFreeException
 import com.unifina.domain.marketplace.Product
 import com.unifina.domain.security.Permission
+import grails.compiler.GrailsCompileStatic
 
 
 /**
  * TODO: merge ProductService and FreeProductService
  */
+@GrailsCompileStatic
 class FreeProductService {
 	PermissionService permissionService
 
 	void deployFreeProduct(Product product) {
-		if (product.pricePerSecond != 0) {
-			throw new ProductNotFreeException(product)
-		} else if (product.state == Product.State.DEPLOYED) { // TODO: state transition mismatch with paid products
+		verifyThatProductIsFree(product)
+		if (product.state == Product.State.DEPLOYED) { // TODO: state transition mismatch with paid products
 			throw new InvalidStateTransitionException(product.state, Product.State.DEPLOYED)
 		}
 
@@ -26,6 +27,28 @@ class FreeProductService {
 
 		product.streams.each {
 			permissionService.systemGrantAnonymousAccess(it, Permission.Operation.READ)
+		}
+	}
+
+	void undeployFreeProduct(Product product) {
+		verifyThatProductIsFree(product)
+		if (product.state == Product.State.NOT_DEPLOYED) { // TODO: state transition mismatch with paid products
+			throw new InvalidStateTransitionException(product.state, Product.State.NOT_DEPLOYED)
+		}
+
+		// TODO: these 3 statements also in ProductService#markAsDeployed
+		product.state = Product.State.NOT_DEPLOYED
+		product.save(failOnError: true)
+		permissionService.systemRevokeAnonymousAccess(product)
+
+		product.streams.each {
+			permissionService.systemRevokeAnonymousAccess(it, Permission.Operation.READ)
+		}
+	}
+
+	private static void verifyThatProductIsFree(Product product) {
+		if (product.pricePerSecond != 0) {
+			throw new ProductNotFreeException(product)
 		}
 	}
 }

--- a/grails-app/services/com/unifina/service/FreeProductService.groovy
+++ b/grails-app/services/com/unifina/service/FreeProductService.groovy
@@ -1,0 +1,31 @@
+package com.unifina.service
+
+import com.unifina.api.InvalidStateTransitionException
+import com.unifina.api.ProductNotFreeException
+import com.unifina.domain.marketplace.Product
+import com.unifina.domain.security.Permission
+
+
+/**
+ * TODO: merge ProductService and FreeProductService
+ */
+class FreeProductService {
+	PermissionService permissionService
+
+	void deployFreeProduct(Product product) {
+		if (product.pricePerSecond != 0) {
+			throw new ProductNotFreeException(product)
+		} else if (product.state == Product.State.DEPLOYED) { // TODO: state transition mismatch with paid products
+			throw new InvalidStateTransitionException(product.state, Product.State.DEPLOYED)
+		}
+
+		// TODO: these 3 statements also in ProductService#markAsDeployed
+		product.state = Product.State.DEPLOYED
+		product.save(failOnError: true)
+		permissionService.systemGrantAnonymousAccess(product)
+
+		product.streams.each {
+			permissionService.systemGrantAnonymousAccess(it, Permission.Operation.READ)
+		}
+	}
+}

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -1,11 +1,17 @@
 package com.unifina.service
 
 import com.unifina.api.NotPermittedException
+import com.unifina.domain.dashboard.Dashboard
+import com.unifina.domain.data.Feed
+import com.unifina.domain.data.Stream
+import com.unifina.domain.marketplace.Product
 import com.unifina.domain.security.Key
 import com.unifina.domain.security.Permission
 import com.unifina.domain.security.Permission.Operation
 import com.unifina.domain.security.SecUser
 import com.unifina.domain.security.SignupInvite
+import com.unifina.domain.signalpath.Canvas
+import com.unifina.domain.signalpath.ModulePackage
 import com.unifina.security.Userish
 import groovy.transform.CompileStatic
 
@@ -482,9 +488,22 @@ class PermissionService {
 
 	@CompileStatic
 	private static String getResourcePropertyName(Object resource) {
-		// Derive property name from class name by turning it into camelCase
-		String simpleName = resource.getClass().getSimpleName()
-		return simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1)
+		// Cannot derive name straight from resource.getClass() because of proxy assist objects!
+		if (resource instanceof Canvas) {
+			return "canvas"
+		} else if (resource instanceof Dashboard) {
+			return "dashboard"
+		} else if (resource instanceof Feed) {
+			return "feed"
+		} else if (resource instanceof ModulePackage) {
+			return "modulePackage"
+		} else if (resource instanceof Product) {
+			return "product"
+		} else if (resource instanceof Stream) {
+			return "stream"
+		} else {
+			throw new IllegalArgumentException("Unexpected resource class: " + resource)
+		}
 	}
 
 	/**

--- a/rest-e2e-tests/products-api.js
+++ b/rest-e2e-tests/products-api.js
@@ -1247,4 +1247,101 @@ describe('Products API', () => {
             })
         })
     })
+
+    describe('GET /api/v1/products/:id/undeployFree', () => {
+        let freeProductId
+
+        before(async () => {
+            const freeProductBody = {
+                name: 'Product',
+                description: 'Description of the product.',
+                category: 'satellite-id',
+                streams: [
+                    streamId1,
+                    streamId2
+                ],
+                pricePerSecond: 0,
+                priceCurrency: 'USD',
+                minimumSubscriptionInSeconds: 60,
+            }
+            freeProductId = await createProductAndReturnId(freeProductBody)
+        })
+
+        it('requires authentication', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .call()
+            await assertResponseIsError(response, 401, 'NOT_AUTHENTICATED')
+        })
+
+        it('requires existing Product', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree('non-existing-id')
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 404, 'NOT_FOUND')
+        })
+
+        it('requires share permission on Product', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .withAuthToken(AUTH_TOKEN_2)
+                .call()
+            const json = await response.json()
+
+            assert.equal(response.status, 403)
+            assert.equal(json.code, 'FORBIDDEN')
+            assert.equal(json.operation, 'share')
+        })
+
+        it('verifies that Product is free', async () => {
+            const paidProductId = await createProductAndReturnId(genericProductBody)
+
+            const response = await Streamr.api.v1.products
+                .undeployFree(paidProductId)
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 400, 'PRODUCT_IS_NOT_FREE')
+        })
+
+        it('verifies that Product is deployed', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 409, 'INVALID_STATE_TRANSITION')
+        })
+
+        context('when called with valid params, body, headers, and permissions', () => {
+            let response
+            let json
+
+            before(async () => {
+                // Deploy 1st
+                await Streamr.api.v1.products
+                    .deployFree(freeProductId)
+                    .withAuthToken(AUTH_TOKEN)
+                    .call()
+
+                response = await Streamr.api.v1.products
+                    .undeployFree(freeProductId)
+                    .withAuthToken(AUTH_TOKEN)
+                    .call()
+
+                json = await response.json()
+            })
+
+            it('responds with 200', () => {
+                assert.equal(response.status, 200)
+            })
+
+            it('responds with Product', () => {
+                assertIsProduct(json)
+            })
+
+            it('state of Product is now NOT_DEPLOYED', () => {
+                assert.equal(json.state, 'NOT_DEPLOYED')
+            })
+        })
+    })
 })

--- a/rest-e2e-tests/schemas/product.json
+++ b/rest-e2e-tests/schemas/product.json
@@ -105,11 +105,17 @@
     },
     "ownerAddress": {
       "description": "Ethereum address of product owner",
-      "$ref": "#/definitions/ethereumAddress"
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/ethereumAddress" }
+      ]
     },
     "beneficiaryAddress": {
       "description": "Ethereum address of beneficiary",
-      "$ref": "#/definitions/ethereumAddress"
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/ethereumAddress" }
+      ]
     },
     "pricePerSecond": {
       "description": "Unit price per second",

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -158,6 +158,11 @@ class Products {
             .withBody(body)
     }
 
+    deployFree(id) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('POST', `products/${id}/deployFree`)
+    }
+
     uploadImage(id, fileBytes) {
         const formData = new FormData()
         formData.append('file', fileBytes)

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -163,6 +163,11 @@ class Products {
             .methodAndPath('POST', `products/${id}/deployFree`)
     }
 
+    undeployFree(id) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('POST', `products/${id}/undeployFree`)
+    }
+
     uploadImage(id, fileBytes) {
         const formData = new FormData()
         formData.append('file', fileBytes)

--- a/rest-e2e-tests/subscriptions-api.js
+++ b/rest-e2e-tests/subscriptions-api.js
@@ -215,9 +215,10 @@ describe('Subscriptions API', () => {
             it('responds with list of subscriptions', () => {
                 assert.isAtLeast(json.length, 1)
                 json.forEach(subscriptionData => assertIsSubscription(subscriptionData))
-                assert.deepEqual(json[json.length - 1].address, publicAddress)
-                assert.deepEqual(json[json.length - 1].endsAt, '2018-10-29T19:11:52Z')
-                assert.deepEqual(json[json.length - 1].product.id, productId)
+                const picked = json.find(subscriptionData => subscriptionData.address === publicAddress)
+                assert.isNotNull(picked)
+                assert.deepEqual(picked.endsAt, '2018-10-29T19:11:52Z')
+                assert.deepEqual(picked.product.id, productId)
             })
         })
     })

--- a/src/java/com/unifina/api/ProductNotFreeException.java
+++ b/src/java/com/unifina/api/ProductNotFreeException.java
@@ -1,0 +1,9 @@
+package com.unifina.api;
+
+import com.unifina.domain.marketplace.Product;
+
+public class ProductNotFreeException extends ApiException {
+	public ProductNotFreeException(Product product) {
+		super(400, "PRODUCT_IS_NOT_FREE", String.format("Product %s is not free", product.getId()));
+	}
+}

--- a/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
@@ -499,4 +499,56 @@ class ProductApiControllerSpec extends Specification {
 		response.status == 200
 		response.json == product.toMap()
 	}
+
+	void "undeployFree() invokes productService#findById (with SHARE permission requirement)"() {
+		def productService = controller.productService = Mock(ProductService)
+		controller.freeProductService = Stub(FreeProductService)
+		def user = new SecUser()
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = user
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		1 * productService.findById('product-id', user, Permission.Operation.SHARE) >> product
+	}
+
+	void "undeployFree() invokes freeProductService#undeployFreeProduct"() {
+		controller.productService = Stub(ProductService) {
+			findById(_, _, _) >> product
+		}
+		def freeProductService = controller.freeProductService = Mock(FreeProductService)
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = new SecUser()
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		1 * freeProductService.undeployFreeProduct(product)
+	}
+
+	void "undeployFree() returns 200 and renders a product"() {
+		controller.productService = Stub(ProductService) {
+			findById(_, _, _) >> product
+		}
+		controller.freeProductService = Stub(FreeProductService)
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = new SecUser()
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		response.status == 200
+		response.json == product.toMap()
+	}
+
 }

--- a/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
@@ -455,6 +455,7 @@ class ProductApiControllerSpec extends Specification {
 		def user = new SecUser()
 
 		params.id = "product-id"
+		request.method = "POST"
 		request.apiUser = user
 		when:
 		withFilters(action: "deployFree") {
@@ -471,6 +472,7 @@ class ProductApiControllerSpec extends Specification {
 		def freeProductService = controller.freeProductService = Mock(FreeProductService)
 
 		params.id = "product-id"
+		request.method = "POST"
 		request.apiUser = new SecUser()
 		when:
 		withFilters(action: "deployFree") {
@@ -487,6 +489,7 @@ class ProductApiControllerSpec extends Specification {
 		controller.freeProductService = Stub(FreeProductService)
 
 		params.id = "product-id"
+		request.method = "POST"
 		request.apiUser = new SecUser()
 		when:
 		withFilters(action: "deployFree") {

--- a/test/unit/com/unifina/service/FreeProductServiceSpec.groovy
+++ b/test/unit/com/unifina/service/FreeProductServiceSpec.groovy
@@ -1,0 +1,86 @@
+package com.unifina.service
+
+import com.unifina.api.InvalidStateTransitionException
+import com.unifina.api.ProductNotFreeException
+import com.unifina.domain.data.Stream
+import com.unifina.domain.marketplace.Category
+import com.unifina.domain.marketplace.Product
+import com.unifina.domain.security.Permission
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+@TestFor(FreeProductService)
+@Mock([Category, Product, Stream])
+class FreeProductServiceSpec extends Specification {
+	Stream s1, s2, s3
+	Product freeProduct
+
+	void setup() {
+		Category category = new Category(name: "Category")
+		category.id = "category-id"
+		category.save()
+
+		s1 = new Stream(name: "stream-1")
+		s2 = new Stream(name: "stream-2")
+		s3 = new Stream(name: "stream-3")
+		[s1, s2, s3].eachWithIndex { Stream stream, int i -> stream.id = "stream-${i+1}" } // assign ids
+		[s1, s2, s3]*.save(failOnError: true, validate: false)
+
+		freeProduct = new Product(
+			name: "name",
+			description: "description",
+			streams: [s1, s2, s3],
+			pricePerSecond: 0,
+			category: category,
+			state: Product.State.NOT_DEPLOYED,
+			blockNumber: 40000,
+			blockIndex: 30,
+			owner: "arnold"
+		)
+		freeProduct.id = "free-product-id"
+		freeProduct.save(failOnError: true, validate: true)
+	}
+	void "deployFreeProduct throws ProductNotFreeException when given paid Product"() {
+		when:
+		service.deployFreeProduct(new Product(pricePerSecond: 2))
+		then:
+		thrown(ProductNotFreeException)
+	}
+
+	void "deployFreeProduct throws InvalidStateTransitionException when given Product in state DEPLOYED"() {
+		when:
+		service.deployFreeProduct(new Product(pricePerSecond: 0, state: Product.State.DEPLOYED))
+		then:
+		thrown(InvalidStateTransitionException)
+	}
+
+	void "deployFreeProduct transitions Product state to DEPLOYED"() {
+		service.permissionService = Stub(PermissionService)
+
+		when:
+		service.deployFreeProduct(freeProduct)
+		then:
+		Product.findById("free-product-id").state == Product.State.DEPLOYED
+	}
+
+	void "deployFreeProduct grants anonymous access to Product"() {
+		def permissionService = service.permissionService = Mock(PermissionService)
+
+		when:
+		service.deployFreeProduct(freeProduct)
+		then:
+		1 * permissionService.systemGrantAnonymousAccess(freeProduct)
+	}
+
+	void "deployFreeProduct grants anonymous READ access to the streams of Product"() {
+		def permissionService = service.permissionService = Mock(PermissionService)
+
+		when:
+		service.deployFreeProduct(freeProduct)
+		then:
+		1 * permissionService.systemGrantAnonymousAccess(s1, Permission.Operation.READ)
+		1 * permissionService.systemGrantAnonymousAccess(s2, Permission.Operation.READ)
+		1 * permissionService.systemGrantAnonymousAccess(s3, Permission.Operation.READ)
+	}
+}

--- a/web-app/misc/swagger.json
+++ b/web-app/misc/swagger.json
@@ -137,7 +137,7 @@
             "in": "query",
             "description": "Maximum price (per second) of product",
             "required": false
-          },
+          }
         ],
         "responses": {
           "200": {
@@ -267,7 +267,7 @@
             "in": "query",
             "description": "Maximum price (per second) of product",
             "required": false
-          },
+          }
         ],
         "responses": {
           "200": {
@@ -1002,7 +1002,7 @@
     "/products/{id}/deployFree": {
       "post": {
         "summary": "Deploy free Product",
-        "description": "Deploy a free Product (price = 0) so that it is publicly viewable and 'gettable'. Its streams are made public as well.",
+        "description": "Deploy a free Product (price = 0) so that it is publicly viewable and purchasable. Its streams are made public as well.",
         "tags": [
           "products"
         ],
@@ -1056,17 +1056,91 @@
                 "code": "FORBIDDEN",
                 "message": "Non-authenticated user does not have permission to share Product (id aQAd59nDQHiCUpXnhm7-TwPLCh9ALaQH2TIxOengS1FQ)"
               }
+            }
+          },
+          "409": {
+            "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
             },
-            "409": {
-              "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              },
-              "examples": {
-                "application/json": {
-                  "code": "INVALID_STATE_TRANSITION",
-                  "message": "Invalid transition DEPLOYED -> DEPLOYED"
-                }
+            "examples": {
+              "application/json": {
+                "code": "INVALID_STATE_TRANSITION",
+                "message": "Invalid transition DEPLOYED -> DEPLOYED"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/products/{id}/undeployFree": {
+      "post": {
+        "summary": "Undeploy free Product",
+        "description": "Undeploy a free Product (price = 0) so that it is no longer publicly viewable or purchasable. Its streams will be made private as well.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "unique identifier of a Product",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product with state=`NOT_DEPLOYED`",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "401": {
+            "description": "Not authenticated (code: `NOT_AUTHENTICATED`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_AUTHENTICATED",
+                "message": "Not authenticated via token or cookie"
+              }
+            }
+          },
+          "404": {
+            "description": "Product not found (code: `NOT_FOUND`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_FOUND",
+                "message": "Product with id 1kDWMNstSmW1NxhJPYFHsAYgkesh19QraMLtgfuDs4sA not found"
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permission to share Product (code: `FORBIDDEN`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "FORBIDDEN",
+                "message": "Non-authenticated user does not have permission to share Product (id aQAd59nDQHiCUpXnhm7-TwPLCh9ALaQH2TIxOengS1FQ)"
+              }
+            }
+          },
+          "409": {
+            "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "INVALID_STATE_TRANSITION",
+                "message": "Invalid transition NOT_DEPLOYED -> NOT_DEPLOYED"
               }
             }
           }
@@ -1206,7 +1280,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "tags": [
           "streams"
@@ -1983,7 +2057,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "responses": {
           "200": {
@@ -2418,7 +2492,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "tags": [
           "dashboards"

--- a/web-app/misc/swagger.json
+++ b/web-app/misc/swagger.json
@@ -999,6 +999,80 @@
         }
       }
     },
+    "/products/{id}/deployFree": {
+      "post": {
+        "summary": "Deploy free Product",
+        "description": "Deploy a free Product (price = 0) so that it is publicly viewable and 'gettable'. Its streams are made public as well.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "unique identifier of a Product",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product with state=`DEPLOYED`",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "401": {
+            "description": "Not authenticated (code: `NOT_AUTHENTICATED`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_AUTHENTICATED",
+                "message": "Not authenticated via token or cookie"
+              }
+            }
+          },
+          "404": {
+            "description": "Product not found (code: `NOT_FOUND`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_FOUND",
+                "message": "Product with id 1kDWMNstSmW1NxhJPYFHsAYgkesh19QraMLtgfuDs4sA not found"
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permission to share Product (code: `FORBIDDEN`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "FORBIDDEN",
+                "message": "Non-authenticated user does not have permission to share Product (id aQAd59nDQHiCUpXnhm7-TwPLCh9ALaQH2TIxOengS1FQ)"
+              }
+            },
+            "409": {
+              "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              },
+              "examples": {
+                "application/json": {
+                  "code": "INVALID_STATE_TRANSITION",
+                  "message": "Invalid transition DEPLOYED -> DEPLOYED"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/products/{id}/images": {
       "post": {
         "summary": "Attach image to Product",
@@ -1810,7 +1884,7 @@
                 "message": "Not authenticated via token or cookie"
               }
             }
-          },
+          }
         }
       },
       "post": {


### PR DESCRIPTION
API endpoint `POST /api/v1/products/:productId/deployFree` for deploying free Products (price = 0).

## Details
- New controller method `ProductApiController#deployFree`
- New service `FreeProductService` and method `deployFreeProduct`
- Bring back switch-statement to fix issue with proxy/assist domain classes in `PermissionService#getResourcePropertyName`
- rest e2e tests for endpoint
- swagger for endpoint
- unit tests for service and controller