### PR TITLE
[CORE-1564] - Request Metamask Account Permission (profile settings page)

### DIFF
--- a/web-app/react-app/components/ProfilePage/IdentityHandler/index.jsx
+++ b/web-app/react-app/components/ProfilePage/IdentityHandler/index.jsx
@@ -53,21 +53,23 @@ export class IdentityHandler extends Component<Props, State> {
         this.props.deleteIntegrationKey(id)
     }
 
-    requestMetamaskAccess = (askPermission: boolean = false) => {
+    requestMetamaskAccess(askPermission: boolean = false): Promise<void> {
         // Checks for legacy access. Asks to unlock if possible.
-        Promise.resolve(window.web3 || window.ethereum)
+        return Promise.resolve()
             .then(() => {
+                if (!window.web3 && !window.ethereum) {
+                    throw new Error('Metamask not detected')
+                }
                 return window.web3.eth.defaultAccount || (askPermission ? window.ethereum.enable() : undefined)
             })
             .then((account) => {
-                if (typeof account !== 'undefined') {
+                if (account) {
                     this.setState({
                         hasWeb3: true,
                     })
                 }
-            })
-            .catch(() => {
-                // no web3 or ethereum
+            }, (err) => {
+                console.warn(err)
                 this.setState({
                     hasWeb3: false,
                 })

--- a/web-app/react-app/tests/utils/web3Provider.test.js
+++ b/web-app/react-app/tests/utils/web3Provider.test.js
@@ -53,17 +53,28 @@ describe('web3Provider', () => {
         })
     })
     describe('getWeb3', () => {
+        let oldGlobalWeb3
+        let oldGlobalEthereum
+
         beforeEach(() => {
+            oldGlobalWeb3 = global.web3
+            oldGlobalEthereum = global.ethereum
             global.web3 = undefined
             global.ethereum = undefined
         })
+
+        afterEach(() => {
+            global.web3 = oldGlobalWeb3
+            global.ethereum = oldGlobalEthereum
+        })
+
         it('must return the web3 object without a provider when metamask does not provide it', () => {
             const web3 = getWeb3()
             expect(web3.currentProvider).toEqual(null)
         })
         it('must return the web3 object with the window.web3.currentProvider provider if it is available/defined', () => {
             // 'legacy' metamask web3 injection scenario
-            global.web3 = Web3
+            global.web3 = new Web3()
             global.web3.currentProvider = new StreamrWeb3.providers.HttpProvider('http://boop:1337')
             const web3 = getWeb3()
             assert.equal(web3.currentProvider.host, 'http://boop:1337')

--- a/web-app/react-app/tests/utils/web3Provider.test.js
+++ b/web-app/react-app/tests/utils/web3Provider.test.js
@@ -53,8 +53,26 @@ describe('web3Provider', () => {
         })
     })
     describe('getWeb3', () => {
-        it('must return the same instance every time', () => {
-            assert(getWeb3() === getWeb3())
+        beforeEach(() => {
+            global.web3 = undefined
+            global.ethereum = undefined
+        })
+        it('must return the web3 object without a provider when metamask does not provide it', () => {
+            const web3 = getWeb3()
+            expect(web3.currentProvider).toEqual(null)
+        })
+        it('must return the web3 object with the window.web3.currentProvider provider if it is available/defined', () => {
+            // 'legacy' metamask web3 injection scenario
+            global.web3 = Web3
+            global.web3.currentProvider = new StreamrWeb3.providers.HttpProvider('http://boop:1337')
+            const web3 = getWeb3()
+            assert.equal(web3.currentProvider.host, 'http://boop:1337')
+        })
+        it('must return the web3 object with the window.ethereum provider if it is available/defined', () => {
+            // permissioned metamask provider injection scenario
+            global.ethereum = new StreamrWeb3.providers.HttpProvider('http://vitalik:300')
+            const web3 = getWeb3()
+            assert.equal(web3.currentProvider.host, 'http://vitalik:300')
         })
     })
 })

--- a/web-app/react-app/utils/web3Provider.js
+++ b/web-app/react-app/utils/web3Provider.js
@@ -3,6 +3,7 @@
 import Web3 from 'web3'
 
 declare var web3: Web3
+declare var ethereum: Web3
 
 export class StreamrWeb3 extends Web3 {
     getDefaultAccount = (): Promise<string> => new Promise((resolve, reject) => {
@@ -15,8 +16,20 @@ export class StreamrWeb3 extends Web3 {
     isEnabled = (): boolean => !!this.currentProvider
 }
 
-const sharedWeb3 = new StreamrWeb3(typeof web3 !== 'undefined' && web3.currentProvider)
+export const getWeb3 = (): StreamrWeb3 => {
+    if (typeof ethereum !== 'undefined') {
+        return new StreamrWeb3(ethereum)
+    } else if (typeof web3 !== 'undefined') {
+        return new StreamrWeb3(web3.currentProvider)
+    }
+    return new StreamrWeb3(false)
+}
 
-export const getWeb3 = (): StreamrWeb3 => sharedWeb3
+export const requestMetamaskPermission = () => {
+    window.postMessage({
+        type: 'ETHEREUM_PROVIDER_REQUEST',
+    }, '*')
+}
 
 export default getWeb3
+

--- a/web-app/react-app/utils/web3Provider.js
+++ b/web-app/react-app/utils/web3Provider.js
@@ -25,11 +25,4 @@ export const getWeb3 = (): StreamrWeb3 => {
     return new StreamrWeb3(false)
 }
 
-export const requestMetamaskPermission = () => {
-    window.postMessage({
-        type: 'ETHEREUM_PROVIDER_REQUEST',
-    }, '*')
-}
-
 export default getWeb3
-


### PR DESCRIPTION
Requesting permission to read the account information from the Metamask Provider, to be compliant with the upcoming breaking change coming from the Metamask extension. Since this will be washed away in the coming weeks with the new userpages, not much time was spent on the UX.

Affects: Profile Page Settings

Behaviour: 
New Metamask client:
<img width="571" alt="screen shot 2018-10-30 at 20 36 47" src="https://user-images.githubusercontent.com/1593398/47741763-c5abd780-dc83-11e8-95bd-137c463341c1.png">

<img width="406" alt="screen shot 2018-10-30 at 20 39 37" src="https://user-images.githubusercontent.com/1593398/47741843-fbe95700-dc83-11e8-9108-fb5e73943ecf.png">

Old Metamask behaviour:
No change

https://github.com/MetaMask/metamask-extension/pull/4703
https://eips.ethereum.org/EIPS/eip-1102