### PR TITLE
CORE-1332: add role checking to StreamrApi-annotation

### DIFF
--- a/grails-app/conf/com/unifina/filters/UnifinaCoreAPIFilters.groovy
+++ b/grails-app/conf/com/unifina/filters/UnifinaCoreAPIFilters.groovy
@@ -73,11 +73,20 @@ class UnifinaCoreAPIFilters {
 					result = new AuthenticationResult((SecUser) springSecurityService.getCurrentUser())
 				}
 				if (!result.guarantees(annotation.authenticationLevel())) {
-					render (
+					render(
 						status: 401,
 						text: [
 							code: "NOT_AUTHENTICATED",
 							message: "Not authenticated via token or cookie"
+						] as JSON
+					)
+					return false
+				} else if (!result.hasOneOfRoles(annotation.allowRoles())) {
+					render(
+						status: 403,
+						text: [
+							code: "NOT_PERMITTED",
+							message: "Not authorized to access this endpoint"
 						] as JSON
 					)
 					return false

--- a/src/java/com/unifina/security/AllowRole.java
+++ b/src/java/com/unifina/security/AllowRole.java
@@ -1,0 +1,21 @@
+package com.unifina.security;
+
+import com.unifina.domain.security.SecUser;
+
+public enum AllowRole {
+	NO_ROLE_REQUIRED,
+	DEVOPS,
+	ADMIN;
+
+	public boolean hasUserRole(SecUser secUser) {
+		switch (this) {
+			case NO_ROLE_REQUIRED:
+				return true;
+			case DEVOPS:
+				return secUser != null && secUser.isDevOps();
+			case ADMIN:
+				return secUser != null && secUser.isAdmin();
+		}
+		throw new IllegalArgumentException("Unexpected AllowRole: " + this);
+	}
+}

--- a/src/java/com/unifina/security/AuthenticationResult.java
+++ b/src/java/com/unifina/security/AuthenticationResult.java
@@ -57,4 +57,13 @@ public class AuthenticationResult {
 			throw new RuntimeException("Unexpected authLevel: " + level);
 		}
 	}
+
+	public boolean hasOneOfRoles(AllowRole[] roles) {
+		for (AllowRole role : roles) {
+			if (role.hasUserRole(getSecUser())) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/java/com/unifina/security/StreamrApi.java
+++ b/src/java/com/unifina/security/StreamrApi.java
@@ -17,4 +17,6 @@ public @interface StreamrApi {
 	 * Set to false if authentication is optional for this API method.
 	 */
 	AuthLevel authenticationLevel() default AuthLevel.USER;
+
+	AllowRole[] allowRoles() default AllowRole.NO_ROLE_REQUIRED;
 }

--- a/test/unit/com/unifina/security/AllowRoleSpec.groovy
+++ b/test/unit/com/unifina/security/AllowRoleSpec.groovy
@@ -1,0 +1,68 @@
+package com.unifina.security
+
+import com.unifina.domain.security.SecRole
+import com.unifina.domain.security.SecUser
+import com.unifina.domain.security.SecUserSecRole
+import grails.test.mixin.Mock
+import spock.lang.Specification
+
+@Mock(SecUserSecRole)
+class AllowRoleSpec extends Specification {
+
+	void "hasUserRole(null) is true when this == NO_ROLE_REQUIRED"() {
+		expect:
+		AllowRole.NO_ROLE_REQUIRED.hasUserRole(null)
+	}
+
+	void "hasUserRole(user w/o roles) is true when this == NO_ROLE_REQUIRED"() {
+		expect:
+		AllowRole.NO_ROLE_REQUIRED.hasUserRole(new SecUser())
+	}
+
+	void "hasUserRole(null) is false when this == DEVOPS"() {
+		expect:
+		!AllowRole.DEVOPS.hasUserRole(null)
+	}
+
+
+	void "hasUserRole(user w/o roles) is false when this == DEVOPS"() {
+		expect:
+		!AllowRole.DEVOPS.hasUserRole(new SecUser())
+	}
+
+	void "hasUserRole(user with DEVOPS role) is true when this == DEVOPS"() {
+		SecUser user = new SecUser()
+		user.save(failOnError: true, validate: false)
+
+		SecRole secRole = new SecRole(authority: "ROLE_DEV_OPS")
+		secRole.save(failOnError: true)
+
+		new SecUserSecRole(secUser: user, secRole: secRole).save(failOnError: true)
+
+		expect:
+		AllowRole.DEVOPS.hasUserRole(user)
+	}
+
+	void "hasUserRole(null) is false when this == ADMIN"() {
+		expect:
+		!AllowRole.ADMIN.hasUserRole(null)
+	}
+
+	void "hasUserRole(user w/o roles) is false when this == ADMIN"() {
+		expect:
+		!AllowRole.ADMIN.hasUserRole(null)
+	}
+
+	void "hasUserRole(user with ADMIN role) is true when this == ADMIN"() {
+		SecUser user = new SecUser()
+		user.save(failOnError: true, validate: false)
+
+		SecRole secRole = new SecRole(authority: "ROLE_ADMIN")
+		secRole.save(failOnError: true)
+
+		new SecUserSecRole(secUser: user, secRole: secRole).save(failOnError: true)
+
+		expect:
+		AllowRole.ADMIN.hasUserRole(user)
+	}
+}


### PR DESCRIPTION
`@StreamrApi` annotation now supports role requirements. By default everything works as before (no roles are required.) 

Usage:
```
@StreamrApi(authenticationLevel = AuthLevel.USER, allowRoles = AllowRole.DEVOPS)
```

or with multiple roles (of which at least one must be satisfied by logged-in user)

```
@StreamrApi(authenticationLevel = AuthLevel.USER, allowRoles = [AllowRole.DEVOPS, AllowRole.ADMIN])
```

Note that `authenticationFilter` has not been (unit) tested in this PR. The reason is that in Grails there are no tools to really unit test a filter by itself, but rather this is done in the context of writing a unit test for a controller that uses the filter. We should make sure that the functionality gets tested when writing first controller that uses role requirements with the annotation.