### PR TITLE
profile/update endpoint can't update username anymore

### DIFF
--- a/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
+++ b/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
@@ -20,8 +20,7 @@ class ProfileController {
 	static defaultAction = "edit"
 
 	static allowedMethods = [
-		update: "POST",
-		regenerateApiKey: "POST"
+		update: "POST"
 	]
 
 	def edit() {
@@ -43,28 +42,6 @@ class ProfileController {
 		} else {
 			return render(user.toMap() as JSON)
 		}
-	}
-
-	def regenerateApiKey() {
-		SecUser user = SecUser.get(springSecurityService.currentUser.id)
-		List<Key> oldKeys = Key.findAllByUser(user)
-
-		// Revoke old keys
-		Stream revokeNotificationStream = new Stream()
-		revokeNotificationStream.id = grailsApplication.config.streamr.apiKey.revokeNotificationStream
-		for (Key oldKey : oldKeys) {
-			oldKey.delete()
-			streamService.sendMessage(revokeNotificationStream, [
-				action: "revoked",
-				user: user.id,
-				key: oldKey.id
-			], 60)
-		}
-
-		new Key(name: 'Key for ' + user.username, user: user).save(validate: true, failOnError: true, flush: true)
-		log.info("User $user.username regenerated api key!")
-
-		render ([success: true] as JSON)
 	}
 
 	def changePwd(ChangePasswordCommand cmd) {

--- a/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
+++ b/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
@@ -19,6 +19,11 @@ class ProfileController {
 
 	static defaultAction = "edit"
 
+	static allowedMethods = [
+		update: "POST",
+		regenerateApiKey: "POST"
+	]
+
 	def edit() {
 		def currentUser = SecUser.get(springSecurityService.currentUser.id)
 		[user: currentUser]

--- a/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
+++ b/grails-app/controllers/com/unifina/controller/security/ProfileController.groovy
@@ -16,18 +16,20 @@ class ProfileController {
 	def userService
 	def permissionService
 	def streamService
-	
+
 	static defaultAction = "edit"
 
 	def edit() {
 		def currentUser = SecUser.get(springSecurityService.currentUser.id)
 		[user: currentUser]
 	}
-	
+
 	def update() {
 		SecUser user = SecUser.get(springSecurityService.currentUser.id)
-		user.properties = params
-		user.name = params.name // for some reason not updated by above row
+
+		// Only these user fields can be updated!
+		user.name = params.name ?: user.name
+		user.timezone = params.timezone ?: user.timezone
 
 		user = user.save(failOnError: true)
 		if (user.hasErrors()) {
@@ -59,7 +61,7 @@ class ProfileController {
 
 		render ([success: true] as JSON)
 	}
-	
+
 	def changePwd(ChangePasswordCommand cmd) {
 		def user = SecUser.get(springSecurityService.currentUser.id)
 		if (request.method == 'GET') {
@@ -73,24 +75,24 @@ class ProfileController {
 			else {
 				user.password = springSecurityService.encodePassword(cmd.password)
 				user.save(flush:true, failOnError:true)
-				
+
 				springSecurityService.reauthenticate user.username
-				
+
 				log.info("User $user.username changed password!")
-				
+
 				flash.message = "Password changed!"
 				redirect(action:"edit")
 			}
 		}
 	}
-	
+
 }
 
 class ChangePasswordCommand {
-	
+
 	def springSecurityService
 	def userService
-	
+
 	String currentpassword
 	String password
 	String password2

--- a/grails-app/views/profile/edit.gsp
+++ b/grails-app/views/profile/edit.gsp
@@ -24,23 +24,6 @@
 		</div>
 	</div>
 
-	<r:script>
-		$(function() {
-			new ConfirmButton("#regenerateApiKeyButton", {
-				title: "${message(code: "profile.regenerateAPIKeyConfirm.title")}",
-				message: "${message(code: "profile.regenerateAPIKeyConfirm.message")}"
-			}, function(result) {
-				if(result) {
-					$.post("${ createLink(action: 'regenerateApiKey') }", {}, function(response) {
-						if(response.success) {
-							location.reload()
-						}
-					})
-				}
-			})
-		})
-	</r:script>
-
 	<webpack:jsBundle name="commons"/>
 	<webpack:jsBundle name="profilePage"/>
 

--- a/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
@@ -14,7 +14,7 @@ class ProfileControllerSpec extends Specification {
 
 	SecUser user
 	String reauthenticated = null
-	
+
 	def springSecurityService = [
 		encodePassword: { pw ->
 			return pw+"-encoded"
@@ -32,14 +32,15 @@ class ProfileControllerSpec extends Specification {
 	void setup() {
 		controller.springSecurityService = springSecurityService
 		controller.streamService = Mock(StreamService)
-		user = new SecUser(id:1, 
-			username:"test@test.com",
+		user = new SecUser(id:1,
+			username: "test@test.com",
 			name: "Test User",
-			password:springSecurityService.encodePassword("foobar123!"), 
-			timezone: "Europe/Helsinki")
+			password:springSecurityService.encodePassword("foobar123!"),
+			timezone: "Europe/Helsinki",
+			enabled: true)
 		user.save(validate:false)
 		springSecurityService.currentUser = user
-		
+
 		assert SecUser.count()==1
 	}
 
@@ -59,7 +60,7 @@ class ProfileControllerSpec extends Specification {
 			response.redirectedUrl == '/profile/edit'
 			flash.message.contains("changed")
 	}
-	
+
 	void "submitting an invalid current password won't let the password be changed"() {
 		when: "password change form is submitted with invalid password"
 			def cmd = new ChangePasswordCommand(currentpassword: "invalid", password: 'barbar123!', password2: 'barbar123!')
@@ -75,7 +76,7 @@ class ProfileControllerSpec extends Specification {
 			flash.error != null
 			view == '/profile/changePwd'
 	}
-	
+
 	void "submitting a too short new password won't let the password be changed"() {
 		when: "password change form is submitted with invalid new password"
 			def cmd = new ChangePasswordCommand(currentpassword: "foobar", password: 'asd', password2: 'asd', pwdStrength: 0)
@@ -91,7 +92,7 @@ class ProfileControllerSpec extends Specification {
 			flash.error != null
 			view == '/profile/changePwd'
 	}
-	
+
 	void "submitting a too weak new password won't let the password be changed"() {
 		when: "password change form is submitted with invalid new password"
 			def cmd = new ChangePasswordCommand(currentpassword: "foobar123", password: 'asd', password2: 'asd', pwdStrength: 0)
@@ -120,6 +121,20 @@ class ProfileControllerSpec extends Specification {
 			response.json.name == "Changed Name"
 			SecUser.get(1).timezone == "Europe/Helsinki"
 			response.json.timezone == "Europe/Helsinki"
+	}
+
+	void "sensitive fields cannot be changed"() {
+		controller.userService = new UserService()
+		controller.userService.grailsApplication = grailsApplication
+		when:
+		params.username = "attacker@email.com"
+		params.enabled = false
+		controller.update()
+
+		then:
+		SecUser.get(1).username == "test@test.com"
+		response.json.username == "test@test.com"
+		SecUser.get(1).enabled
 	}
 
 	void "regenerating api key removes old user-linked keys"() {
@@ -165,5 +180,5 @@ class ProfileControllerSpec extends Specification {
 				key: keyId
 		], _)
 	}
-	
+
 }

--- a/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
@@ -137,48 +137,4 @@ class ProfileControllerSpec extends Specification {
 		SecUser.get(1).enabled
 	}
 
-	void "regenerating api key removes old user-linked keys"() {
-		setup:
-		Key key = new Key(name: "key", user: user).save(failOnError: true, validate: true)
-		String keyId = key.id
-
-		when:
-		request.method = "POST"
-		controller.regenerateApiKey()
-
-		then:
-		Key.get(keyId) == null
-	}
-
-	void "regenerating api key creates a new user-linked key"() {
-		setup:
-		Key key = new Key(name: "key", user: user).save(failOnError: true, validate: true)
-		String keyId = key.id
-
-		when:
-		request.method = "POST"
-		controller.regenerateApiKey()
-
-		then:
-		Key.findByUser(user) != null
-		Key.findByUser(user).id != keyId
-	}
-
-	void "regenerating the api key sends message to Kafka"() {
-		setup:
-		Key key = new Key(name: "key", user: user).save(failOnError: true, validate: true)
-		String keyId = key.id
-
-		when:
-		request.method = "POST"
-		controller.regenerateApiKey()
-
-		then:
-		1 * controller.streamService.sendMessage(_, [
-				action: "revoked",
-				user: 1,
-				key: keyId
-		], _)
-	}
-
 }

--- a/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/security/ProfileControllerSpec.groovy
@@ -113,6 +113,7 @@ class ProfileControllerSpec extends Specification {
 		controller.userService = new UserService()
 		controller.userService.grailsApplication = grailsApplication
 		when: "new settings are submitted"
+			request.method = 'POST'
 			params.name = "Changed Name"
 			params.timezone = "Europe/Helsinki"
 			controller.update()
@@ -126,7 +127,9 @@ class ProfileControllerSpec extends Specification {
 	void "sensitive fields cannot be changed"() {
 		controller.userService = new UserService()
 		controller.userService.grailsApplication = grailsApplication
+
 		when:
+		request.method = 'POST'
 		params.username = "attacker@email.com"
 		params.enabled = false
 		controller.update()


### PR DESCRIPTION
A security researcher discovered a bug in the old `ProfileController#update` action, which allowed the username to be changed. This bug combined with CSRF vulnerability enables an attacker to take over accounts by tricking a user into a malicious site while they are logged in, and then making a request to the faulty endpoint.

- This update only fixes the bug in the endpoint. The app still remains vulnerable to CSRF attacks in general (no other ways to exploit it with critical consequences are currently known).
- The new single-page app, once released, will use token-based sessions instead of cookie-based sessions. That will be the ultimate fix to CSRF. Probably not worth it to ship a full CSRF fix to the old app anymore.