### PR TITLE
Fix message parsing regression in master

### DIFF
--- a/src/java/com/unifina/feed/redis/MultipleRedisMessageSource.java
+++ b/src/java/com/unifina/feed/redis/MultipleRedisMessageSource.java
@@ -1,5 +1,6 @@
 package com.unifina.feed.redis;
 
+import com.unifina.data.StreamrBinaryMessage;
 import com.unifina.domain.data.Feed;
 import com.unifina.feed.AbstractMessageSource;
 import com.unifina.feed.MessageRecipient;
@@ -16,7 +17,7 @@ import java.util.*;
  * All the RedisMessageSources forward their received messages to the same recipient: the one
  * set on the MultipleRedisMessageSource instance.
  */
-public class MultipleRedisMessageSource extends AbstractMessageSource<StreamrBinaryMessageWithKafkaMetadata, String> {
+public class MultipleRedisMessageSource extends AbstractMessageSource<StreamrBinaryMessage, String> {
 	private final Map<String, RedisMessageSource> messageSourceByHost = new HashMap<>();
 
 	public MultipleRedisMessageSource(Feed feed, Map<String, Object> config) {
@@ -68,7 +69,7 @@ public class MultipleRedisMessageSource extends AbstractMessageSource<StreamrBin
 	}
 
 	@Override
-	public void setRecipient(MessageRecipient<StreamrBinaryMessageWithKafkaMetadata, String> recipient) {
+	public void setRecipient(MessageRecipient<StreamrBinaryMessage, String> recipient) {
 		super.setRecipient(recipient);
 		for (RedisMessageSource ms : messageSourceByHost.values()) {
 			ms.setRecipient(recipient);

--- a/src/java/com/unifina/feed/redis/RedisMessageSource.java
+++ b/src/java/com/unifina/feed/redis/RedisMessageSource.java
@@ -5,6 +5,7 @@ import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.codec.ByteArrayCodec;
 import com.lambdaworks.redis.pubsub.RedisPubSubAdapter;
 import com.lambdaworks.redis.pubsub.RedisPubSubConnection;
+import com.unifina.data.StreamrBinaryMessage;
 import com.unifina.domain.data.Feed;
 import com.unifina.feed.AbstractMessageSource;
 import com.unifina.feed.Message;
@@ -15,7 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Map;
 
-public class RedisMessageSource extends AbstractMessageSource<StreamrBinaryMessageWithKafkaMetadata, String> {
+public class RedisMessageSource extends AbstractMessageSource<StreamrBinaryMessage, String> {
 
 	private static final Charset utf8 = Charset.forName("UTF-8");
 
@@ -46,7 +47,7 @@ public class RedisMessageSource extends AbstractMessageSource<StreamrBinaryMessa
 			public void message(byte[] channel, byte[] messageBytes) {
 				String streamId = new String(channel, utf8);
 				StreamrBinaryMessageWithKafkaMetadata msg = new StreamrBinaryMessageWithKafkaMetadata(ByteBuffer.wrap(messageBytes));
-				forward(new Message<>(streamId, msg.getOffset(), msg, false));
+				forward(new Message<>(streamId, msg.getOffset(), msg.getStreamrBinaryMessage(), false));
 			}
 
 			@Override

--- a/test/integration/com/unifina/service/RunCanvasSpec.groovy
+++ b/test/integration/com/unifina/service/RunCanvasSpec.groovy
@@ -5,12 +5,14 @@ import com.unifina.domain.security.SecUser
 import com.unifina.domain.signalpath.Canvas
 import com.unifina.feed.FeedFactory
 import grails.test.spock.IntegrationSpec
+import spock.lang.Ignore
 import spock.lang.Unroll
 import spock.util.concurrent.PollingConditions
 
 /**
  * Verifies that Canvases can be created, run, fed data through StreamService, and that the fed data be processed.
  */
+@Ignore
 class RunCanvasSpec extends IntegrationSpec {
 
 	def static final SUM_FROM_1_TO_100_TIMES_2 = "10100.0"

--- a/test/integration/com/unifina/service/RunCanvasSpec.groovy
+++ b/test/integration/com/unifina/service/RunCanvasSpec.groovy
@@ -5,14 +5,12 @@ import com.unifina.domain.security.SecUser
 import com.unifina.domain.signalpath.Canvas
 import com.unifina.feed.FeedFactory
 import grails.test.spock.IntegrationSpec
-import spock.lang.Ignore
 import spock.lang.Unroll
 import spock.util.concurrent.PollingConditions
 
 /**
  * Verifies that Canvases can be created, run, fed data through StreamService, and that the fed data be processed.
  */
-@Ignore
 class RunCanvasSpec extends IntegrationSpec {
 
 	def static final SUM_FROM_1_TO_100_TIMES_2 = "10100.0"


### PR DESCRIPTION
**Why it broke**

After some binary protocol refactoring in #528, `StreamrBinaryMessageWithKafkaMetadata` is no longer a subclass of `StreamrBinaryMessage`, but instead the former contains the latter.

`StreamrBinaryMessageParser` expects `StreamrBinaryMessage`s as input - a condition previously fulfilled by both `StreamrBinaryMessageWithKafkaMetadata` and `StreamrBinaryMessage` due to inheritance, but after the refactor the class would not accept `StreamrBinaryMessageWithKafkaMetadata` anymore, failing only at runtime due to some generics at play.

**Why it wasn't caught by tests**

Integration test `RunCanvasSpec` tests that the overall message pipeline is working, but for some reason it was `@Ignore`d in [this commit](https://github.com/streamr-dev/engine-and-editor/commit/34a11beb4ef3de7c1a6e9e414eff807a3abb72b2), meaning that it is not being run.

**What's the fix**

- Refactored `RedisMessageSource` and related components to output `StreamrBinaryMessage`s instead of `StreamrBinaryMessageWithKafkaMetadata`. 
- Re-enabled `RunCanvasSpec` in a separate PR #540, pending fixes to CI issues.