### PR TITLE
Enable CORS for /profile/* endpoints

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -211,7 +211,7 @@ environments {
 /**
  * API & CORS config
  */
-cors.url.pattern = ['/api/*', '/contact/send']
+cors.url.pattern = ['/api/*', '/contact/send', '/profile/*']
 streamr.apiKey.revokeNotificationStream = "revoked-api-keys"
 
 /**


### PR DESCRIPTION
Enables user to edit their name, timezone & change their password via API calls. Required for new editor frontend. 

Related to both `EDITOR-8` & `EDITOR-9`.