### PR TITLE
CORE-1591: admin-only user creation API endpoint

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -57,6 +57,7 @@ class UrlMappings {
 		"/api/v1/modules"(resources: "moduleApi")
 		"/api/v1/modules/$id/help"(controller: "moduleApi", action: "help")
 
+		"/api/v1/users"(resources: "userApi")
 		"/api/v1/users/me"(controller: "userApi", action: "getUserInfo")
 		"/api/v1/users/me/keys"(resources: "keyApi", excludes: ["create", "edit", "update"]) { resourceClass = SecUser }
 		"/api/v1/users/me/products"(controller: "productApi", action: "index") { operation = Permission.Operation.SHARE }

--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -11,6 +11,7 @@ import com.unifina.api.InvalidStateException
 import com.unifina.api.InvalidUsernameAndPasswordException
 import com.unifina.api.ValidationException
 import com.unifina.exceptions.CanvasUnreachableException
+import com.unifina.exceptions.UserCreationFailedException
 import com.unifina.security.AuthLevel
 import com.unifina.security.StreamrApi
 import grails.converters.JSON
@@ -27,7 +28,8 @@ class ErrorController {
 		InvalidSessionTokenException: { InvalidSessionTokenException e -> new ApiError(400, "INVALID_SESSION_TOKEN_ERROR", e.message)},
 		ChallengeVerificationFailedException: { ChallengeVerificationFailedException e -> new ApiError(400, "CHALLENGE_VERIFICATION_FAILED_ERROR", e.message)},
 		InvalidUsernameAndPasswordException: { InvalidUsernameAndPasswordException e -> new ApiError(400, "INVALID_USERNAME_PASSWORD_ERROR", e.message)},
-		InvalidAPIKeyException: { InvalidAPIKeyException e -> new ApiError(400, "INVALID_API_KEY_ERROR", e.message)}
+		InvalidAPIKeyException: { InvalidAPIKeyException e -> new ApiError(400, "INVALID_API_KEY_ERROR", e.message)},
+		UserCreationFailedException: { UserCreationFailedException e -> new ApiError(422, "FAILED_TO_CREATE_USER", e.message)}
 	]
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)

--- a/grails-app/controllers/com/unifina/controller/api/UserApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/UserApiController.groovy
@@ -1,14 +1,32 @@
 package com.unifina.controller.api
 
+import com.unifina.api.CreateUserCommand
+import com.unifina.api.ValidationException
+import com.unifina.domain.security.SecUser
+import com.unifina.security.AllowRole
 import com.unifina.security.StreamrApi
+import com.unifina.service.UserService
+import grails.compiler.GrailsCompileStatic
 import grails.converters.JSON
 import grails.plugin.springsecurity.annotation.Secured
 
 @Secured(["IS_AUTHENTICATED_ANONYMOUSLY"])
 class UserApiController {
 
+	UserService userService
+
 	@StreamrApi
 	def getUserInfo() {
 		render(request.apiUser?.toMap() as JSON)
+	}
+
+	@GrailsCompileStatic
+	@StreamrApi(allowRoles = AllowRole.ADMIN)
+	def save(CreateUserCommand createUserCommand) {
+		if (!createUserCommand.validate()) {
+			throw new ValidationException(createUserCommand.errors)
+		}
+		SecUser user = (SecUser) userService.createUser(createUserCommand.properties)
+		render(user.toMap() as JSON)
 	}
 }

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -279,6 +279,18 @@ class Permissions {
     }
 }
 
+class Users {
+    constructor(options) {
+        this.options = options
+    }
+
+    create(body) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('POST', 'users')
+            .withBody(body)
+    }
+}
+
 module.exports = (baseUrl, logging) => {
     const options = {
         baseUrl,
@@ -293,7 +305,8 @@ module.exports = (baseUrl, logging) => {
                 login: new Login(options),
                 products: new Products(options),
                 streams: new Streams(options),
-                subscriptions: new Subscriptions(options)
+                subscriptions: new Subscriptions(options),
+                users: new Users(options)
             }
         }
     }

--- a/rest-e2e-tests/users-api.test.js
+++ b/rest-e2e-tests/users-api.test.js
@@ -1,0 +1,80 @@
+const assert = require('chai').assert
+const initStreamrApi = require('./streamr-api-clients')
+const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
+
+const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const LOGGING_ENABLED = false
+
+const ADMIN_USER_TOKEN = 'tester-admin-api-key'
+const USER_TOKEN = 'tester1-api-key'
+
+const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
+
+const timestamp = Date.now()
+
+describe('Users API', () => {
+    describe('POST /api/v1/users', () => {
+        it('requires authentication', async () => {
+            const response = await Streamr.api.v1.users
+                .create({
+                    username: `users-api-test-${timestamp}@streamr.com`,
+                    password: 'password',
+                    name: 'Users API Test',
+                })
+                .call()
+
+            await assertResponseIsError(response, 401, 'NOT_AUTHENTICATED')
+        })
+
+        it('checks user permission level', async () => {
+            const response = await Streamr.api.v1.users
+                .create({
+                    username: `users-api-test-${timestamp}@streamr.com`,
+                    password: 'password',
+                    name: 'Users API Test',
+                })
+                .withAuthToken(USER_TOKEN)
+                .call()
+
+            await assertResponseIsError(response, 403, 'NOT_PERMITTED')
+        })
+
+        it('validates body', async () => {
+            const response = await Streamr.api.v1.users
+                .create({})
+                .withAuthToken(ADMIN_USER_TOKEN)
+                .call()
+
+            await assertResponseIsError(response, 422, 'VALIDATION_ERROR')
+        })
+
+        context('when called with valid body and headers', () => {
+            let response
+            let json
+
+            before(async () => {
+                response = await Streamr.api.v1.users
+                    .create({
+                        username: `users-api-test-${timestamp}@streamr.com`,
+                        password: 'password',
+                        name: 'Users API Test',
+                    })
+                    .withAuthToken(ADMIN_USER_TOKEN)
+                    .call()
+                json = await response.json()
+            })
+
+            it('responds with 200', () => {
+                assert.equal(response.status, 200)
+            })
+
+            it('responds with User', () => {
+                assert.deepEqual(json, {
+                    username: `users-api-test-${timestamp}@streamr.com`,
+                    name: 'Users API Test',
+                    timezone: 'UTC'
+                })
+            })
+        })
+    })
+})

--- a/src/groovy/com/unifina/api/CreateUserCommand.groovy
+++ b/src/groovy/com/unifina/api/CreateUserCommand.groovy
@@ -1,0 +1,19 @@
+package com.unifina.api
+
+import com.unifina.utils.UsernameValidator
+import grails.validation.Validateable
+
+@Validateable
+class CreateUserCommand {
+	String username
+	String password
+	String name
+	String timezone = "UTC"
+
+	static constraints = {
+		username(blank: false, validator: UsernameValidator.validate)
+		password(blank: false)
+		name(blank: false)
+		timezone(nullable: true)
+	}
+}


### PR DESCRIPTION
Admin-only API endpoint for creating users. Handy for creating isolated user environments for well encapsulated integration tests. POST `/api/v1/users` with body
```
username: "something@something.com",
password: "password",
name: "Full Name",
timezone: "UTC" [optional]
```