### PR TITLE
CORE-1267: fix Webcomponent deserialization bug

### DIFF
--- a/grails-app/domain/com/unifina/domain/dashboard/DashboardItem.groovy
+++ b/grails-app/domain/com/unifina/domain/dashboard/DashboardItem.groovy
@@ -32,7 +32,7 @@ class DashboardItem {
 				title       : title,
 				canvas      : canvas?.id,
 				module      : module,
-				webcomponent: webcomponent.toString()
+				webcomponent: webcomponent.getName()
 		]
 	}
 }

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -108,4 +108,5 @@ databaseChangeLog = {
 	include file: 'core/2018-04-12-free-and-paid-subscriptions.groovy'
 	include file: 'core/2018-04-16-add-ends-at-field-to-permission.groovy'
 	include file: 'core/2018-04-26-fix-test-data-products.groovy'
+	include file: 'core/2018-04-29-fix-webcomponent-deserialization-bug.groovy'
 }

--- a/grails-app/migrations/core/2018-04-29-fix-webcomponent-deserialization-bug.groovy
+++ b/grails-app/migrations/core/2018-04-29-fix-webcomponent-deserialization-bug.groovy
@@ -1,0 +1,16 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "eric", id: "fix-webcomponent-deserialization-bug") {
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_CLIENT" WHERE webcomponent = "streamr-client"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_WIDGET" WHERE webcomponent = "streamr-widget"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_INPUT" WHERE webcomponent = "streamr-input"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_LABEL" WHERE webcomponent = "streamr-label"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_CHART" WHERE webcomponent = "streamr-chart"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_HEATMAP" WHERE webcomponent = "streamr-heatmap"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_TABLE" WHERE webcomponent = "streamr-table"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_BUTTON" WHERE webcomponent = "streamr-button"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_SWITCHER" WHERE webcomponent = "streamr-switcher"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_TEXT_FIELD" WHERE webcomponent = "streamr-text-field"')
+		sql('UPDATE dashboard_item SET webcomponent = "STREAMR_MAP" WHERE webcomponent = "streamr-map"')
+	}
+}

--- a/src/java/com/unifina/utils/Webcomponent.java
+++ b/src/java/com/unifina/utils/Webcomponent.java
@@ -19,12 +19,8 @@ public enum Webcomponent {
 		this.name = name;
 	}
 
-	String getName() {
+	public String getName() {
 		return name;
-	}
-
-	public String toString() {
-		return getName();
 	}
 
 	public static Webcomponent getByName(String s) {


### PR DESCRIPTION
Domain class `DashboardItem` contains field `webcomponent` of type `Webcomponent`, which is an Enum. When GORM loads a `DashboardItem` from the database it loads the associated `webcomponent` by deserializing a string stored in the database (via `Enum#valueOf(String`). These strings are produced to the database by `Webcomponent#toString()`. However, in this particular case, the method was overridden to produce a different string compared to the default behavior of `Enum#toString`. Thus de-serialization fails.

The bug is exemplified by `canvas.refresh()` at Line 94 of `CanvasApiController#stop`. Hypothesis: apparently refreshing a domain class causes associated domain classes to be loaded in as well, and because `Canvas` `hasMany` `DashboardItem`, dashboard items get loaded when canvas is refreshed.