### PR TITLE
CORE-1330: Make API and user guide documentation public

### DIFF
--- a/grails-app/controllers/com/unifina/controller/help/HelpController.groovy
+++ b/grails-app/controllers/com/unifina/controller/help/HelpController.groovy
@@ -3,7 +3,7 @@ package com.unifina.controller.help
 import com.unifina.domain.security.SecUser
 import grails.plugin.springsecurity.annotation.Secured
 
-@Secured(["ROLE_USER"])
+@Secured(["IS_AUTHENTICATED_ANONYMOUSLY"])
 class HelpController {
 
 	def springSecurityService


### PR DESCRIPTION
Make API and user guide documentation public.

Tested by hand that
- Works when not logged in
- Works when logged in (and API key is included in Swagger)