### PR TITLE
CORE-1375: add grantedAccess to ListParam

### DIFF
--- a/grails-app/services/com/unifina/service/ApiService.groovy
+++ b/grails-app/services/com/unifina/service/ApiService.groovy
@@ -35,7 +35,7 @@ class ApiService {
 	 *
 	 * @param domainClass Class of domain object
 	 * @param listParams conditions for listing
-	 * @param apiUser user for which listing is conducted (READ permission is checked)
+	 * @param apiUser user for which listing is conducted
 	 * @return list of results with pagination information
 	 * @throws ValidationException if listParams does not pass validation
 	 */
@@ -45,7 +45,8 @@ class ApiService {
 			throw new ValidationException(listParams.errors)
 		}
 		Closure searchCriteria = listParams.createListCriteria()
-		permissionService.get(domainClass, apiUser, listParams.operation, listParams.publicAccess, searchCriteria)
+		SecUser effectiveUser = listParams.grantedAccess ? apiUser : null
+		permissionService.get(domainClass, effectiveUser, listParams.operation, listParams.publicAccess, searchCriteria)
 	}
 
 	/**

--- a/src/groovy/com/unifina/api/ListParams.groovy
+++ b/src/groovy/com/unifina/api/ListParams.groovy
@@ -13,6 +13,7 @@ abstract class ListParams {
 	String order = "asc"
 	Integer max = MAX_LIMIT
 	Integer offset = 0
+	Boolean grantedAccess = true
 	Boolean publicAccess = false
 	Permission.Operation operation = Permission.Operation.READ
 
@@ -22,6 +23,7 @@ abstract class ListParams {
 		order(inList: ["asc", "desc"], nullable: false)
 		max(min: 1, max: MAX_LIMIT)
 		offset(min: 0, nullable: false)
+		grantedAccess(nullable: false)
 		publicAccess(nullable: false)
 	}
 
@@ -53,6 +55,7 @@ abstract class ListParams {
 			order: sortBy != null ? order : null,
 			max: max,
 			offset: offset,
+			grantedAccess: grantedAccess,
 			publicAccess: publicAccess
 		]
 	}

--- a/test/unit/com/unifina/api/ListParamsSpec.groovy
+++ b/test/unit/com/unifina/api/ListParamsSpec.groovy
@@ -45,6 +45,7 @@ class ListParamsSpec extends Specification {
 			order: null,
 			max: 1000,
 			offset: 0,
+			grantedAccess: true,
 			publicAccess: false
 		]
 	}
@@ -62,6 +63,7 @@ class ListParamsSpec extends Specification {
 			order: "desc",
 			max: 50,
 			offset: 1337,
+			grantedAccess: false,
 			publicAccess: true
 		)
 
@@ -72,6 +74,7 @@ class ListParamsSpec extends Specification {
 			order: "desc",
 			max: 50,
 			offset: 1337,
+			grantedAccess: false,
 			publicAccess: true
 		]
 	}
@@ -83,6 +86,7 @@ class ListParamsSpec extends Specification {
 			order: "desc",
 			max: 50,
 			offset: 1337,
+			grantedAccess: false,
 			publicAccess: true
 		)
 
@@ -136,6 +140,7 @@ class ListParamsSpec extends Specification {
 			order: "desc",
 			max: 50,
 			offset: 1337,
+			grantedAccess: false,
 			publicAccess: true,
 			additional: "additional information here"
 		).createListCriteria()

--- a/test/unit/com/unifina/service/ApiServiceSpec.groovy
+++ b/test/unit/com/unifina/service/ApiServiceSpec.groovy
@@ -52,6 +52,19 @@ class ApiServiceSpec extends Specification {
 		]
 	}
 
+	void "list() passes user as null to permissionService#get if grantedAccess=false"() {
+		def permissionService = service.permissionService = Mock(PermissionService)
+
+		SecUser me = new SecUser(username: "me@me.com")
+		ListParams listParams = new DashboardListParams(publicAccess: true, grantedAccess: false)
+
+		when:
+		service.list(Dashboard, listParams, me)
+
+		then:
+		1 * permissionService.get(Dashboard, null, _, _, _)
+	}
+
 	void "list() invokes listParams#validate and listParams#createListCriteria and passes returned closure to permissionService#get"() {
 		def permissionService = service.permissionService = Mock(PermissionService)
 
@@ -92,7 +105,7 @@ class ApiServiceSpec extends Specification {
 		when:
 		service.addLinkHintToHeader(params, 1000, [action: "index", controller: "dashboardApi"], response)
 		then:
-		1 * response.addHeader("Link", '<http://localhost:8080/api/v1/dashboards?max=1000&offset=1150&publicAccess=true&name=dashboard>; rel="more"')
+		1 * response.addHeader("Link", '<http://localhost:8080/api/v1/dashboards?max=1000&offset=1150&grantedAccess=true&publicAccess=true&name=dashboard>; rel="more"')
 	}
 
 	void "getByIdAndThrowIfNotFound() throws NotFoundException if domain object cannot be found"() {

--- a/web-app/misc/swagger.json
+++ b/web-app/misc/swagger.json
@@ -114,6 +114,9 @@
             "$ref": "#/parameters/offset"
           },
           {
+            "$ref": "#/parameters/grantedAccess"
+          },
+          {
             "$ref": "#/parameters/publicAccess"
           },
           {
@@ -257,6 +260,9 @@
           },
           {
             "$ref": "#/parameters/offset"
+          },
+          {
+            "$ref": "#/parameters/grantedAccess"
           },
           {
             "$ref": "#/parameters/publicAccess"
@@ -1363,6 +1369,9 @@
             "$ref": "#/parameters/offset"
           },
           {
+            "$ref": "#/parameters/grantedAccess"
+          },
+          {
             "$ref": "#/parameters/publicAccess"
           },
           {
@@ -2154,6 +2163,9 @@
             "$ref": "#/parameters/offset"
           },
           {
+            "$ref": "#/parameters/grantedAccess"
+          },
+          {
             "$ref": "#/parameters/publicAccess"
           },
           {
@@ -2601,6 +2613,9 @@
           },
           {
             "$ref": "#/parameters/offset"
+          },
+          {
+            "$ref": "#/parameters/grantedAccess"
           },
           {
             "$ref": "#/parameters/publicAccess"
@@ -3164,6 +3179,14 @@
       "description": "Skip the first (offset) results. Used together with max for paging.",
       "required": false,
       "default": 0
+    },
+    "grantedAccess": {
+      "name": "grantedAccess",
+      "type": "boolean",
+      "in": "query",
+      "description": "If false, excludes resources that user has been granted specific permission to from results.",
+      "required": false,
+      "default": true
     },
     "publicAccess": {
       "name": "publicAccess",


### PR DESCRIPTION
Add url parameter `grantedAccess` to API listing endpoints. When set to `false`, API endpoint will respond with a result set that exclude resources that are not publicly available.