### PR TITLE
CORE-1470: API endpoint to start canvas as admin

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -25,6 +25,7 @@ class UrlMappings {
 		// API v1 url mappings
 		"/api/v1/canvases"(resources: "canvasApi", excludes: ["create", "edit"])
 		"/api/v1/canvases/$id/start"(controller: "canvasApi", action: "start")
+		"/api/v1/canvases/$id/startAsAdmin"(controller: "canvasApi", action: "startAsAdmin")
 		"/api/v1/canvases/$id/stop"(controller: "canvasApi", action: "stop")
 		"/api/v1/canvases/$resourceId/permissions"(resources: "permissionApi", excludes: ["create", "edit", "update"]) { resourceClass = Canvas }
 		"/api/v1/canvases/$resourceId/permissions/me"(controller: "permissionApi", action: "getOwnPermissions") { resourceClass = Canvas }

--- a/src/groovy/com/unifina/api/StartCanvasAsAdminParams.groovy
+++ b/src/groovy/com/unifina/api/StartCanvasAsAdminParams.groovy
@@ -1,0 +1,13 @@
+package com.unifina.api
+
+import com.unifina.domain.security.SecUser
+import grails.validation.Validateable
+
+@Validateable
+class StartCanvasAsAdminParams {
+	SecUser startedBy
+
+	static constraints = {
+		startedBy(nullable: false)
+	}
+}


### PR DESCRIPTION
Allow admin to start any canvas as any user via admin-only API endpoint.