### PR TITLE
CORE-1196: Expiration of subscription-linked permissions

### DIFF
--- a/grails-app/domain/com/unifina/domain/security/Permission.groovy
+++ b/grails-app/domain/com/unifina/domain/security/Permission.groovy
@@ -54,6 +54,8 @@ class Permission {
 
 	/** Is this a Permission of a Subscription? **/
 	Subscription subscription
+	/** When does this Permission expire? null == forever valid */
+	Date endsAt
 
 	static belongsTo = [Canvas, Dashboard, Feed, ModulePackage, Stream, Subscription]
 
@@ -71,6 +73,7 @@ class Permission {
 			[obj.canvas, obj.dashboard, obj.feed, obj.modulePackage, obj.stream, obj.product].count { it != null } == 1
 		})
 		subscription(nullable: true)
+		endsAt(nullable: true)
 	}
 
 	static mapping = {
@@ -140,6 +143,9 @@ class Permission {
 		}
 		if (product) {
 			map["product"] = product.id
+		}
+		if (endsAt) {
+			map["endsAt"] = endsAt
 		}
 		return map
 	}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -106,4 +106,5 @@ databaseChangeLog = {
 	include file: 'core/2018-04-09-allow-nulls-in-certain-product-fields.groovy'
 	include file: 'core/2018-04-11-test-data-products-subscriptions.groovy'
 	include file: 'core/2018-04-12-free-and-paid-subscriptions.groovy'
+	include file: 'core/2018-04-16-add-ends-at-field-to-permission.groovy'
 }

--- a/grails-app/migrations/core/2018-04-16-add-ends-at-field-to-permission.groovy
+++ b/grails-app/migrations/core/2018-04-16-add-ends-at-field-to-permission.groovy
@@ -1,0 +1,8 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "eric", id: "add-ends-at-field-to-permission") {
+		addColumn(tableName: "permission") {
+			column(name: "ends_at", type: "datetime")
+		}
+	}
+}

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -122,6 +122,10 @@ class PermissionService {
 					eq(userProp, userish)
 				}
 			}
+			or {
+				isNull("endsAt")
+				gt("endsAt", new Date())
+			}
 		}.toList()
 	}
 
@@ -191,6 +195,10 @@ class PermissionService {
 					if (isUser) {
 						eq(userProp, userish)
 					}
+				}
+				or {
+					isNull("endsAt")
+					gt("endsAt", new Date())
 				}
 			}
 		}
@@ -411,6 +419,10 @@ class PermissionService {
 					String userProp = getUserPropertyName(userish)
 					eq(userProp, userish)
 				}
+			}
+			or {
+				isNull("endsAt")
+				gt("endsAt", new Date())
 			}
 		}
 		return !p.empty

--- a/grails-app/services/com/unifina/service/SubscriptionService.groovy
+++ b/grails-app/services/com/unifina/service/SubscriptionService.groovy
@@ -110,6 +110,7 @@ class SubscriptionService {
 			streams.collect { Stream stream ->
 				Permission permission = permissionService.systemGrant(user, stream, Permission.Operation.READ)
 				permission.subscription = subscription
+				permission.endsAt = subscription.endsAt
 				permission.save(failOnError: true)
 			}
 		}

--- a/test/unit/com/unifina/service/PermissionServiceSpec.groovy
+++ b/test/unit/com/unifina/service/PermissionServiceSpec.groovy
@@ -96,7 +96,6 @@ class PermissionServiceSpec extends Specification {
 		service.canRead(myKey, dashAllowed)
 	}
 
-
 	void "access denied through key to non-permitted Dashboard"() {
 		expect:
 		!service.canRead(myKey, dashRestricted)
@@ -412,5 +411,23 @@ class PermissionServiceSpec extends Specification {
 		then:
 		!Permission.exists(dashAnonymousReadPermission.id)
 		!service.canRead(null, dashPublic)
+	}
+
+	void "check() returns false if permission with endsAt set in past"() {
+		def p = service.systemGrant(stranger, dashOwned, Operation.READ)
+		p.endsAt = new Date(0)
+		p.save(failOnError: true)
+
+		expect:
+		!service.check(stranger, dashOwned, Operation.READ)
+	}
+
+	void "check() returns true if permission with endsAt set in future"() {
+		def p = service.systemGrant(stranger, dashOwned, Operation.READ)
+		p.endsAt = new Date(System.currentTimeMillis() + 60000)
+		p.save(failOnError: true)
+
+		expect:
+		service.check(stranger, dashOwned, Operation.READ)
 	}
 }

--- a/test/unit/com/unifina/service/SubscriptionServiceSpec.groovy
+++ b/test/unit/com/unifina/service/SubscriptionServiceSpec.groovy
@@ -256,7 +256,8 @@ class SubscriptionServiceSpec extends Specification {
 		assert Permission.count() == 0
 
 		when:
-		service.subscribeToFreeProduct(product, user, new Date())
+		def endDate = new Date()
+		service.subscribeToFreeProduct(product, user, endDate)
 
 		then:
 		Permission.findAll()*.toInternalMap() as Set == [
@@ -264,13 +265,15 @@ class SubscriptionServiceSpec extends Specification {
 				operation: "READ",
 				user: 1L,
 				stream: "stream-1",
-				subscription: 1L
+				subscription: 1L,
+				endsAt: endDate
 			],
 			[
 				operation: "READ",
 				user: 1L,
 				stream: "stream-2",
-				subscription: 1L
+				subscription: 1L,
+				endsAt: endDate
 			]
 		] as Set
 	}

--- a/test/unit/com/unifina/service/SubscriptionServiceSpec.groovy
+++ b/test/unit/com/unifina/service/SubscriptionServiceSpec.groovy
@@ -141,7 +141,8 @@ class SubscriptionServiceSpec extends Specification {
 		).save(failOnError: true, validate: false)
 
 		when:
-		service.onSubscribed(product, "0x0000000000000000000000000000000000000000", new Date())
+		def date = new Date()
+		service.onSubscribed(product, "0x0000000000000000000000000000000000000000", date)
 
 		then:
 		Permission.findAll()*.toInternalMap() as Set == [
@@ -149,13 +150,15 @@ class SubscriptionServiceSpec extends Specification {
 				operation: "READ",
 				user: 1L,
 				stream: "stream-1",
-				subscription: 1L
+				subscription: 1L,
+				endsAt: date
 			],
 			[
 				operation: "READ",
 				user: 1L,
 				stream: "stream-2",
-				subscription: 1L
+				subscription: 1L,
+				endsAt: date
 			]
 		] as Set
 	}
@@ -344,16 +347,17 @@ class SubscriptionServiceSpec extends Specification {
 	void "afterIntegrationKeyCreated() creates subscription-linked permissions for given integration key"() {
 		service.permissionService = new PermissionService()
 
+		def date = new Date()
 		def product2 = new Product(streams: [s3]).save(failOnError: true, validate: false)
 		def sub1 = new PaidSubscription(
 			address: "0x0000000000000000000000000000000000000000",
 			product: product,
-			endsAt: new Date()
+			endsAt: date
 		).save(failOnError: true, validate: true)
 		def sub2 = new PaidSubscription(
 			address: "0x0000000000000000000000000000000000000000",
 			product: product2,
-			endsAt: new Date()
+			endsAt: date
 		).save(failOnError: true, validate: true)
 
 		def integrationKey = new IntegrationKey(
@@ -372,18 +376,21 @@ class SubscriptionServiceSpec extends Specification {
 				user: 1L,
 				stream: "stream-1",
 				subscription: 1L,
+				endsAt: date
 		    ],
 			[
 				operation: "READ",
 				user: 1L,
 				stream: "stream-2",
 				subscription: 1L,
+				endsAt: date
 			],
 			[
 				operation: "READ",
 				user: 1L,
 				stream: "stream-3",
 				subscription: 2L,
+				endsAt: date
 			]
 		] as Set
 	}
@@ -404,16 +411,17 @@ class SubscriptionServiceSpec extends Specification {
 		).save(failOnError: true, validate: false)
 
 		setup: "create permissions"
-		service.onSubscribed(product, "0x0000000000000000000000000000000000000000", new Date()) // 1, 2
+		def date = new Date()
+		service.onSubscribed(product, "0x0000000000000000000000000000000000000000", date) // 1, 2
 
 		product.streams = [s1]
 		product.save(failOnError: true, validate: false)
-		service.onSubscribed(product, "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", new Date()) // 3
+		service.onSubscribed(product, "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", date) // 3
 
 		assert Permission.findAll()*.toInternalMap() as Set == [
-			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-1"],
-			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-2"],
-			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-1"],
+			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-1", endsAt: date],
+			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-2", endsAt: date],
+			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-1", endsAt: date],
 		] as Set
 
 		and: "change product"
@@ -424,10 +432,10 @@ class SubscriptionServiceSpec extends Specification {
 		service.afterProductUpdated(product)
 		then:
 		Permission.findAll()*.toInternalMap() as Set == [
-			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-2"],
-			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-3"],
-			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-2"],
-			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-3"],
+			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-2", endsAt: date],
+			[operation: "READ", subscription: 1L, user: 1L, stream: "stream-3", endsAt: date],
+			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-2", endsAt: date],
+			[operation: "READ", subscription: 2L, user: 2L, stream: "stream-3", endsAt: date],
 		] as Set
 	}
 }


### PR DESCRIPTION
## Summary

Add support for permissions that expire at a specific point in time. 

## Details
- Add field `Date endsAt` to domain class *Permission*
- Database queries of *PermissionService* filter out expired permissions
- Subscription-linked permissions now come attached with an expiration date