### PR TITLE
CORE-1357 remove captcha from signup by default

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -473,6 +473,7 @@ streamr.fileUpload.s3.bucket = System.getProperty("streamr.fileUpload.s3.bucket"
  * Signup Configs
  */
 streamr.signup.requireInvite = (System.getProperty("streamr.signup.requireInvite") ? Boolean.parseBoolean(System.getProperty("streamr.signup.requireInvite")) : false)
+streamr.signup.requireCaptcha = (System.getProperty("streamr.signup.requireCaptcha") ? Boolean.parseBoolean(System.getProperty("streamr.signup.requireCaptcha")) : false)
 
 /**
  * Miscellaneous

--- a/grails-app/controllers/com/unifina/controller/security/RegisterController.groovy
+++ b/grails-app/controllers/com/unifina/controller/security/RegisterController.groovy
@@ -101,14 +101,16 @@ class RegisterController {
             return
         }
 
-		def response = Unirest.post(grailsApplication.config.recaptcha.verifyUrl)
+		if (grailsApplication.config.streamr.signup.requireCaptcha) {
+			def response = Unirest.post(grailsApplication.config.recaptcha.verifyUrl)
 				.field("secret", (String) grailsApplication.config.recaptchav2.secret)
-				.field("response",(String) params."g-recaptcha-response")
+				.field("response", (String) params."g-recaptcha-response")
 				.asJson()
-		if (response.body.jsonObject.success != true) {
-			flash.error = "Confirming reCaptcha failed for some reason. Please refresh page and refill form."
-			render view: 'signup', model: [ user: cmd ]
-			return
+			if (response.body.jsonObject.success != true) {
+				flash.error = "Confirming reCaptcha failed for some reason. Please refresh page and refill form."
+				render view: 'signup', model: [user: cmd]
+				return
+			}
 		}
 
 		SignupInvite invite

--- a/grails-app/views/register/signup.gsp
+++ b/grails-app/views/register/signup.gsp
@@ -3,14 +3,16 @@
     <meta name="layout" content="login" />
     <title>Sign Up</title>
 
-	<r:script>
-	function reCaptchaSuccess(response) {
-		$("form[name=signupForm]").submit()
-	}
-	</r:script>
+	<g:if test="${grailsApplication.config.streamr.signup.requireCaptcha}">
+		<r:script>
+			function reCaptchaSuccess(response) {
+				$("form[name=signupForm]").submit()
+			}
+		</r:script>
 
-	<!-- reCAPTCHA script-->
-	<script src='https://www.google.com/recaptcha/api.js' async></script>
+		<!-- reCAPTCHA script-->
+		<script src='https://www.google.com/recaptcha/api.js' async></script>
+	</g:if>
 </head>
 
 <body class="login-page show-sign-in">
@@ -36,7 +38,10 @@
 		</div>
 
 		 %{--reCaptcha v2--}%
-		<div class="g-recaptcha" data-sitekey="${grailsApplication.config.recaptchav2.sitekey}" style="margin: 10px 0;"></div>
+		<g:if test="${grailsApplication.config.streamr.signup.requireCaptcha}">
+			<div class="g-recaptcha" data-sitekey="${grailsApplication.config.recaptchav2.sitekey}" style="margin: 10px 0;"></div>
+		</g:if>
+
 		<button id="signUpButton" class="btn btn-primary btn-block btn-lg">
 			<g:message code="springSecurity.register.button" />
 		</button>


### PR DESCRIPTION
Captcha on signup can now be enabled/disabled via a configuration option. It is now **disabled** by default. The reason is that we are using Google reCaptcha and that is blocked by the Chinese firewall, so Chinese can't sign up without VPN.