### PR TITLE
WIP: Fix RunCanvasSpec

### DIFF
--- a/grails-app/services/com/unifina/service/NodeService.groovy
+++ b/grails-app/services/com/unifina/service/NodeService.groovy
@@ -34,7 +34,7 @@ class NodeService {
 			if (addresses.size() == 1) {
 				cachedIp = addresses[0].hostAddress
 			} else if (addresses.size() > 1) {
-				log.warn("Multiple IPs found: ${addresses*.hostAddress}. To select which address to use, please set the streamr.node.ip system property.")
+				log.warn("Multiple IPs found: ${addresses*.hostAddress}. By default the first one will be used. To select another aaddress, please set the streamr.node.ip system property.")
 				cachedIp = addresses[0].hostAddress
 			} else {
 				// Fallback to localhost
@@ -43,6 +43,7 @@ class NodeService {
 			}
 		}
 
+		log.info("Using IP address: " + cachedIp)
 		return cachedIp
 	}
 

--- a/grails-app/services/com/unifina/service/SignalPathService.groovy
+++ b/grails-app/services/com/unifina/service/SignalPathService.groovy
@@ -121,7 +121,6 @@ class SignalPathService {
 		runner.addStartListener(new IStartListener() {
 			@Override
 			void onStart() {
-				log.info("Start listener called for runner ${runner.runnerId}")
 				addRunner(runner)
 			}
 		})
@@ -129,7 +128,6 @@ class SignalPathService {
 		runner.addStopListener(new IStopListener() {
 			@Override
 			void onStop() {
-				log.info("Stop listener called for runner ${runner.runnerId}")
 				removeRunner(runner)
 			}
 		})

--- a/grails-app/services/com/unifina/service/SignalPathService.groovy
+++ b/grails-app/services/com/unifina/service/SignalPathService.groovy
@@ -121,6 +121,7 @@ class SignalPathService {
 		runner.addStartListener(new IStartListener() {
 			@Override
 			void onStart() {
+				log.info("Start listener called for runner ${runner.runnerId}")
 				addRunner(runner)
 			}
 		})
@@ -128,6 +129,7 @@ class SignalPathService {
 		runner.addStopListener(new IStopListener() {
 			@Override
 			void onStop() {
+				log.info("Stop listener called for runner ${runner.runnerId}")
 				removeRunner(runner)
 			}
 		})

--- a/src/java/com/unifina/datasource/DataSource.java
+++ b/src/java/com/unifina/datasource/DataSource.java
@@ -14,7 +14,7 @@ import java.util.*;
 
 /**
  * DataSource is a class global to the current run context. It handles
- * the creation of data feeds either explicitly (via DataSource#connectFeed(feed)) 
+ * the creation of data feeds either explicitly (via DataSource#connectFeed(feed))
  * or implicitly according to a SignalPath's needs (via DataSource#connectSignalPath(signalPath)).
  *
  * @author Henri
@@ -84,7 +84,10 @@ public abstract class DataSource {
 	}
 
 	public void startFeed() {
+		log.info("startListeners: " + startListeners);
+
 		for (IStartListener startListener : startListeners) {
+			log.info("calling onStart() on " + startListener);
 			startListener.onStart();
 		}
 

--- a/src/java/com/unifina/datasource/DataSource.java
+++ b/src/java/com/unifina/datasource/DataSource.java
@@ -84,10 +84,7 @@ public abstract class DataSource {
 	}
 
 	public void startFeed() {
-		log.info("startListeners: " + startListeners);
-
 		for (IStartListener startListener : startListeners) {
-			log.info("calling onStart() on " + startListener);
 			startListener.onStart();
 		}
 

--- a/src/java/com/unifina/signalpath/ModuleWithUI.java
+++ b/src/java/com/unifina/signalpath/ModuleWithUI.java
@@ -177,7 +177,6 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 
 			// If not found by id, try to find the Stream by path. This UI channel may be dynamically generated, and the id is not saved in the JSON.
 			if (stream == null) {
-				String runtimePath = getRuntimePath();
 				stream = getStreamService().getStreamByUiChannelPath(getRuntimePath());
 
 				// The uiChannelId may be replaced by a stream loaded by path from the db

--- a/src/java/com/unifina/signalpath/ModuleWithUI.java
+++ b/src/java/com/unifina/signalpath/ModuleWithUI.java
@@ -10,6 +10,7 @@ import com.unifina.service.StreamService;
 import com.unifina.utils.IdGenerator;
 import com.unifina.utils.MapTraversal;
 import grails.util.Holders;
+import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.security.AccessControlException;
@@ -24,6 +25,8 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 	protected int resendLast = 0;
 
 	private transient StreamService streamService;
+
+	private static final Logger log = Logger.getLogger(ModuleWithUI.class);
 
 	public ModuleWithUI() {
 		super();
@@ -93,7 +96,7 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 			return domainObject.getWebcomponent();
 		}
 	}
-	
+
 	@Override
 	public Map<String, Object> getConfiguration() {
 		Map<String, Object> config = super.getConfiguration();
@@ -101,14 +104,14 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 		if (uiChannel != null) {
 			config.put("uiChannel", uiChannel.toMap());
 		}
-		
+
 		ModuleOptions options = ModuleOptions.get(config);
 		options.add(new ModuleOption("uiResendAll", resendAll, "boolean"));
 		options.add(new ModuleOption("uiResendLast", resendLast, "int"));
-		
+
 		return config;
 	}
-	
+
 	@Override
 	protected void onConfiguration(Map<String, Object> config) {
 		super.onConfiguration(config);
@@ -119,7 +122,7 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 				uiChannelId == null ? IdGenerator.getShort() : uiChannelId,
 				getEffectiveName(),
 				uiChannelId == null);
-		
+
 		ModuleOptions options = ModuleOptions.get(config);
 		if (options.getOption("uiResendAll")!=null) {
 			resendAll = options.getOption("uiResendAll").getBoolean();
@@ -127,7 +130,7 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 		if (options.getOption("uiResendLast")!=null) {
 			resendLast = options.getOption("uiResendLast").getInt();
 		}
-		
+
 	}
 
 	public class UiChannel implements Serializable {
@@ -167,14 +170,21 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 		 * case that it's created dynamically and not saved in the JSON.
 		 */
 		public void initialize() {
+			log.info("initialize(): isNew: "+isNew+", id: "+id);
+
 			// Avoid lookup if we are sure the Stream won't be found
 			if (!isNew) {
 				stream = getStreamService().getStream(id);
+				log.info("Searching for stream "+id+" got me "+stream);
 			}
 
 			// If not found by id, try to find the Stream by path. This UI channel may be dynamically generated, and the id is not saved in the JSON.
 			if (stream == null) {
+				String runtimePath = getRuntimePath();
+				log.info("runtimePath: "+runtimePath);
 				stream = getStreamService().getStreamByUiChannelPath(getRuntimePath());
+
+				log.info("stream for runtimePath: "+stream);
 
 				// The uiChannelId may be replaced by a stream loaded by path from the db
 				if (stream != null) {
@@ -193,19 +203,23 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 				params.put("uiChannelPath", getRuntimePath());
 				params.put("uiChannelCanvas", getRootSignalPath().getCanvas());
 				stream = getStreamService().createStream(params, user, id);
+				log.info("Created stream: "+stream);
 			}
 
 			// Fix for CORE-893: Guard against excessive memory use by setting stream.uiChannelCanvas to the instance already in memory
+			log.info("setting the uiChannelCanvas: "+stream);
 			stream.setUiChannelCanvas(getRootSignalPath().getCanvas());
 
 			// User must have write permission to related Canvas in order to write to the UI channel
 			PermissionService permissionService = Holders.getApplicationContext().getBean(PermissionService.class);
+			log.info("Checking permissions for stream "+stream);
 			if (!permissionService.canWrite(user, stream.getUiChannelCanvas())) {
 				throw new AccessControlException(ModuleWithUI.this.getName() + ": User " + user.getUsername() +
 						" does not have write access to UI Channel Stream " + stream.getId());
 			}
 
 			isNew = false;
+			log.info("returning from initialize()");
 		}
 
 		public boolean isInitialized() {

--- a/src/java/com/unifina/signalpath/ModuleWithUI.java
+++ b/src/java/com/unifina/signalpath/ModuleWithUI.java
@@ -192,16 +192,23 @@ public abstract class ModuleWithUI extends AbstractSignalPathModule {
 				}
 			}
 
+			log.info("Getting user");
 			SecUser user = SecUser.getViaJava(getGlobals().getUserId());
+			log.info("Got user: "+user);
 
 			// Else create a new Stream object for this UI channel
 			if (stream == null) {
+				log.info("Starting stream auto-creation");
 				// Initialize a new UI channel Stream
 				Map<String, Object> params = new LinkedHashMap<>();
+				log.info("calling getUiChannelName()");
 				params.put("name", getUiChannelName());
 				params.put("uiChannel", true);
+				log.info("calling getRuntimePath()");
 				params.put("uiChannelPath", getRuntimePath());
+				log.info("calling getRootSignalPath().getCanvas()");
 				params.put("uiChannelCanvas", getRootSignalPath().getCanvas());
+				log.info("Creating stream with params: "+params);
 				stream = getStreamService().createStream(params, user, id);
 				log.info("Created stream: "+stream);
 			}

--- a/src/java/com/unifina/signalpath/SignalPathRunner.java
+++ b/src/java/com/unifina/signalpath/SignalPathRunner.java
@@ -71,10 +71,14 @@ public class SignalPathRunner extends Thread {
 		while (getRunning() != target && i++ < 60) {
 			log.debug("Waiting for " + runnerId + " to start...");
 			if (target && thrownOnStartUp != null) {
-				log.info("Giving up on waiting because run threw exception.");
+				log.error("Giving up on waiting because run threw exception.");
 			} else {
 				wait(500);
 			}
+		}
+
+		if (getRunning() != target) {
+			log.error("Timed out while waiting for runner to " + (target ? "start" : "stop"));
 		}
 	}
 

--- a/test/integration/com/unifina/service/RunCanvasSpec.groovy
+++ b/test/integration/com/unifina/service/RunCanvasSpec.groovy
@@ -44,13 +44,18 @@ class RunCanvasSpec extends IntegrationSpec {
 		when:
 		canvasService.start(canvas, true, user)
 
+		// Allow time for Canvas to start
+		Thread.sleep(60 * 1000)
+
+		// Try and warm up Kafka by sending one message and waiting some more
+		streamService.sendMessage(stream, [numero: 0, areWeDoneYet: false], 300)
 		Thread.sleep(60 * 1000)
 
 		// Produce data
-		(1..100).each { streamService.sendMessage(stream, [numero: it, areWeDoneYet: false], 30) }
+		(1..100).each { streamService.sendMessage(stream, [numero: it, areWeDoneYet: false], 300) }
 
 		// Terminator data package to know when we're done
-		streamService.sendMessage(stream, [numero: 0, areWeDoneYet: true], 30)
+		streamService.sendMessage(stream, [numero: 0, areWeDoneYet: true], 300)
 
 		// Synchronization: wait for terminator package
 		conditions.within(10) { assert modules(canvasService, canvas)*.outputs[0][1].value == true }

--- a/test/integration/com/unifina/service/RunCanvasSpec.groovy
+++ b/test/integration/com/unifina/service/RunCanvasSpec.groovy
@@ -5,14 +5,12 @@ import com.unifina.domain.security.SecUser
 import com.unifina.domain.signalpath.Canvas
 import com.unifina.feed.FeedFactory
 import grails.test.spock.IntegrationSpec
-import spock.lang.Ignore
 import spock.lang.Unroll
 import spock.util.concurrent.PollingConditions
 
 /**
  * Verifies that Canvases can be created, run, fed data through StreamService, and that the fed data be processed.
  */
-@Ignore
 class RunCanvasSpec extends IntegrationSpec {
 
 	def static final SUM_FROM_1_TO_100_TIMES_2 = "10100.0"

--- a/test/integration/com/unifina/service/RunCanvasSpec.groovy
+++ b/test/integration/com/unifina/service/RunCanvasSpec.groovy
@@ -44,7 +44,7 @@ class RunCanvasSpec extends IntegrationSpec {
 		when:
 		canvasService.start(canvas, true, user)
 
-		Thread.sleep(2000)
+		Thread.sleep(60 * 1000)
 
 		// Produce data
 		(1..100).each { streamService.sendMessage(stream, [numero: it, areWeDoneYet: false], 30) }

--- a/travis_scripts/integration_test.sh
+++ b/travis_scripts/integration_test.sh
@@ -1,6 +1,7 @@
 sudo /etc/init.d/mysql stop
 npm install
 git clone https://github.com/streamr-dev/streamr-docker-dev.git
+sudo ifconfig docker0 10.200.10.1/24
 $TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 1
 grails clean
 grails test-app -integration


### PR DESCRIPTION
Bring back `RunCanvasSpec`, which was originally `@Ignore`d by @harbu months ago due to troubles on Travis.

Two bugs were found and fixed:
- `RunCanvasSpec` was transactional and ended up blocking database transactions executed by the system under test
- Kafka didn't work due to the equivalent of `streamr-docker-dev bind-ip` missing from Travis config