### PR TITLE
CORE-1348: pricePerSecond as String

### DIFF
--- a/grails-app/domain/com/unifina/domain/marketplace/Product.groovy
+++ b/grails-app/domain/com/unifina/domain/marketplace/Product.groovy
@@ -97,7 +97,7 @@ class Product {
 			updated: lastUpdated,
 			ownerAddress: ownerAddress,
 			beneficiaryAddress: beneficiaryAddress,
-			pricePerSecond: pricePerSecond,
+			pricePerSecond: pricePerSecond.toString(),
 			priceCurrency: priceCurrency.toString(),
 			minimumSubscriptionInSeconds: minimumSubscriptionInSeconds,
 			owner: owner

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -199,7 +199,7 @@ describe('Products API', () => {
                     previewConfigJson: null,
                     ownerAddress: '0xAAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDDDDDDD',
                     beneficiaryAddress: '0x0000000000000000000011111111111111111111',
-                    pricePerSecond: 5,
+                    pricePerSecond: "5",
                     priceCurrency: 'USD',
                     minimumSubscriptionInSeconds: 60,
                     owner: 'product-api-tester@streamr.com'
@@ -350,7 +350,7 @@ describe('Products API', () => {
                     previewConfigJson: null,
                     ownerAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
                     beneficiaryAddress: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
-                    pricePerSecond: 4556,
+                    pricePerSecond: '4556',
                     priceCurrency: 'DATA',
                     minimumSubscriptionInSeconds: 30000,
                     owner: 'product-api-tester@streamr.com'

--- a/rest-e2e-tests/schemas/product.json
+++ b/rest-e2e-tests/schemas/product.json
@@ -119,8 +119,8 @@
     },
     "pricePerSecond": {
       "description": "Unit price per second",
-      "type": "integer",
-      "minimum": 0
+      "type": "string",
+      "pattern": "^\\d+$"
     },
     "priceCurrency": {
       "description": "Unit currency",

--- a/src/groovy/com/unifina/api/UpdateProductCommand.groovy
+++ b/src/groovy/com/unifina/api/UpdateProductCommand.groovy
@@ -31,8 +31,8 @@ class UpdateProductCommand {
 		previewStream(nullable: true)
 		previewConfigJson(nullable: true)
 
-		ownerAddress(nullable: true)
-		beneficiaryAddress(nullable: true)
+		ownerAddress(nullable: true, validator: Product.isEthereumAddressOrIsNull)
+		beneficiaryAddress(nullable: true, validator: Product.isEthereumAddressOrIsNull)
 		pricePerSecond(nullable: true)
 		priceCurrency(nullable: true)
 		minimumSubscriptionInSeconds(nullable: true)

--- a/test/unit/com/unifina/api/UpdateProductCommandSpec.groovy
+++ b/test/unit/com/unifina/api/UpdateProductCommandSpec.groovy
@@ -85,7 +85,7 @@ class UpdateProductCommandSpec extends Specification {
 			previewConfigJson: "{newConfig: true}",
 			ownerAddress: "0x0",
 			beneficiaryAddress: "0x0",
-			pricePerSecond: 0L,
+			pricePerSecond: "0",
 			priceCurrency: "DATA",
 			minimumSubscriptionInSeconds: 0L
 		]
@@ -114,7 +114,7 @@ class UpdateProductCommandSpec extends Specification {
 			previewConfigJson: "{newConfig: true}",
 			ownerAddress: "0x0",
 			beneficiaryAddress: "0x0",
-			pricePerSecond: 5L,
+			pricePerSecond: "5",
 			priceCurrency: "DATA",
 			minimumSubscriptionInSeconds: 0L
 		]
@@ -143,7 +143,7 @@ class UpdateProductCommandSpec extends Specification {
 			previewConfigJson: "{newConfig: true}",
 			ownerAddress: "0xA",
 			beneficiaryAddress: "0xF",
-			pricePerSecond: 10L,
+			pricePerSecond: "10",
 			priceCurrency: "USD",
 			minimumSubscriptionInSeconds: 10L
 		]

--- a/test/unit/com/unifina/controller/api/SubscriptionApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/SubscriptionApiControllerSpec.groovy
@@ -51,6 +51,7 @@ class SubscriptionApiControllerSpec extends Specification {
 			imageUrl: "image1",
 			category: new Category(id: "category-1"),
 			streams: [],
+			pricePerSecond: 0,
 		)
 
 		def p2 = new Product(
@@ -59,6 +60,7 @@ class SubscriptionApiControllerSpec extends Specification {
 			imageUrl: "image1",
 			category: new Category(id: "category-2"),
 			streams: [],
+			pricePerSecond: 0,
 		)
 
 		def s1 = new PaidSubscription(

--- a/test/unit/com/unifina/service/ProductServiceSpec.groovy
+++ b/test/unit/com/unifina/service/ProductServiceSpec.groovy
@@ -126,7 +126,7 @@ class ProductServiceSpec extends Specification {
 			updated: product.lastUpdated,
 			ownerAddress: "0x0000000000000000000000000000000000000000",
 			beneficiaryAddress: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-			pricePerSecond: 10,
+			pricePerSecond: "10",
 			priceCurrency: "DATA",
 			minimumSubscriptionInSeconds: 1,
 			owner: "arnold"
@@ -365,7 +365,7 @@ class ProductServiceSpec extends Specification {
 				updated: product.lastUpdated,
 				ownerAddress: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
 				beneficiaryAddress: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-				pricePerSecond: 20L,
+				pricePerSecond: "20",
 				priceCurrency: "DATA",
 				minimumSubscriptionInSeconds: 1000,
 				owner: "arnold"
@@ -774,7 +774,7 @@ class ProductServiceSpec extends Specification {
 				state: "DEPLOYED",
 				ownerAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
 				beneficiaryAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-				pricePerSecond: 2,
+				pricePerSecond: "2",
 				priceCurrency: "USD",
 				minimumSubscriptionInSeconds: 600,
 				owner: "arnold"


### PR DESCRIPTION
- `Product#toMap` returns `pricePerSecond` as a String instead of a Long
-  Apparently prices can be sent in JSON body as either String or Long, both will be accepted. Thus no changes required on that front.