### PR TITLE
Fix memory leak issue

### DIFF
--- a/src/java/com/unifina/feed/StreamrMessage.java
+++ b/src/java/com/unifina/feed/StreamrMessage.java
@@ -23,4 +23,14 @@ public class StreamrMessage extends MapMessage {
 	public String getStreamId() {
 		return streamId;
 	}
+
+	@Override
+	public String toString() {
+		return "StreamrMessage{" +
+				"partition=" + partition +
+				", streamId='" + streamId + '\'' +
+				", timestamp=" + timestamp +
+				", payload=" + payload +
+				'}';
+	}
 }

--- a/src/java/com/unifina/signalpath/SignalPathRunner.java
+++ b/src/java/com/unifina/signalpath/SignalPathRunner.java
@@ -141,10 +141,12 @@ public class SignalPathRunner extends Thread {
 
 	private void runSignalPaths() {
 		// Start feed, blocks until feed is complete
-		globals.getDataSource().startFeed();
-
-		// Stop the feed, cleanup
-		globals.getDataSource().stopFeed();
+		try {
+			globals.getDataSource().startFeed();
+		} finally {
+			// Stop the feed, cleanup
+			globals.getDataSource().stopFeed();
+		}
 	}
 
 	/**


### PR DESCRIPTION
- remove (unused) catch-up functionality from `AbstractFeedProxy`
- add hard limit to the size of `DataSourceEventQueue#queue` as a precaution to avoid the queue from growing without bound. 
- make sure that the `RedisFeed` of a crashed `SignalPath` gets properly cleaned up so as to avoid leaking memory.