### PR TITLE
[CORE-1554] Javascript injection vulnerability in old Editor

### DIFF
--- a/grails-app/views/layouts/_topnav.gsp
+++ b/grails-app/views/layouts/_topnav.gsp
@@ -4,11 +4,11 @@ Tour.list(function(tourList) {
 	$('#help-tour-list').prepend(
 		tourList.map(function(item, idx) {
 			var url = Streamr.createLink(item.controller, item.action) + "?playTour=" + idx
-			return $('<li/>').append('<a/>', {
+			return $('<li/>').append($('<a/>', {
 				class: 'tour-link',
 				href: url,
-				text: 'Tour' + item.title,
-			})
+				text: 'Tour: ' + item.title,
+			}))
 		})
 	)
 })

--- a/grails-app/views/layouts/_topnav.gsp
+++ b/grails-app/views/layouts/_topnav.gsp
@@ -4,7 +4,11 @@ Tour.list(function(tourList) {
 	$('#help-tour-list').prepend(
 		tourList.map(function(item, idx) {
 			var url = Streamr.createLink(item.controller, item.action) + "?playTour=" + idx
-			return $('<li><a class="tour-link" href="'+url+'">Tour: '+item.title+'</a></li>')
+			return $('<li/>').append('<a/>', {
+				class: 'tour-link',
+				href: url,
+				text: 'Tour' + item.title,
+			})
 		})
 	)
 })

--- a/web-app/js/unifina/dashboard/dashboard-editor.js
+++ b/web-app/js/unifina/dashboard/dashboard-editor.js
@@ -93,7 +93,7 @@
 
             if (this.model.getChecked().length) {
                 this.$el.find('.howmanychecked')
-                    .html(this.model.getChecked().length)
+                    .text(this.model.getChecked().length)
             } else {
                 this.$el.find('.howmanychecked')
                     .empty()

--- a/web-app/js/unifina/module-browser/module-browser.js
+++ b/web-app/js/unifina/module-browser/module-browser.js
@@ -48,7 +48,11 @@ ModuleBrowser.prototype.renderModules = function(element,list){
 				_this.categoryName += " > "+ module.data
 			}
 			// var title = $("<h"+(level+1)+" id='"+module.metadata.id+"' style='padding-left:"+((level-1)*20)+"px;'>"+module.data+"</h"+(level+1)+">")
-			var title = $("<"+h+" id='category"+module.metadata.id+"' style='padding-left:"+((_this.level-1)*20)+"px;'>"+_this.categoryName+"</"+h+">")
+			var title = $('<' + h + '/>', {
+				id: 'category' + module.metadata.id,
+				style: 'padding-left:' + ((_this.level-1)*20) + 'px',
+				text: this.categoryName,
+			})
 			element.append(title)
 			_this.renderModules(element, module.children)
 		}

--- a/web-app/js/unifina/module-browser/module-browser.js
+++ b/web-app/js/unifina/module-browser/module-browser.js
@@ -51,7 +51,7 @@ ModuleBrowser.prototype.renderModules = function(element,list){
 			var title = $('<' + h + '/>', {
 				id: 'category' + module.metadata.id,
 				style: 'padding-left:' + ((_this.level-1)*20) + 'px',
-				text: this.categoryName,
+				text: _this.categoryName,
 			})
 			element.append(title)
 			_this.renderModules(element, module.children)

--- a/web-app/js/unifina/signalPath/core/Endpoint.js
+++ b/web-app/js/unifina/signalPath/core/Endpoint.js
@@ -10,7 +10,9 @@ SignalPath.Endpoint = function(json, parentDiv, module, type, pub) {
 	function createDiv() {
 
 		// Create connection div
-		var div = $("<div class='endpoint "+pub.type+" "+pub.json.type+"'></div>");
+		var div = $("<div/>", {
+			class: 'endpoint ' + pub.type + ' ' + pub.json.type,
+		})
 		div.data("spObject",pub);
 		pub.div = div;
 

--- a/web-app/js/unifina/signalPath/core/IOSwitch.js
+++ b/web-app/js/unifina/signalPath/core/IOSwitch.js
@@ -39,10 +39,10 @@ SignalPath.IOSwitch = function(parentContainer, clazz, options) {
 			var currentValue = pub.getValue();
 			pub.setValue(pub.nextValue(currentValue));
 			pub.update();
-			pub.div.html(pub.buttonText());
+			pub.div.text(pub.buttonText());
 		},
 		update: function() {
-			pub.div.html(pub.buttonText());
+			pub.div.text(pub.buttonText());
 			if (pub.isActiveValue(pub.getValue())) {
 				pub.div.addClass("ioSwitchTrue");
 				pub.div.removeClass("ioSwitchFalse");
@@ -52,7 +52,7 @@ SignalPath.IOSwitch = function(parentContainer, clazz, options) {
 				pub.div.addClass("ioSwitchFalse");
 			}
 			// The value may be visible elsewhere (eg. a tooltip), update that too
-			$("#"+pub.getStateTextId()).html(pub.stateText());
+			$("#"+pub.getStateTextId()).text(pub.stateText());
 
  			_setTooltipTitle(pub.stateText())
  			

--- a/web-app/js/unifina/signalPath/core/Input.js
+++ b/web-app/js/unifina/signalPath/core/Input.js
@@ -78,7 +78,7 @@ SignalPath.Input = function(json, parentDiv, module, type, pub) {
 							if (result != null) {
 								iv.setValue(result);
 								iv.update();
-								iv.div.html(iv.buttonText());
+								iv.div.text(iv.buttonText());
 							}
 						},
 						className: 'initial-value-dialog'

--- a/web-app/js/unifina/signalPath/core/Parameter.js
+++ b/web-app/js/unifina/signalPath/core/Parameter.js
@@ -117,11 +117,21 @@
 		// Show search if no value is selected
 		if(!this.data.value)
 			this.showInput()
-		var search = $("<input type='text' class='parameterInput streamSearch form-control' value='"+(this.data.streamName || "")+"'>");
+		var search = $("<input/>", {
+			type: 'text',
+			class: 'parameterInput streamSearch form-control',
+			value: this.data.streamName || '',
+		})
 		this.search = search
 		this.span.append(search);
 
-		this.label = $("<span class='streamName'><a href='#'>"+this.data.streamName+"</a></span>");
+		this.label = $('<span/>', {
+			class: 'streamName',
+		})
+			.append($('<a/>', {
+				href: '#',
+				text: this.data.streamName,
+			}))
 		this.span.append(this.label);
 
 		this.label.click(function(e) {

--- a/web-app/js/unifina/signalPath/generic/emptyModule.js
+++ b/web-app/js/unifina/signalPath/generic/emptyModule.js
@@ -42,7 +42,10 @@ SignalPath.EmptyModule = function(data, canvas, prot) {
 	function createDiv() {
 		var buttons = []
 
-		prot.div = $("<div id='"+prot.id+"' class='component module context-menu "+prot.type+"'></div>");
+		prot.div = $("<div/>", {
+			id: prot.id,
+			class: 'component module context-menu ' + prot.type,
+		})
 		prot.div.data("spObject",prot);
 		
 		// Set absolute position
@@ -54,7 +57,10 @@ SignalPath.EmptyModule = function(data, canvas, prot) {
 		
 		// Create title
 		var moduleName = prot.jsonData.displayName || prot.jsonData.name
-		prot.title = $("<span class='modulename'>" + moduleName + "</span>");
+		prot.title = $("<span/>", {
+			class: 'modulename',
+			text: moduleName,
+		})
 		prot.header.append(prot.title);
         
         // If there are options, create options editor
@@ -371,7 +377,17 @@ SignalPath.EmptyModule = function(data, canvas, prot) {
 	
 
 	function createModuleButton(additionalClasses) {
-		var button = $("<div class='modulebutton'><a class='btn btn-default btn-xs showOnFocus' href='#' style='padding: 0px'><i class='fa fa-fw "+(additionalClasses ? additionalClasses : "")+"'></span></div>");
+		var i = $('<i/>', {
+            class: 'fa fa-fw ' + additionalClasses || '',
+        })
+		var a = $('<a/>', {
+            class: 'btn btn-default btn-xs showOnFocus',
+            href: '#',
+            style: 'padding: 0px',
+        }).append(i)
+		var button = $('<div/>', {
+			class: 'modulebutton',
+		}).append(a)
 		return button;
 	}
 	prot.createModuleButton = createModuleButton;
@@ -402,7 +418,10 @@ SignalPath.EmptyModule = function(data, canvas, prot) {
 	 */
 	function createOption(key, option) {
 		var div = $("<div class='option'></div>");
-		var title = $("<span class='optionTitle'>" + key + "</span>").appendTo(div);
+		var title = $('<span/>', {
+			class: 'optionTitle',
+			text: key,
+		}).appendTo(div)
 		var value = $("<span class='optionValue'></span>").appendTo(div);
 		var input
 
@@ -670,12 +689,14 @@ $('body').contextMenu({
 		menu.data('spObject', target.data('spObject'))
 
 		var prot = menu.data('spObject');
-		var html = prot.getContextMenu(menu.data('target')).map(function(item) {
-			return '<li><a tabindex="-1" data-cmd="' +
-				item.cmd+'" href="#">' +
-				item.title+'</a></li>';
-		}).join('');
-    	menu.html(html)
+		menu.append(prot.getContextMenu(menu.data('target')).map(function(item) {
+			return $('<li/>').append($('<a/>', {
+				tabindex: '-1',
+				'data-cmd': item.cmd,
+				href: '#',
+				text: item.title,
+			}))
+        }))
     },
 
     onSelected: function(menu, item) {

--- a/web-app/js/unifina/signalPath/generic/emptyModule.js
+++ b/web-app/js/unifina/signalPath/generic/emptyModule.js
@@ -689,7 +689,7 @@ $('body').contextMenu({
 		menu.data('spObject', target.data('spObject'))
 
 		var prot = menu.data('spObject');
-		menu.append(prot.getContextMenu(menu.data('target')).map(function(item) {
+		menu.empty().append(prot.getContextMenu(menu.data('target')).map(function(item) {
 			return $('<li/>').append($('<a/>', {
 				tabindex: '-1',
 				'data-cmd': item.cmd,

--- a/web-app/js/unifina/signalPath/specific/chartInput.js
+++ b/web-app/js/unifina/signalPath/specific/chartInput.js
@@ -22,8 +22,10 @@ SignalPath.ChartInput = function(json, parentDiv, module, type, pub) {
     // Use 1-based index for display to the user
     var displayedAxis = json.yAxis + 1
     // Cycle Y-axis button
-    var $yAxisSelectorButton = $("<div class='y-axis-number btn "+btnDefaultClass+" btn-xs "+popoverClass+" popover-colorful'></div>")
-    
+    var $yAxisSelectorButton = $('<div/>', {
+        class: 'y-axis-number btn btn-xs popover-colorful ' + btnDefaultClass + ' ' + popoverClass
+    })
+
     pub.seriesIndex = null
     pub.disableContextMenu = true
     
@@ -107,8 +109,8 @@ SignalPath.ChartInput = function(json, parentDiv, module, type, pub) {
     
     function updateButton() {
         displayedAxis = json.yAxis + 1
-        $yAxisSelectorButton.html(displayedAxis)
-        $("#"+tooltipAxisId).html(displayedAxis)
+        $yAxisSelectorButton.text(displayedAxis)
+        $("#"+tooltipAxisId).text(displayedAxis)
     }
     
     function cycleYAxis() {

--- a/web-app/js/unifina/signalPath/specific/commentModule.js
+++ b/web-app/js/unifina/signalPath/specific/commentModule.js
@@ -8,8 +8,8 @@ SignalPath.CommentModule = function(data,canvas,prot) {
 		superCreateDiv();
         prot.body.addClass("drag-exclude")
 		textarea = $("<textarea class='comment'></textarea>");
-		textarea.html(prot.jsonData.text || "");
-        
+		textarea.text(prot.jsonData.text || "");
+
         prot.initResizable({
             minWidth: 100,
             minHeight: 50

--- a/web-app/js/unifina/signalPath/specific/gaugeModule.js
+++ b/web-app/js/unifina/signalPath/specific/gaugeModule.js
@@ -51,7 +51,10 @@ SignalPath.GaugeModule = function(data,canvas,prot) {
 		if (area==null || area.length==0) {
 			// Create the chart area
 			var areaId = "chartArea_"+(new Date()).getTime();
-			area = $("<div id='"+areaId+"' class='chartDrawArea'></div>");
+			area = $('<div/>', {
+				id: areaId,
+				class: 'chartDrawArea',
+			})
 			prot.body.append(area);
 			
 			resizeChart(prot.div.width(),prot.div.height());

--- a/web-app/js/unifina/signalPath/specific/solidityModule.js
+++ b/web-app/js/unifina/signalPath/specific/solidityModule.js
@@ -21,7 +21,10 @@ SignalPath.SolidityModule = function(data,canvas,prot) {
         if (!pub.getContract) { return }
 
 		if (pub.getContract() && pub.getContract().address) {
-            var $addressField = $("<input style='width:100%' value='" + pub.getContract().address +"'>")
+			var $addressField = $('<input/>', {
+				style: 'width: 100%',
+				value: pub.getContract().address,
+			})
             $addressField.on("change", function () {
                 var address = $addressField.val()
                 if (address.length === 42 && address.slice(0, 2) === "0x") {

--- a/web-app/js/unifina/stream-fields/stream-fields.js
+++ b/web-app/js/unifina/stream-fields/stream-fields.js
@@ -31,11 +31,31 @@
 		render: function() {
 			var $types = $("<select name='field_type' class='form-control input-sm'></select>")
 			$types.append(TYPES.map(function(type) {
-				return $("<option value='"+type+"'>"+type+"</option>")
+				return $('<option/>', {
+					value: type,
+					text: type,
+				})
 			}))
-			$(this.el).html('<td class="name"><input type="text" class="form-control input-sm" name="field_name" value="'+this.model.get('name')+'"></td><td class="types">'+this.model.get('type')+'</td><td><span class="btn btn-sm delete fa fa-trash-o delete-field-button"></span></td>');
+			var input = $('<input/>', {
+				type: 'text',
+				class: 'form-control input-sm',
+				name: 'field_name',
+				value: this.model.get('name'),
+			})
+			var td1 = $('<td/>', {
+                class: 'name',
+            }).append(input)
+			var span = $('<span/>', {
+				class: 'btn btn-sm delete fa fa-trash-o delete-field-button',
+			})
+			var td2 = $('<td/>', {
+			    class: 'types',
+            }).append(span)
+			$(this.el).empty()
+				.append(td1)
+				.append(td2)
 			$types.val(this.model.get('type'))
-			$(this.el).find("td.types").html($types)
+			$(this.el).find("td.types").empty().append($types)
 			return this; // for chainable calls, like .render().el
 		},
 		update: function() {

--- a/web-app/js/unifina/streamr-chart/streamr-chart.js
+++ b/web-app/js/unifina/streamr-chart/streamr-chart.js
@@ -70,7 +70,10 @@ function StreamrChart(parent, options) {
 		]
 
 		rangeConfig.forEach(function(c) {
-			var $option =  $("<option value='"+c.range+"'>"+c.name+"</option>")
+			var $option =  $('<option/>', {
+				value: c.range,
+				text: c.name,
+			})
             $rangeSelect.append($option)
 		})
 

--- a/web-app/js/unifina/streamr-switcher/streamr-switcher.js
+++ b/web-app/js/unifina/streamr-switcher/streamr-switcher.js
@@ -70,7 +70,27 @@
 		if ($el.is('input[type="checkbox"]')) {
 			box_class = $el.attr('data-class');
 			this.$checkbox = $el;
-			this.$box = $('<div class="switcher"><div class="switcher-toggler"></div><div class="switcher-inner"><div class="switcher-state-on">' + this.options.on_state_content + '</div><div class="switcher-state-off">' + this.options.off_state_content + '</div></div></div>');
+			var $switcherToggler = $('<div/>', {
+                class: 'switcher-toggler',
+            })
+			var $switcherStateOn = $('<div/>', {
+				class: 'switcher-state-on',
+				text: this.options.on_state_content,
+			})
+			var $switcherStateOff = $('<div/>', {
+				class: 'switcher-state-off',
+				text: this.options.off_state_content,
+			})
+			var $switcherInner = $('<div/>', {
+				class: 'switcher-inner',
+			})
+				.append($switcherStateOn)
+				.append($switcherStateOff)
+			this.$box = $('<div/>', {
+				class: 'switcher',
+			})
+				.append($switcherToggler)
+				.append($switcherInner)
 			if (this.options.theme) {
 				this.$box.addClass('switcher-theme-' + this.options.theme);
 			}

--- a/web-app/js/unifina/streamr-table/streamr-table.js
+++ b/web-app/js/unifina/streamr-table/streamr-table.js
@@ -64,12 +64,15 @@ StreamrTable.prototype.setHeaders = function(headers) {
 
 StreamrTable.prototype.addRow = function (row, rowId, op) {
 	if (op != "append") { op = "prepend" }
-	var rowIdString = (rowId != null) ? " id='" + rowId + "'" : "";
-	var newRow = $("<tr"+ rowIdString +"></tr>");
+	var newRow = $('<tr/>', {
+        id: rowId != null ? rowId : '',
+	});
 	for (var i = 0; i < row.length; i++) {
 		var content = row[i] == null ? "" :
 					  row[i] instanceof Object ? JSON.stringify(row[i]) : row[i];
-		newRow.append("<td>" + content + "</td>");
+		newRow.append('<td/>', {
+			text: content,
+		});
 	}
 	this.tableBody[op](newRow);
 }

--- a/web-app/js/unifina/streamr-table/streamr-table.js
+++ b/web-app/js/unifina/streamr-table/streamr-table.js
@@ -70,9 +70,9 @@ StreamrTable.prototype.addRow = function (row, rowId, op) {
 	for (var i = 0; i < row.length; i++) {
 		var content = row[i] == null ? "" :
 					  row[i] instanceof Object ? JSON.stringify(row[i]) : row[i];
-		newRow.append('<td/>', {
+		newRow.append($('<td/>', {
 			text: content,
-		});
+		}));
 	}
 	this.tableBody[op](newRow);
 }


### PR DESCRIPTION
- Changed `$(elementAsHtml)` to `$(tagName, attributes)` where necessary (basically where there was any variable injections. Example:
```
// old
var element = $("<div attr1="foo"><a attr2="bar">" + content + "</a></div>")

// new
var a = $('<a/>', {
  attr2: 'bar',
  text: content, // attribute text is escaped by jQuery
})
var element = $('<div/>', {
  attr1: 'foo',
}).append(a)
```
- Change occurences of `$el.html(text)` to `$el.text(text)` (`.text()` escapes the content) where `.html()` cleary was not needed
- Change occurences of `$el.html(jQueryElement)` to `$el.empty().append(jQueryElement)`

I went through the features with changed code but would also appreciate if someone else tried them as well:) (eg. `.append('<div/>', { ... })` instead of `.append($('<div/>', { ... })` ignores the second parameter totally and appends an empty element)