### PR TITLE
CORE-1384: test subscription case-insensitivity

### DIFF
--- a/test/integration/com/unifina/com/unifina/domain/marketplace/PaidSubscriptionIntegrationSpec.groovy
+++ b/test/integration/com/unifina/com/unifina/domain/marketplace/PaidSubscriptionIntegrationSpec.groovy
@@ -1,0 +1,96 @@
+package com.unifina.com.unifina.domain.marketplace
+
+import com.unifina.domain.marketplace.Category
+import com.unifina.domain.marketplace.PaidSubscription
+import com.unifina.domain.marketplace.Product
+import com.unifina.domain.security.IntegrationKey
+import com.unifina.domain.security.SecUser
+import grails.test.spock.IntegrationSpec
+import grails.validation.ValidationException
+
+class PaidSubscriptionIntegrationSpec extends IntegrationSpec {
+
+	Product product
+
+	void setup() {
+		def owner = new SecUser(
+			username: "subscription-service-integration-spec-1@streamr.com",
+			password: "xxx",
+			name: "Subscription Service Integration Spec 1",
+			timezone: "UTC"
+		).save(failOnError: true)
+
+		product = new Product(
+			name: "Subscription Service Integration Spec Product",
+			description: "description",
+			category: Category.get("energy"),
+			state: Product.State.DEPLOYED,
+			dateCreated: new Date(),
+			lastUpdated: new Date(),
+			owner: owner,
+			ownerAddress: "0x0000000000000000000000000000000000000000",
+			beneficiaryAddress: "0x0000000000000000000000000000000000000000",
+			pricePerSecond: 1,
+		).save(failOnError: true)
+	}
+
+	void "fetchUser() is case-insensitive w.r.t. ethereum addresses [database property]"() {
+		setup:
+		def subscriber = new SecUser(
+			username: "subscription-service-integration-spec-2@streamr.com",
+			password: "xxx",
+			name: "Subscription Service Integration Spec 2",
+			timezone: "UTC"
+		).save(failOnError: true)
+
+		new IntegrationKey(
+			user: subscriber,
+			name: "Integration Key",
+			service: IntegrationKey.Service.ETHEREUM_ID,
+			json: "{}",
+			idInService: "0xffffffffffFFFFFFFFFFaaaaaaaaaaBBBBBBBBBB"
+		).save(failOnError: true)
+
+		def subscription = new PaidSubscription(
+			product: product,
+			endsAt: new Date(0),
+			address: "0xffffffffffffffffffffaaaaaaaaaabbbbbbbbbb"
+		)
+
+		expect:
+		subscription.fetchUser() == subscriber
+	}
+
+	void "fetching by address is case-insensitive w.r.t. ethereum addresses [database property]"() {
+		setup:
+		def subscription = new PaidSubscription(
+			product: product,
+			endsAt: new Date(0),
+			address: "0xffffffffffffffffffffaaaaaaaaaabbbbbbbbbb"
+		).save(failOnError: true)
+
+		expect:
+		PaidSubscription.findByProductAndAddress(product, "0xFFFFFFFFFFFFFFFFFFFFAAAAAAAAAAbbbbbbbbbb") == subscription
+	}
+
+	void "address-product uniqueness constraint is case-insensitive w.r.t. ethereum addresses [database property]"() {
+		setup:
+		new PaidSubscription(
+			product: product,
+			endsAt: new Date(0),
+			address: "0xffffffffffffffffffffaaaaaaaaaabbbbbbbbbb"
+		).save(failOnError: true)
+
+		when:
+		new PaidSubscription(
+			product: product,
+			endsAt: new Date(0),
+			address: "0xFFFFFFFFFFFFFFFFFFFFaaaaaaaaaaBBBBBBBBBB"
+		).save(failOnError: true)
+
+		then:
+		def e = thrown(ValidationException)
+		e.message.contains("unique")
+	}
+
+}


### PR DESCRIPTION
I was worried that case-sensitivity issues could cause problems when matching the Ethereum addresses of `PaidSubscription` to those of `IntegrationKey`. Then I (re-)learned that MySQL is by default case-insensitive with respect to strings. Therefore string matching in `WHERE` clause and uniqueness constraints are case-insensitive so no problems arise!

Anyway I thought it would be a good idea to encode this assumptions as tests just in case there were any changes to our environment in the future and this property would no longer hold. 