### PR TITLE
CORE-1506: show user's permission in api listing endpoints

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/CanvasApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/CanvasApiController.groovy
@@ -34,7 +34,7 @@ class CanvasApiController {
 		}
 		def results = apiService.list(Canvas, listParams, (SecUser) request.apiUser)
 		apiService.addLinkHintToHeader(listParams, results.size(), params, response)
-		render(results*.toMap() as JSON)
+		render(apiService.formListResult(Canvas, results, (SecUser) request.apiUser, listParams) as JSON)
 	}
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)

--- a/grails-app/controllers/com/unifina/controller/api/DashboardApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/DashboardApiController.groovy
@@ -25,7 +25,7 @@ class DashboardApiController {
 		}
 		def results = apiService.list(Dashboard, listParams, (SecUser) request.apiUser)
 		apiService.addLinkHintToHeader(listParams, results.size(), params, response)
-		render(results*.toMap() as JSON)
+		render(apiService.formListResult(Dashboard, results, (SecUser) request.apiUser, listParams) as JSON)
 	}
 
 	@StreamrApi

--- a/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
@@ -28,7 +28,7 @@ class StreamApiController {
 			render(results*.toSummaryMap() as JSON)
 			return
 		}
-		render(results*.toMap() as JSON)
+		render(apiService.formListResult(Stream, results, (SecUser) request.apiUser, listParams) as JSON)
 	}
 
 	@StreamrApi

--- a/grails-app/domain/com/unifina/domain/security/Permission.groovy
+++ b/grails-app/domain/com/unifina/domain/security/Permission.groovy
@@ -80,6 +80,24 @@ class Permission {
 		anonymous(index: 'anonymous_idx')
 	}
 
+	Object getDomainObjectId() {
+		if (canvas) {
+			return canvas.id
+		} else if (dashboard) {
+			return dashboard.id
+		} else if (feed) {
+			return feed.id
+		} else if (modulePackage) {
+			return modulePackage.id
+		} else if (stream) {
+			return stream.id
+		} else if (product) {
+			return product.id
+		} else {
+			throw new IllegalStateException("Illegal state.")
+		}
+	}
+
 	/**
 	 * Client-side representation of Permission object
 	 * Resource type/id is not indicated because API caller will have it in the URL

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -133,6 +133,11 @@ class PermissionService {
 	 * Get all the user's permissions associated with a specific resource class.
 	 */
 	List<Permission> getPermissionsForUserishAndResources(Class resourceClass, Userish userish, List resources) {
+		// GORM doesn't handle empty `in` properly
+		if (resources == null || resources.isEmpty()) {
+			return []
+		}
+
 		userish = userish.resolveToUserish()
 
 		String userProp = getUserPropertyName(userish)

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -129,6 +129,28 @@ class PermissionService {
 		}.toList()
 	}
 
+	/**
+	 * Get all the user's permissions associated with a specific resource class.
+	 */
+	List<Permission> getPermissionsForUserishAndResources(Class resourceClass, Userish userish, List resources) {
+		userish = userish.resolveToUserish()
+
+		String userProp = getUserPropertyName(userish)
+		String idProperty = getResourcePropertyName(resourceClass)
+
+		return Permission.withCriteria {
+			'in'(idProperty, resources)
+			or {
+				eq("anonymous", true)
+				eq(userProp, userish)
+			}
+			or {
+				isNull("endsAt")
+				gt("endsAt", new Date())
+			}
+		}
+	}
+
 	/** Overload to allow leaving out the anonymous-include-flag but including the filter */
 	@CompileStatic
 	<T> List<T> get(Class<T> resourceClass, Userish userish, Operation op, Closure resourceFilter = {}) {

--- a/grails-app/services/com/unifina/service/SignalPathService.groovy
+++ b/grails-app/services/com/unifina/service/SignalPathService.groovy
@@ -295,14 +295,13 @@ class SignalPathService {
 				 * Special handling for runner thread stop request
 				 */
 				if (req.type=="stopRequest") {
-					if (!permissionService.canWrite(req.getUser(), req.getCanvas())) {
+					if (!permissionService.canWrite(req.getUser(), req.getCanvas()) && !req.getUser()?.isAdmin()) {
 						throw new AccessControlException("stopRequest requires write permission!");
 					}
 
 					if (stopLocal(req.getCanvas())) {
 						return req
-					}
-					else {
+					} else {
 						throw new CanvasUnreachableException("Canvas could not be stopped.")
 					}
 				}

--- a/src/groovy/com/unifina/api/ListParams.groovy
+++ b/src/groovy/com/unifina/api/ListParams.groovy
@@ -15,6 +15,7 @@ abstract class ListParams {
 	Integer offset = 0
 	Boolean grantedAccess = true
 	Boolean publicAccess = false
+	Boolean includePermissions = false
 	Permission.Operation operation = Permission.Operation.READ
 
 	static constraints = {
@@ -25,6 +26,7 @@ abstract class ListParams {
 		offset(min: 0, nullable: false)
 		grantedAccess(nullable: false)
 		publicAccess(nullable: false)
+		includePermissions(nullable: false)
 	}
 
 	protected abstract List<String> getSearchFields()
@@ -56,7 +58,8 @@ abstract class ListParams {
 			max: max,
 			offset: offset,
 			grantedAccess: grantedAccess,
-			publicAccess: publicAccess
+			publicAccess: publicAccess,
+			includePermissions: includePermissions,
 		]
 	}
 }

--- a/test/unit/com/unifina/api/ListParamsSpec.groovy
+++ b/test/unit/com/unifina/api/ListParamsSpec.groovy
@@ -46,7 +46,8 @@ class ListParamsSpec extends Specification {
 			max: 1000,
 			offset: 0,
 			grantedAccess: true,
-			publicAccess: false
+			publicAccess: false,
+			includePermissions: false,
 		]
 	}
 
@@ -64,7 +65,8 @@ class ListParamsSpec extends Specification {
 			max: 50,
 			offset: 1337,
 			grantedAccess: false,
-			publicAccess: true
+			publicAccess: true,
+			includePermissions: true
 		)
 
 		expect:
@@ -75,7 +77,8 @@ class ListParamsSpec extends Specification {
 			max: 50,
 			offset: 1337,
 			grantedAccess: false,
-			publicAccess: true
+			publicAccess: true,
+			includePermissions: true
 		]
 	}
 

--- a/test/unit/com/unifina/controller/api/CanvasApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/CanvasApiControllerSpec.groovy
@@ -100,6 +100,7 @@ class CanvasApiControllerSpec extends Specification {
 			assert listParams.toMap() == new CanvasListParams().toMap()
 			[canvas1, canvas2, canvas3]
 		}
+		1 * controller.apiService.formListResult(Canvas, [canvas1, canvas2, canvas3], me, _) >> [canvas1, canvas2, canvas3]*.toMap()
 	}
 
 	void "index() adds name param to filter criteria"() {

--- a/test/unit/com/unifina/controller/api/CanvasApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/CanvasApiControllerSpec.groovy
@@ -119,6 +119,7 @@ class CanvasApiControllerSpec extends Specification {
 			assert listParams.toMap() == new CanvasListParams(name: "Foo").toMap()
 			[]
 		}
+		1 * controller.apiService.formListResult(Canvas, [], me, _) >> []
 	}
 
 	void "index() adds adhoc param to filter criteria"() {
@@ -137,6 +138,7 @@ class CanvasApiControllerSpec extends Specification {
 			assert listParams.toMap() == new CanvasListParams(adhoc: true).toMap()
 			[]
 		}
+		1 * controller.apiService.formListResult(Canvas, [], me, _) >> []
 	}
 
 	void "index() adds state param to filter criteria"() {
@@ -155,6 +157,7 @@ class CanvasApiControllerSpec extends Specification {
 			assert listParams.toMap() == new CanvasListParams(state: Canvas.State.RUNNING).toMap()
 			[]
 		}
+		1 * controller.apiService.formListResult(Canvas, [], me, _) >> []
 	}
 
 	void "show() authorizes, reconstructs and renders the canvas as json"() {

--- a/test/unit/com/unifina/controller/api/DashboardApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/DashboardApiControllerSpec.groovy
@@ -91,6 +91,7 @@ class DashboardApiControllerSpec extends Specification {
 			assert listParams.toMap() == new DashboardListParams().toMap()
 			dashboards
 		}
+		1 * controller.apiService.formListResult(Dashboard, dashboards, me, _) >> dashboards*.toMap()
 	}
 
 	void "index() adds name param to filter criteria"() {

--- a/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
@@ -61,6 +61,12 @@ class StreamApiControllerSpec extends Specification {
 	}
 
 	void "find all streams of logged in user"() {
+		def streamOneTwoAndThree = [
+			Stream.findById(streamOneId),
+			Stream.findById(streamTwoId),
+			Stream.findById(streamThreeId)
+		]
+
 		when:
 		request.addHeader("Authorization", "Token apiKey")
 		request.method = "GET"
@@ -74,14 +80,17 @@ class StreamApiControllerSpec extends Specification {
 		1 * apiService.list(Stream, {
 			assert it.toMap() == new StreamListParams().toMap()
 			return true
-		}, user) >> [
-		    Stream.findById(streamOneId),
-			Stream.findById(streamTwoId),
-			Stream.findById(streamThreeId)
-		]
+		}, user) >> streamOneTwoAndThree
+		1 * apiService.formListResult(Stream, streamOneTwoAndThree, user, _) >> streamOneTwoAndThree*.toMap()
 	}
 
 	void "find all streams of logged in user without config"() {
+		def streamOneTwoAndThree = [
+			Stream.findById(streamOneId),
+			Stream.findById(streamTwoId),
+			Stream.findById(streamThreeId)
+		]
+
 		when:
 		request.addHeader("Authorization", "Token apiKey")
 		request.method = "GET"
@@ -97,11 +106,7 @@ class StreamApiControllerSpec extends Specification {
 		1 * apiService.list(Stream, {
 			assert it.toMap() == new StreamListParams().toMap()
 			return true
-		}, user) >> [
-			Stream.findById(streamOneId),
-			Stream.findById(streamTwoId),
-			Stream.findById(streamThreeId)
-		]
+		}, user) >> streamOneTwoAndThree
 	}
 
 	void "find streams by name of logged in user"() {
@@ -128,6 +133,7 @@ class StreamApiControllerSpec extends Specification {
 		}, user) >> [
 			Stream.findById(streamOneId)
 		]
+		1 * apiService.formListResult(Stream, [Stream.findById(streamOneId)], user, _) >> [Stream.findById(streamOneId)]*.toMap()
 	}
 
 	void "index() adds name param to filter criteria"() {
@@ -148,6 +154,7 @@ class StreamApiControllerSpec extends Specification {
 		}, user) >> [
 			Stream.findById(streamTwoId)
 		]
+		1 * apiService.formListResult(Stream, [Stream.findById(streamTwoId)], user, _) >> [Stream.findById(streamTwoId)]*.toMap()
 	}
 
 	void "creating stream fails given invalid token"() {

--- a/test/unit/com/unifina/service/SignalPathServiceSpec.groovy
+++ b/test/unit/com/unifina/service/SignalPathServiceSpec.groovy
@@ -1,6 +1,6 @@
 package com.unifina.service
 
-import com.unifina.BeanMockingSpecification
+
 import com.unifina.domain.security.Permission
 import com.unifina.domain.security.SecRole
 import com.unifina.domain.security.SecUser
@@ -14,10 +14,14 @@ import com.unifina.signalpath.SignalPathRunner
 import com.unifina.utils.Globals
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+import grails.util.Holders
+import spock.lang.Specification
+
+import java.security.AccessControlException
 
 @TestFor(SignalPathService)
 @Mock([SecUser, SecRole, SecUserSecRole, Canvas, Serialization])
-class SignalPathServiceSpec extends BeanMockingSpecification {
+class SignalPathServiceSpec extends Specification {
 
 	SecUser me
 	SecUser admin
@@ -43,8 +47,13 @@ class SignalPathServiceSpec extends BeanMockingSpecification {
 		c1.save(failOnError: true)
 		assert c1.serialization.id != null
 
-		canvasService = mockBean(CanvasService, Mock(CanvasService))
+		canvasService = Mock(CanvasService)
+		Holders.getApplicationContext().beanFactory.registerSingleton("canvasService", canvasService)
 		service.servletContext = [:]
+	}
+
+	def cleanup() {
+		Holders.getApplicationContext().beanFactory.destroySingleton("canvasService")
 	}
 
 	def "clearState() clears serialized state"() {
@@ -243,6 +252,130 @@ class SignalPathServiceSpec extends BeanMockingSpecification {
 
 		expect:
 		service.runningSignalPaths == [sp1, sp2, sp3]
+	}
+
+	void "runtimeRequest() does not allow stopping canvas if user does not have write permission on canvas"() {
+		Canvas canvas = new Canvas(runner: "runner-id")
+		canvas.id = "canvas-id"
+
+		SignalPath sp = new SignalPath()
+		sp.canvas = canvas
+
+		service.permissionService = new PermissionService()
+		service.servletContext["signalPathRunners"] = [
+			"runner-id": new SignalPathRunner(sp, new Globals(), false),
+		]
+
+		def request = new RuntimeRequest(
+			[type: "stopRequest"],
+			new SecUser(),
+			canvas,
+			"canvases/canvas-id",
+			"",
+			[] as Set
+		)
+		when:
+		service.runtimeRequest(request, true)
+		then:
+		def e = thrown(AccessControlException)
+		e.message == "stopRequest requires write permission!"
+	}
+
+	void "runtimeRequest() allows stopping canvas if user has write permission on canvas"() {
+		SecUser user = new SecUser()
+		user.save(failOnError: true, validate: false)
+
+		Canvas canvas = new Canvas(runner: "runner-id")
+		canvas.id = "canvas-id"
+
+		SignalPath sp = new SignalPath()
+		sp.canvas = canvas
+
+		boolean isAborted = false
+
+		def permissionService = service.permissionService = Mock(PermissionService)
+		service.servletContext["signalPathRunners"] = [
+			"runner-id": new SignalPathRunner(sp, new Globals(), false) {
+				@Override
+				void abort() {
+					isAborted = true
+				}
+			},
+		]
+
+		def request = new RuntimeRequest(
+			[type: "stopRequest"],
+			user,
+			canvas,
+			"canvases/canvas-id",
+			"",
+			[] as Set
+		)
+
+		when:
+		def response = service.runtimeRequest(request, true)
+
+		then:
+		noExceptionThrown()
+
+		and:
+		1 * permissionService.canWrite(user, canvas) >> true
+
+		and:
+		response == [type: "stopRequest"]
+
+		and:
+		isAborted
+	}
+
+	void "runtimeRequest() allows stopping canvas if user is admin"() {
+		SecUser user = new SecUser()
+		user.save(failOnError: true, validate: false)
+
+		SecRole adminRole = new SecRole(authority: "ROLE_ADMIN")
+		adminRole.save(failOnError: true, validate: false)
+
+		SecUserSecRole secUserSecRole = new SecUserSecRole(secUser: user, secRole: adminRole)
+		secUserSecRole.save(failOnError: true, validate: false)
+
+		Canvas canvas = new Canvas(runner: "runner-id")
+		canvas.id = "canvas-id"
+
+		SignalPath sp = new SignalPath()
+		sp.canvas = canvas
+
+		boolean isAborted = false
+
+		service.permissionService = new PermissionService()
+		service.servletContext["signalPathRunners"] = [
+			"runner-id": new SignalPathRunner(sp, new Globals(), false) {
+				@Override
+				void abort() {
+					isAborted = true
+				}
+			},
+		]
+
+		def request = new RuntimeRequest(
+			[type: "stopRequest"],
+			user,
+			canvas,
+			"canvases/canvas-id",
+			"",
+			[] as Set
+		)
+
+		when:
+		def response = service.runtimeRequest(request, true)
+
+		then:
+		noExceptionThrown()
+
+		and:
+		response == [type: "stopRequest"]
+
+		and:
+		isAborted
 	}
 
 }

--- a/web-app/misc/swagger.json
+++ b/web-app/misc/swagger.json
@@ -268,6 +268,9 @@
             "$ref": "#/parameters/publicAccess"
           },
           {
+            "$ref": "#/parameters/includePermissions"
+          },
+          {
             "name": "categories",
             "type": "string",
             "in": "query",
@@ -1375,6 +1378,9 @@
             "$ref": "#/parameters/publicAccess"
           },
           {
+            "$ref": "#/parameters/includePermissions"
+          },
+          {
             "$ref": "#/parameters/operation"
           }
         ],
@@ -2169,6 +2175,9 @@
             "$ref": "#/parameters/publicAccess"
           },
           {
+            "$ref": "#/parameters/includePermissions"
+          },
+          {
             "$ref": "#/parameters/operation"
           }
         ],
@@ -2619,6 +2628,9 @@
           },
           {
             "$ref": "#/parameters/publicAccess"
+          },
+          {
+            "$ref": "#/parameters/includePermissions"
           },
           {
             "$ref": "#/parameters/operation"
@@ -3193,6 +3205,14 @@
       "type": "boolean",
       "in": "query",
       "description": "If true, includes publicly available resources in the results.",
+      "required": false,
+      "default": false
+    },
+    "includePermissions": {
+      "name": "includePermissions",
+      "type": "boolean",
+      "in": "query",
+      "description": "If true, add permissions information into results.",
       "required": false,
       "default": false
     },


### PR DESCRIPTION
Add boolean parameter `includePermissions` to API listing endpoints. When true, returned domain objects will be associated with current user's permissions.

E.g. `GET api/v1/streams?includePermissions=true`

Response:
```
[
{
"id": "ln2g8OKHSdi7BcL-bcnh2g",
"partitions": 1,
"name": "Twitter-Bitcoin",
"description": "Bitcoin mentions on Twitter",
"uiChannel": false,
"dateCreated": "2016-05-31T18:16:00Z",
"lastUpdated": "2016-05-31T18:16:00Z",
"permissions": [ "READ", "WRITE", "SHARE"]
},
...
]
```