### PR TITLE
CORE-1550: Re-add old fix, try eager fetching

### DIFF
--- a/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
+++ b/grails-app/domain/com/unifina/domain/security/IntegrationKey.groovy
@@ -20,6 +20,7 @@ class IntegrationKey implements Serializable {
 	static mapping = {
 		id generator: IdGenerator.name // Note: doesn't apply in unit tests
 		json type: 'text'
+		user lazy: false
 		idInService(index: "id_in_service_and_service_idx")
 		service(index: "id_in_service_and_service_idx")
 	}

--- a/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
@@ -23,6 +23,11 @@ class EthereumAccountParameter extends Parameter<IntegrationKey> {
 	public IntegrationKey parseValue(String id) {
 		IntegrationKey key = (IntegrationKey) InvokerHelper.invokeStaticMethod(IntegrationKey.class, "findByIdAndService",
 				new Object[]{id, "ETHEREUM"});
+
+		// make a call to the method in order to force the initialization of object, to avoid leaking a GORM proxy object
+		// see https://streamr.atlassian.net/browse/CORE-1550
+		key.getJson();
+
 		// Ensure the IntegrationKey is not a Hibernate proxy
 		key = (IntegrationKey) GrailsHibernateUtil.unwrapIfProxy(key);
 		return key;

--- a/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
@@ -24,12 +24,15 @@ class EthereumAccountParameter extends Parameter<IntegrationKey> {
 		IntegrationKey key = (IntegrationKey) InvokerHelper.invokeStaticMethod(IntegrationKey.class, "findByIdAndService",
 				new Object[]{id, "ETHEREUM"});
 
-		// make a call to the method in order to force the initialization of object, to avoid leaking a GORM proxy object
-		// see https://streamr.atlassian.net/browse/CORE-1550
-		key.getJson();
+		if (key != null) {
+			// Ensure the IntegrationKey is not a Hibernate proxy
+			key = (IntegrationKey) GrailsHibernateUtil.unwrapIfProxy(key);
 
-		// Ensure the IntegrationKey is not a Hibernate proxy
-		key = (IntegrationKey) GrailsHibernateUtil.unwrapIfProxy(key);
+			// make a call to the method in order to force the initialization of object, to avoid leaking a GORM proxy object
+			// see https://streamr.atlassian.net/browse/CORE-1550
+			key.getJson();
+		}
+
 		return key;
 	}
 


### PR DESCRIPTION
was added in https://github.com/streamr-dev/engine-and-editor/commit/eef4def20807d3a71259d83b343cc34051a99368 but modified in https://github.com/streamr-dev/engine-and-editor/commit/88cef228c4319d5baea4ffbef9fb5a30b27db82c, now re-adding the first fix, just to see if it helps. This is an old problem with lazy loading of IntegrationKey domain object.