### PR TITLE
CORE-1378: fix infinite loop in related products

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ProductApiController.groovy
@@ -35,19 +35,9 @@ class ProductApiController {
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def related() {
 		Product product = productService.findById((String) params.id, loggedInUser(), Permission.Operation.READ)
-		int max = 3
-		if (params.max != null) {
-			try {
-				max = Integer.parseInt((String) params.max)
-			} catch (NumberFormatException e) {
-				max = 3
-			}
-			if (max > 10) {
-				max = 10
-			}
-		}
+		int max = Math.min(params.int('max', 3), 10)
 		def related = productService.relatedProducts(product, max, loggedInUser())
-		render(related as JSON)
+		render(related*.toSummaryMap() as JSON)
 	}
 
 	@GrailsCompileStatic

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -17,27 +17,24 @@ class ProductService {
 	Random random = ThreadLocalRandom.current()
 
 	List<Product> relatedProducts(Product product, int maxResults, SecUser user) {
-		if (product == null) {
-			return new ArrayList<Product>()
-		}
 		// find Product.owner's other products
-		ListParams params = new ProductListParams(productOwner: product.owner, max: maxResults)
+		ListParams params = new ProductListParams(productOwner: product.owner, max: maxResults, publicAccess: true)
 		Set<Product> all = new HashSet<Product>(list(params, user))
 
 		// find other products from the same category
-		params = new ProductListParams(categories: [product.category].toSet(), max: maxResults)
-		Set<Product> cat = new HashSet<Product>(list(params, user))
-		all.addAll(cat)
+		params = new ProductListParams(categories: [product.category].toSet(), max: maxResults, publicAccess: true)
+		all.addAll(list(params, user))
 
-		all.removeIf { Product p -> p.id == product.id }
-		if (all.size() <= maxResults) {
-			return new ArrayList<Product>(all)
+		// remove given product itself from the set (if it is there)
+		all.remove(product)
+
+		def relatedProducts = new ArrayList<Product>(all)
+
+		while (relatedProducts.size() > maxResults) {
+			int i = random.nextInt(relatedProducts.size() - 1)
+			relatedProducts.remove(i)
 		}
-		while (all.size() > maxResults) {
-			int i = random.nextInt(all.size() - 1)
-			all.remove(i)
-		}
-		return new ArrayList<Product>(all)
+		return relatedProducts
 	}
 
 	void removeUsersProducts(String username) {

--- a/test/unit/com/unifina/service/ProductServiceRelatedProductsSpec.groovy
+++ b/test/unit/com/unifina/service/ProductServiceRelatedProductsSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 
 @TestFor(ProductService)
 @Mock([Product, SecUser, Category])
-class RelatedProductsSpec extends Specification {
+class ProductServiceRelatedProductsSpec extends Specification {
 	Product newProduct(String id, String name, String description, Category c, SecUser user) {
 		Product p = new Product(
 			name: name,

--- a/test/unit/com/unifina/service/RelatedProductsSpec.groovy
+++ b/test/unit/com/unifina/service/RelatedProductsSpec.groovy
@@ -125,13 +125,4 @@ class RelatedProductsSpec extends Specification {
 		products.contains(p3) == true
 		products.contains(p5) == true
 	}
-
-	void "find related products with non existing id"() {
-		when:
-		def products = service.relatedProducts(null, 3, apiUser)
-		then:
-		0 * service.apiService._
-		products.size() == 0
-	}
-
 }


### PR DESCRIPTION
- Fix inifinite loop in `ProductService#relatedProducts`, see comment in "Files changed".
- Respond with `Product#toSummaryMap()` instead of `Product`.
- Add `publicAccess=true` to fetches inside `ProductService#relatedProducts` to make sure that results are returned.
- Some refactorings