### PR TITLE
[CORE-1482] Redirect after a protected route not working

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="FLOW" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0.171-oracle" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/grails-app/controllers/com/unifina/controller/security/LoginRedirectValidator.groovy
+++ b/grails-app/controllers/com/unifina/controller/security/LoginRedirectValidator.groovy
@@ -23,3 +23,4 @@ class LoginRedirectValidator {
 		return matcher.matches()
 	}
 }
+

--- a/test/unit/com/unifina/security/RedirectAppendingAuthenticationEntryPointSpec.groovy
+++ b/test/unit/com/unifina/security/RedirectAppendingAuthenticationEntryPointSpec.groovy
@@ -6,40 +6,52 @@ import spock.lang.Specification
 import javax.servlet.http.HttpServletRequest
 
 class RedirectAppendingAuthenticationEntryPointSpec extends Specification {
-	RedirectAppendingAuthenticationEntryPoint redirect
-	HttpServletRequest request
 
-	def setup() {
-		request = new MockHttpServletRequest() {
-			@Override
-			String getRequestURI() {
-				return "https://www.streamr.com/canvas/editor?addModule=5"
-			}
+	def "redirect url is url encoded"() {
+		setup:
+		HttpServletRequest request = new MockHttpServletRequest()
+		request.setScheme("https")
+		request.setServerName("www.streamr.com")
+		request.setRequestURI("/canvas/editor")
+		request.setQueryString("addModule=5")
 
-			@Override
-			StringBuffer getRequestURL() {
-				return new StringBuffer("https://www.streamr.com/canvas/editor")
-			}
-
-			@Override
-			String getQueryString() {
-				return "addModule=5"
-			}
-		}
-		redirect = new RedirectAppendingAuthenticationEntryPoint("https://www.streamr.com/login/auth") {
+		RedirectAppendingAuthenticationEntryPoint redirect = new RedirectAppendingAuthenticationEntryPoint("https://www.streamr.com/login/auth") {
 			@Override
 			String getFullURI(String uriWithoutContextPath) {
 				return "https://..."
 			}
 		}
-	}
 
-	def "query parameters are not lost while logging in"() {
 		when:
 		def url = redirect.buildRedirectUrlToLoginPage(request, null, null)
 
 		then:
 		url == "https://www.streamr.com/login/auth?redirect=https%3A%2F%2Fwww.streamr.com%2Fcanvas%2Feditor%3FaddModule%3D5"
+	}
 
+	def "redirect url is read from x-forwarded-... headers if present"() {
+		setup:
+		HttpServletRequest request = new MockHttpServletRequest()
+		request.setScheme("http")
+		request.setServerName("diipadaapa")
+		request.setServerPort(8081)
+		request.setRequestURI("/canvas/editor")
+		request.setQueryString("addModule=5")
+		request.addHeader("X-Forwarded-Proto", "https")
+		request.addHeader("X-Forwarded-Host", "www.streamr.com")
+		request.addHeader("X-Forwarded-Port", "443")
+
+		RedirectAppendingAuthenticationEntryPoint redirect = new RedirectAppendingAuthenticationEntryPoint("https://www.streamr.com/login/auth") {
+			@Override
+			String getFullURI(String uriWithoutContextPath) {
+				return "https://..."
+			}
+		}
+
+		when:
+		def url = redirect.buildRedirectUrlToLoginPage(request, null, null)
+
+		then:
+		url == "https://www.streamr.com/login/auth?redirect=https%3A%2F%2Fwww.streamr.com%2Fcanvas%2Feditor%3FaddModule%3D5"
 	}
 }


### PR DESCRIPTION
Check for presence of `X-Forwarded-*` headers written by load balancers, and use that to build the redirect url. Otherwise the redirect url ends up with `http://tomcat/...` written by nginx, which doesn't pass redirect url validation.