### PR TITLE
CORE-1346: Duplicate results returned by API listing endpoints

### DIFF
--- a/test/integration/com/unifina/service/PermissionServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/PermissionServiceIntegrationSpec.groovy
@@ -21,7 +21,7 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 	PermissionService service
 
 	SecUser me, anotherUser, stranger, someone
-	Key anonymousKey
+	Key myKey, anotherUserKey, anonymousKey
 
 	Dashboard dashAllowed, dashRestricted, dashOwned, dashPublic
 	Permission dashReadPermission, dashAnonymousReadPermission
@@ -64,6 +64,8 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 		).save(failOnError: true)
 
 		// Keys
+		myKey = new Key(name: "my key", user: me).save(failOnError: true)
+		anotherUserKey = new Key(name: "another user's key", user: anotherUser).save(failOnError: true)
 		anonymousKey = new Key(name: "anonymous key 1").save(failOnError: true)
 
 		// Dashboards
@@ -94,6 +96,8 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 		dashOwned?.delete(flush: true)
 		dashPublic?.delete(flush: true)
 
+		myKey?.delete(flush: true)
+		anotherUserKey?.delete(flush: true)
 		anonymousKey?.delete(flush: true)
 
 		me?.delete(flush: true)
@@ -139,6 +143,17 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 		thrown AccessControlException
 	}
 
+	void "default revocation is all access"() {
+		setup:
+		service.grant(me, dashOwned, stranger, Permission.Operation.READ)
+		service.grant(me, dashOwned, stranger, Permission.Operation.SHARE)
+		when:
+		service.revoke(me, dashOwned, stranger)
+		then: "by default, revoke all access"
+		service.get(Dashboard, stranger) == []
+		service.get(Dashboard, stranger, Permission.Operation.SHARE) == []
+	}
+
 	void "revocation is granular"() {
 		setup:
 		service.grant(me, dashOwned, stranger, Permission.Operation.READ)
@@ -172,5 +187,106 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 
 		expect:
 		service.get(Dashboard, someone, Permission.Operation.READ) as Set == [dashOwned, dashRestricted] as Set
+	}
+
+	void "getAll lists public resources"() {
+		expect:
+		service.getAll(Dashboard, me) as Set == [dashOwned, dashPublic, dashAllowed] as Set
+		service.getAll(Dashboard, anotherUser) as Set == [dashAllowed, dashRestricted, dashPublic] as Set
+		service.getAll(Dashboard, stranger) == [dashPublic]
+	}
+
+	void "getAll lists public resources with keys"() {
+		expect:
+		service.getAll(Dashboard, myKey) as Set == [dashOwned, dashPublic, dashAllowed] as Set
+		service.getAll(Dashboard, anotherUserKey) as Set == [dashAllowed, dashRestricted, dashPublic] as Set
+		service.getAll(Dashboard, anonymousKey) as Set == [dashPublic, dashAllowed] as Set
+	}
+
+	void "getAll returns public resources on bad/null user"() {
+		expect:
+		service.get(Dashboard, new SecUser()) == []
+		service.get(Dashboard, null) == []
+		service.getAll(Dashboard, new SecUser()) == [dashPublic]
+		service.getAll(Dashboard, null) == [dashPublic]
+	}
+
+	void "granting and revoking read rights"() {
+		when:
+		service.grant(me, dashOwned, stranger)
+		then:
+		service.get(Dashboard, stranger) == [dashOwned]
+
+		when:
+		service.revoke(me, dashOwned, stranger)
+		then:
+		service.get(Dashboard, stranger) == []
+	}
+
+	void "granting and revoking write rights"() {
+		when:
+		service.grant(me, dashOwned, stranger, Permission.Operation.WRITE)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.WRITE) == [dashOwned]
+
+		when:
+		service.revoke(me, dashOwned, stranger, Permission.Operation.WRITE)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.WRITE) == []
+
+		when: "revoking read also revokes write"
+		service.grant(me, dashOwned, stranger, Permission.Operation.WRITE)
+		service.revoke(me, dashOwned, stranger)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.WRITE) == []
+	}
+
+	void "granting and revoking share rights"() {
+		when:
+		service.grant(me, dashOwned, stranger, Permission.Operation.SHARE)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.SHARE) == [dashOwned]
+
+		when:
+		service.revoke(me, dashOwned, stranger, Permission.Operation.SHARE)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.SHARE) == []
+
+		when: "revoking read also revokes share"
+		service.grant(me, dashOwned, stranger, Permission.Operation.SHARE)
+		service.revoke(me, dashOwned, stranger)
+		then:
+		service.get(Dashboard, stranger, Permission.Operation.SHARE) == []
+	}
+
+	void "granting works (roughly) idempotently"() {
+		expect:
+		service.get(Dashboard, stranger) == []
+		when: "double-granting still has the same effect: there exists a permission for user to resource"
+		service.grant(me, dashOwned, stranger)
+		service.grant(me, dashOwned, stranger)
+		then: "now you see it..."
+		service.get(Dashboard, stranger) == [dashOwned]
+		when:
+		service.grant(me, dashOwned, stranger)
+		service.grant(me, dashOwned, stranger)
+		service.grant(me, dashOwned, stranger)
+		service.revoke(me, dashOwned, stranger)
+		then: "now you don't."
+		service.get(Dashboard, stranger) == []
+	}
+
+	void "retrieve all readable Dashboards correctly"() {
+		expect:
+		service.get(Dashboard, me) as Set == [dashOwned, dashAllowed] as Set
+		service.get(Dashboard, anotherUser) as Set == [dashAllowed, dashRestricted, dashPublic] as Set
+		service.get(Dashboard, stranger) == []
+	}
+
+	void "retrieve all readable Dashboards correctly with keys"() {
+		expect:
+		service.get(Dashboard, myKey) as Set == [dashOwned, dashAllowed] as Set
+		service.get(Dashboard, anotherUserKey) as Set == [dashAllowed, dashRestricted, dashPublic] as Set
+		service.get(Dashboard, anonymousKey) as Set == [dashAllowed] as Set
 	}
 }

--- a/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
@@ -2,6 +2,7 @@ package com.unifina.controller.api
 
 import com.unifina.api.NotFoundException
 import com.unifina.api.NotPermittedException
+import com.unifina.api.StreamListParams
 import com.unifina.domain.data.Feed
 import com.unifina.domain.data.Stream
 import com.unifina.domain.security.Key
@@ -16,7 +17,7 @@ import grails.test.mixin.TestFor
 import spock.lang.Specification
 
 @TestFor(StreamApiController)
-@Mock([SecUser, Stream, Key, Permission, Feed, UnifinaCoreAPIFilters, UserService, PermissionService, SpringSecurityService, StreamService, ApiService, DashboardService])
+@Mock([SecUser, Stream, Key, Permission, Feed, UnifinaCoreAPIFilters, UserService, PermissionService, SpringSecurityService, StreamService, DashboardService])
 class StreamApiControllerSpec extends Specification {
 
 	Feed feed
@@ -24,6 +25,7 @@ class StreamApiControllerSpec extends Specification {
 
 	def streamService
 	def permissionService
+	def apiService
 
 	def streamOneId
 	def streamTwoId
@@ -34,8 +36,7 @@ class StreamApiControllerSpec extends Specification {
 		permissionService = mainContext.getBean(PermissionService)
 
 		controller.permissionService = permissionService
-		controller.apiService = mainContext.getBean(ApiService)
-		controller.apiService.permissionService = permissionService
+		apiService = controller.apiService = Mock(ApiService)
 
 		user = new SecUser(username: "me", password: "foo")
 		user.save(validate: false)
@@ -70,6 +71,14 @@ class StreamApiControllerSpec extends Specification {
 
 		then:
 		response.json.length() == 3
+		1 * apiService.list(Stream, {
+			assert it.toMap() == new StreamListParams().toMap()
+			return true
+		}, user) >> [
+		    Stream.findById(streamOneId),
+			Stream.findById(streamTwoId),
+			Stream.findById(streamThreeId)
+		]
 	}
 
 	void "find all streams of logged in user without config"() {
@@ -85,6 +94,14 @@ class StreamApiControllerSpec extends Specification {
 		then:
 		response.json.length() == 3
 		response.json[0].config == null
+		1 * apiService.list(Stream, {
+			assert it.toMap() == new StreamListParams().toMap()
+			return true
+		}, user) >> [
+			Stream.findById(streamOneId),
+			Stream.findById(streamTwoId),
+			Stream.findById(streamThreeId)
+		]
 	}
 
 	void "find streams by name of logged in user"() {
@@ -105,6 +122,12 @@ class StreamApiControllerSpec extends Specification {
 			fields: []
 		]
 		response.json[0].description == "description"
+		1 * apiService.list(Stream, {
+			assert it.toMap() == new StreamListParams(name: "stream").toMap()
+			return true
+		}, user) >> [
+			Stream.findById(streamOneId)
+		]
 	}
 
 	void "index() adds name param to filter criteria"() {
@@ -119,6 +142,12 @@ class StreamApiControllerSpec extends Specification {
 
 		then:
 		response.json[0].name == name
+		1 * apiService.list(Stream, {
+			assert it.toMap() == new StreamListParams(name: "ztream").toMap()
+			return true
+		}, user) >> [
+			Stream.findById(streamTwoId)
+		]
 	}
 
 	void "creating stream fails given invalid token"() {

--- a/test/unit/com/unifina/controller/security/RegisterControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/security/RegisterControllerSpec.groovy
@@ -16,7 +16,7 @@ import spock.lang.Specification
 
 @TestFor(RegisterController)
 @Mock([SignupInvite, SignupCodeService, RegistrationCode, SecUser, Key, SecRole, SecUserSecRole,
-		Feed, ModulePackage, PermissionService, Permission, UserService])
+		Feed, ModulePackage, Permission, UserService])
 class RegisterControllerSpec extends Specification {
 
 	def username = "user@invite.to"
@@ -40,7 +40,7 @@ class RegisterControllerSpec extends Specification {
 		
 		controller.springSecurityService = springSecurityService
 		controller.signupCodeService = new SignupCodeService()
-		def permissionService = new PermissionService()
+		def permissionService = Stub(PermissionService)
 		controller.userService = new UserService()
 		controller.userService.springSecurityService = springSecurityService
 		controller.userService.grailsApplication = grailsApplication

--- a/test/unit/com/unifina/service/DashboardServiceSpec.groovy
+++ b/test/unit/com/unifina/service/DashboardServiceSpec.groovy
@@ -46,10 +46,17 @@ class DashboardServiceSpec extends Specification {
 	}
 
 	def "get all dashboards of user"() {
+		service.permissionService = Mock(PermissionService)
 		when:
 		def dashboards = service.findAllDashboards(user)
 		then:
 		dashboards*.name as Set == ["my-dashboard-1", "my-dashboard-2", "my-dashboard-3", "not-my-dashboard-2"] as Set
+		1 * service.permissionService.getAll(Dashboard, user, _) >> [
+		    Dashboard.findById("1"),
+			Dashboard.findById("2"),
+			Dashboard.findById("3"),
+			Dashboard.findById("5"),
+		]
 	}
 
 	def "findById() cannot fetch non-existent dashboard"() {

--- a/test/unit/com/unifina/service/UserServiceSpec.groovy
+++ b/test/unit/com/unifina/service/UserServiceSpec.groovy
@@ -55,12 +55,11 @@ class UserServiceSpec extends Specification {
 		defineBeans {
 			passwordEncoder(PlaintextPasswordEncoder)
 			springSecurityService(SpringSecurityService)
-			permissionService(PermissionService)
 		}
 		// Do some wiring that should be done automatically but for some reason is not (in unit tests)
 		grailsApplication.mainContext.getBean("springSecurityService").grailsApplication = grailsApplication
 		grailsApplication.mainContext.getBean("springSecurityService").passwordEncoder = grailsApplication.mainContext.getBean("passwordEncoder")
-		permissionService = mainContext.getBean(PermissionService)
+		permissionService = service.permissionService = Mock(PermissionService)
 	}
 
     def "the user is created when called, with default roles if none supplied"() {
@@ -106,11 +105,10 @@ class UserServiceSpec extends Specification {
 		user.getAuthorities().size() == 1
 		user.getAuthorities().toArray()[0].authority == "ROLE_USER"
 
-		permissionService.get(Feed, user).size() == 0
-
-		permissionService.get(ModulePackage, user).size() == 2
-		permissionService.get(ModulePackage, user)[0].id == 1
-		permissionService.get(ModulePackage, user)[1].id == 2
+		1 * permissionService.get(Feed, {it.id == 1} as SecUser) >> []
+		1 * permissionService.get(ModulePackage, {it.id == 1} as SecUser) >> []
+		1 * permissionService.systemGrant({ it.id == 1} as SecUser, { it.id == 1} as ModulePackage)
+		1 * permissionService.systemGrant({ it.id == 1} as SecUser, { it.id == 2} as ModulePackage)
     }
 
 	def "it should fail if the default roles, feeds of modulePackages are not found"() {


### PR DESCRIPTION
### Summary
Addresses issue in which a resource can appear several times in the JSON response list produced by an API endpoint.

### Details
If a user has two or more permissions with the same access-level (e.g. ` Operation.READ`) to a resource, the resulting list of resources produced by `apiService#list` and `permissionService#createUserPermissionCriteria` will contain that resource multiple times. The desire is that a resource appear at maximum once per results (even across pagination).

This was fixed by modifying the database query that Grails produces. By grouping the `permission` table by resource id (e.g. `canvas_id`, `dashboard_id`, `stream_id` etc.) we ensure that a resource appear at most once in the result set before joining with the resource database table. 

### Concerning tests
Unfortunately changes had to be made to multiple tests because of spotty test support of GORM.  Specifically, the `groupProperty` function has not been stubbed in the GORM test support library thereby causing runtime errors for all tests that attempt to use `permissionService#createUserPermissionCriteria`. To summarize:

- Multiple tests from `PermissionServiceSpec` were moved to `PermissionServiceIntegrationSpec`
- Elsewhere `PermissionService` was mocked to allow tests to pass in unit test environment.