### PR TITLE
CORE-1258: API endpoint for unpublishing free products

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
@@ -25,7 +25,8 @@ class ProductApiController {
 		setUndeployed: "POST",
 		setPricing: "POST",
 		uploadImage: "POST",
-		deployFree: "POST"
+		deployFree: "POST",
+		undeployFree: "POST"
 	]
 
 	ApiService apiService
@@ -91,6 +92,14 @@ class ProductApiController {
 	def deployFree(String id) {
 		Product product = productService.findById(id, loggedInUser(), Permission.Operation.SHARE)
 		freeProductService.deployFreeProduct(product)
+		render(product.toMap() as JSON)
+	}
+
+	@GrailsCompileStatic
+	@StreamrApi(authenticationLevel = AuthLevel.USER)
+	def undeployFree(String id) {
+		Product product = productService.findById(id, loggedInUser(), Permission.Operation.SHARE)
+		freeProductService.undeployFreeProduct(product)
 		render(product.toMap() as JSON)
 	}
 

--- a/grails-app/services/com/unifina/service/FreeProductService.groovy
+++ b/grails-app/services/com/unifina/service/FreeProductService.groovy
@@ -4,18 +4,19 @@ import com.unifina.api.InvalidStateTransitionException
 import com.unifina.api.ProductNotFreeException
 import com.unifina.domain.marketplace.Product
 import com.unifina.domain.security.Permission
+import grails.compiler.GrailsCompileStatic
 
 
 /**
  * TODO: merge ProductService and FreeProductService
  */
+@GrailsCompileStatic
 class FreeProductService {
 	PermissionService permissionService
 
 	void deployFreeProduct(Product product) {
-		if (product.pricePerSecond != 0) {
-			throw new ProductNotFreeException(product)
-		} else if (product.state == Product.State.DEPLOYED) { // TODO: state transition mismatch with paid products
+		verifyThatProductIsFree(product)
+		if (product.state == Product.State.DEPLOYED) { // TODO: state transition mismatch with paid products
 			throw new InvalidStateTransitionException(product.state, Product.State.DEPLOYED)
 		}
 
@@ -26,6 +27,28 @@ class FreeProductService {
 
 		product.streams.each {
 			permissionService.systemGrantAnonymousAccess(it, Permission.Operation.READ)
+		}
+	}
+
+	void undeployFreeProduct(Product product) {
+		verifyThatProductIsFree(product)
+		if (product.state == Product.State.NOT_DEPLOYED) { // TODO: state transition mismatch with paid products
+			throw new InvalidStateTransitionException(product.state, Product.State.NOT_DEPLOYED)
+		}
+
+		// TODO: these 3 statements also in ProductService#markAsDeployed
+		product.state = Product.State.NOT_DEPLOYED
+		product.save(failOnError: true)
+		permissionService.systemRevokeAnonymousAccess(product)
+
+		product.streams.each {
+			permissionService.systemRevokeAnonymousAccess(it, Permission.Operation.READ)
+		}
+	}
+
+	private static void verifyThatProductIsFree(Product product) {
+		if (product.pricePerSecond != 0) {
+			throw new ProductNotFreeException(product)
 		}
 	}
 }

--- a/rest-e2e-tests/products-api.js
+++ b/rest-e2e-tests/products-api.js
@@ -1247,4 +1247,101 @@ describe('Products API', () => {
             })
         })
     })
+
+    describe('GET /api/v1/products/:id/undeployFree', () => {
+        let freeProductId
+
+        before(async () => {
+            const freeProductBody = {
+                name: 'Product',
+                description: 'Description of the product.',
+                category: 'satellite-id',
+                streams: [
+                    streamId1,
+                    streamId2
+                ],
+                pricePerSecond: 0,
+                priceCurrency: 'USD',
+                minimumSubscriptionInSeconds: 60,
+            }
+            freeProductId = await createProductAndReturnId(freeProductBody)
+        })
+
+        it('requires authentication', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .call()
+            await assertResponseIsError(response, 401, 'NOT_AUTHENTICATED')
+        })
+
+        it('requires existing Product', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree('non-existing-id')
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 404, 'NOT_FOUND')
+        })
+
+        it('requires share permission on Product', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .withAuthToken(AUTH_TOKEN_2)
+                .call()
+            const json = await response.json()
+
+            assert.equal(response.status, 403)
+            assert.equal(json.code, 'FORBIDDEN')
+            assert.equal(json.operation, 'share')
+        })
+
+        it('verifies that Product is free', async () => {
+            const paidProductId = await createProductAndReturnId(genericProductBody)
+
+            const response = await Streamr.api.v1.products
+                .undeployFree(paidProductId)
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 400, 'PRODUCT_IS_NOT_FREE')
+        })
+
+        it('verifies that Product is deployed', async () => {
+            const response = await Streamr.api.v1.products
+                .undeployFree(freeProductId)
+                .withAuthToken(AUTH_TOKEN)
+                .call()
+            await assertResponseIsError(response, 409, 'INVALID_STATE_TRANSITION')
+        })
+
+        context('when called with valid params, body, headers, and permissions', () => {
+            let response
+            let json
+
+            before(async () => {
+                // Deploy 1st
+                await Streamr.api.v1.products
+                    .deployFree(freeProductId)
+                    .withAuthToken(AUTH_TOKEN)
+                    .call()
+
+                response = await Streamr.api.v1.products
+                    .undeployFree(freeProductId)
+                    .withAuthToken(AUTH_TOKEN)
+                    .call()
+
+                json = await response.json()
+            })
+
+            it('responds with 200', () => {
+                assert.equal(response.status, 200)
+            })
+
+            it('responds with Product', () => {
+                assertIsProduct(json)
+            })
+
+            it('state of Product is now NOT_DEPLOYED', () => {
+                assert.equal(json.state, 'NOT_DEPLOYED')
+            })
+        })
+    })
 })

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -163,6 +163,11 @@ class Products {
             .methodAndPath('POST', `products/${id}/deployFree`)
     }
 
+    undeployFree(id) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('POST', `products/${id}/undeployFree`)
+    }
+
     uploadImage(id, fileBytes) {
         const formData = new FormData()
         formData.append('file', fileBytes)

--- a/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/ProductApiControllerSpec.groovy
@@ -499,4 +499,56 @@ class ProductApiControllerSpec extends Specification {
 		response.status == 200
 		response.json == product.toMap()
 	}
+
+	void "undeployFree() invokes productService#findById (with SHARE permission requirement)"() {
+		def productService = controller.productService = Mock(ProductService)
+		controller.freeProductService = Stub(FreeProductService)
+		def user = new SecUser()
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = user
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		1 * productService.findById('product-id', user, Permission.Operation.SHARE) >> product
+	}
+
+	void "undeployFree() invokes freeProductService#undeployFreeProduct"() {
+		controller.productService = Stub(ProductService) {
+			findById(_, _, _) >> product
+		}
+		def freeProductService = controller.freeProductService = Mock(FreeProductService)
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = new SecUser()
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		1 * freeProductService.undeployFreeProduct(product)
+	}
+
+	void "undeployFree() returns 200 and renders a product"() {
+		controller.productService = Stub(ProductService) {
+			findById(_, _, _) >> product
+		}
+		controller.freeProductService = Stub(FreeProductService)
+
+		params.id = "product-id"
+		request.method = "POST"
+		request.apiUser = new SecUser()
+		when:
+		withFilters(action: "undeployFree") {
+			controller.undeployFree()
+		}
+		then:
+		response.status == 200
+		response.json == product.toMap()
+	}
+
 }

--- a/web-app/misc/swagger.json
+++ b/web-app/misc/swagger.json
@@ -137,7 +137,7 @@
             "in": "query",
             "description": "Maximum price (per second) of product",
             "required": false
-          },
+          }
         ],
         "responses": {
           "200": {
@@ -267,7 +267,7 @@
             "in": "query",
             "description": "Maximum price (per second) of product",
             "required": false
-          },
+          }
         ],
         "responses": {
           "200": {
@@ -1002,7 +1002,7 @@
     "/products/{id}/deployFree": {
       "post": {
         "summary": "Deploy free Product",
-        "description": "Deploy a free Product (price = 0) so that it is publicly viewable and 'gettable'. Its streams are made public as well.",
+        "description": "Deploy a free Product (price = 0) so that it is publicly viewable and purchasable. Its streams are made public as well.",
         "tags": [
           "products"
         ],
@@ -1056,17 +1056,91 @@
                 "code": "FORBIDDEN",
                 "message": "Non-authenticated user does not have permission to share Product (id aQAd59nDQHiCUpXnhm7-TwPLCh9ALaQH2TIxOengS1FQ)"
               }
+            }
+          },
+          "409": {
+            "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
             },
-            "409": {
-              "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              },
-              "examples": {
-                "application/json": {
-                  "code": "INVALID_STATE_TRANSITION",
-                  "message": "Invalid transition DEPLOYED -> DEPLOYED"
-                }
+            "examples": {
+              "application/json": {
+                "code": "INVALID_STATE_TRANSITION",
+                "message": "Invalid transition DEPLOYED -> DEPLOYED"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/products/{id}/undeployFree": {
+      "post": {
+        "summary": "Undeploy free Product",
+        "description": "Undeploy a free Product (price = 0) so that it is no longer publicly viewable or purchasable. Its streams will be made private as well.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "unique identifier of a Product",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product with state=`NOT_DEPLOYED`",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "401": {
+            "description": "Not authenticated (code: `NOT_AUTHENTICATED`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_AUTHENTICATED",
+                "message": "Not authenticated via token or cookie"
+              }
+            }
+          },
+          "404": {
+            "description": "Product not found (code: `NOT_FOUND`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "NOT_FOUND",
+                "message": "Product with id 1kDWMNstSmW1NxhJPYFHsAYgkesh19QraMLtgfuDs4sA not found"
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permission to share Product (code: `FORBIDDEN`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "FORBIDDEN",
+                "message": "Non-authenticated user does not have permission to share Product (id aQAd59nDQHiCUpXnhm7-TwPLCh9ALaQH2TIxOengS1FQ)"
+              }
+            }
+          },
+          "409": {
+            "description": "Cannot move to this state from current state of Product (code: `INVALID_STATE_TRANSITION`)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/json": {
+                "code": "INVALID_STATE_TRANSITION",
+                "message": "Invalid transition NOT_DEPLOYED -> NOT_DEPLOYED"
               }
             }
           }
@@ -1206,7 +1280,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "tags": [
           "streams"
@@ -1983,7 +2057,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "responses": {
           "200": {
@@ -2418,7 +2492,7 @@
           { "$ref": "#/parameters/max" },
           { "$ref": "#/parameters/offset" },
           { "$ref": "#/parameters/publicAccess" },
-          { "$ref": "#/parameters/operation" },
+          { "$ref": "#/parameters/operation" }
         ],
         "tags": [
           "dashboards"


### PR DESCRIPTION
_Be advised: Basing on feature branch CORE-1257-publish-free-products_

API endpoint `POST /api/v1/products/:productId/undeployFree` for undeploying free Products (price = 0).

## Details
- New controller method `ProductApiController#undeployFree`
- New service method `FreeProductService#undeployFreeProduct`
- unit tests for service and controller
- rest e2e tests for endpoint
- swagger for endpoint