### PR TITLE
CORE-1226: query params addModule and addStream to /canvas/editor

### DIFF
--- a/grails-app/controllers/com/unifina/controller/core/signalpath/CanvasController.groovy
+++ b/grails-app/controllers/com/unifina/controller/core/signalpath/CanvasController.groovy
@@ -48,9 +48,6 @@ class CanvasController {
 		def endDate = new Date()
 		def currentUser = SecUser.get(springSecurityService.currentUser.id)
 
-		// TODO: what's the case for request.JSON in editor action? GETs don't have bodies. Where can a POST come from? What can it possibly do with the response?
-		def json = request.JSON
-
 		[
 			beginDate: beginDate,
 			endDate: endDate,
@@ -58,7 +55,6 @@ class CanvasController {
 			examples: params.examples,
 			user: currentUser,
 			key: currentUser?.keys?.iterator()?.next(), // any one of the user's keys will do
-			json: (json as JSON)?.toString(),
 			addModuleId: params.addModule,
 			addStreamId: params.addStream
 		]

--- a/grails-app/controllers/com/unifina/controller/core/signalpath/CanvasController.groovy
+++ b/grails-app/controllers/com/unifina/controller/core/signalpath/CanvasController.groovy
@@ -47,6 +47,8 @@ class CanvasController {
 		def beginDate = new Date()
 		def endDate = new Date()
 		def currentUser = SecUser.get(springSecurityService.currentUser.id)
+
+		// TODO: what's the case for request.JSON in editor action? GETs don't have bodies. Where can a POST come from? What can it possibly do with the response?
 		def json = request.JSON
 
 		[
@@ -56,7 +58,9 @@ class CanvasController {
 			examples: params.examples,
 			user: currentUser,
 			key: currentUser?.keys?.iterator()?.next(), // any one of the user's keys will do
-			json: (json as JSON)?.toString()
+			json: (json as JSON)?.toString(),
+			addModuleId: params.addModule,
+			addStreamId: params.addStream
 		]
 	}
 

--- a/grails-app/views/canvas/editor.gsp
+++ b/grails-app/views/canvas/editor.gsp
@@ -23,10 +23,15 @@
 	var loadBrowser
 	var saveAndAskName
 
+
+	var shouldPreventTour = ${addStreamId || addModuleId}
+
 $(function() {
 	$('#moduleTree').bind('loaded.jstree', function() {
-		Tour.startableTours([0])
-		Tour.autoStart()
+	    if (!shouldPreventTour){
+			Tour.startableTours([0])
+			Tour.autoStart()
+		}
 	})
 	saveAsAndAskName = function() {
 		bootbox.prompt({

--- a/grails-app/views/canvas/editor.gsp
+++ b/grails-app/views/canvas/editor.gsp
@@ -400,9 +400,6 @@ $(function() {
 	<g:if test="${id}">
 		SignalPath.load('${id}');
 	</g:if>
-	<g:elseif test="${ json && json != "{}" }">
-		SignalPath.loadJSON(${raw(json)})
-	</g:elseif>
 	<g:else>
 		$(SignalPath).trigger('new') // For event listeners
 	</g:else>

--- a/grails-app/views/canvas/editor.gsp
+++ b/grails-app/views/canvas/editor.gsp
@@ -204,8 +204,9 @@ $(function() {
 		limit: 3
 	}], {
 		inBody: true
-	}, function(item) {
+	}, addModuleToCanvas)
 
+	function addModuleToCanvas(item) {
 		if (item.resultType == "stream") { // is stream, specifies module
 			SignalPath.addModule(item.feed.module, {
 				params: [{
@@ -216,7 +217,7 @@ $(function() {
 		} else { // is module
 			SignalPath.addModule(item.id, {})
 		}
-	})
+	}
 
     $('#main-menu-inner').scroll(function() {
     	streamrSearch.redrawMenu()
@@ -400,6 +401,19 @@ $(function() {
 	<g:else>
 		$(SignalPath).trigger('new') // For event listeners
 	</g:else>
+
+	<g:if test="${addModuleId}">
+		addModuleToCanvas({
+			id: "${addModuleId}"
+		})
+	</g:if>
+	<g:if test="${addStreamId}">
+		addModuleToCanvas({
+			resultType: "stream",
+			feed: { id: 7, name: "API", module: 147 },
+			id: "${addStreamId}"
+		})
+	</g:if>
 
     $(document).unload(function () {
         SignalPath.unload()


### PR DESCRIPTION
Currently has an issue (on my very local dev env at least) that the correct canvas only flashes by, is replaced with empty canvas. Might have something to do with the tour being active.

Henri marked as reviewer mostly to comment on why request.JSON is in canvas/editor controller code (it should be a GET, without body, so what should request.JSON be and when?)