### PR TITLE
feat: DEVOPS-20 - Staging/CI Docker environment:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
         skip_cleanup: true
         local_dir: build
     if: NOT type IN (pull_request)
-  - stage: Build docker Staging
+  - stage: Build docker dev
     env:
     - OWNER=streamr
     - IMAGE_NAME=engine-and-editor
@@ -78,6 +78,20 @@ jobs:
     - npm install
     - grails test war
     - docker build -f Dockerfile.dev -t $OWNER/$IMAGE_NAME:$TAG .
+    deploy:
+    - provider: script
+      script: bash travis_scripts/deploy_docker.sh staging
+    if: NOT type IN (pull_request)
+  - stage: Build docker Staging
+    env:
+    - OWNER=streamr
+    - IMAGE_NAME=engine-and-editor
+    - TAG=stg
+    script:
+    - grails clean
+    - npm install
+    - grails war
+    - docker build -f Dockerfile.stg -t $OWNER/$IMAGE_NAME:$TAG .
     deploy:
     - provider: script
       script: bash travis_scripts/deploy_docker.sh staging

--- a/Dockerfile.stg
+++ b/Dockerfile.stg
@@ -1,0 +1,26 @@
+# Use official Tomcat 7 runtime as base image
+FROM tomcat:7.0-jre8-alpine
+
+# Install dependencies
+#   bash: required by wait_for_it.sh script
+#   mysql: required for waiting for database dumps to be done
+RUN apk update
+RUN apk add bash mysql-client
+RUN sed -i "s/port=\"8080\"/port=\"8081\"/g" /usr/local/tomcat/conf/server.xml
+# Copy wait-for-it.sh script
+COPY wait-for-it.sh /usr/local/tomcat/bin/wait-for-it.sh
+
+# Copy pre-built unifina-core.war into container as unifina-core.war
+COPY target/ROOT.war /usr/local/tomcat/webapps/streamr-core.war
+
+ENV CATALINA_OPTS -Dstreamr.database.user=root \
+    -Dstreamr.database.password=password \
+    -Dstreamr.database.host=mysql \
+    -Dstreamr.kafka.bootstrap.servers=kafka:9092 \
+    -Dstreamr.ui.server=ws://127.0.0.1:8890/api/v1/ws \
+    -Dstreamr.http.api.server=http://127.0.0.1:8890/api/v1 \
+    -Dstreamr.redis.hosts=redis \
+    -Dstreamr.cassandra.hosts=cassandra
+EXPOSE 8081
+# Wait for MySQL server, MySQL dumps, and Cassandra to be ready
+CMD ["sh", "-c", "wait-for-it.sh mysql:3306 --timeout=120 && while ! mysql --user=root --host=mysql --password=password core_dev -e \"SELECT 1;\"; do echo 'waiting for db'; sleep 1; done && wait-for-it.sh cassandra:9042 --timeout=120 && catalina.sh run"]


### PR DESCRIPTION
-  Build war without test flag

The CI environment will run the docker version of the platform and the same image should then be used for production deployments(just a different war), Our current use-case only supported the developer experience with Docker now we are adding the staging step.