### PR TITLE
fix: GET/PUT/DELETE /api/v1/users/me

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -65,9 +65,9 @@ class UrlMappings {
 		"/api/v1/modules/$id"(controller: "moduleApi", action: "jsonGetModule")
 		"/api/v1/module_categories"(controller: "moduleApi", action: "jsonGetModuleTree")
 
-		"/api/v1/users/me"(controller: "userApi", action: "getUserInfo")
-		"/api/v1/users/me/update"(controller: "userApi", action: "update")
-		"/api/v1/users/me/delete"(controller: "userApi", action: "delete")
+		"/api/v1/users/me"(method: "GET", controller: "userApi", action: "getUserInfo")
+		"/api/v1/users/me"(method: "PUT", controller: "userApi", action: "update")
+		"/api/v1/users/me"(method: "DELETE", controller: "userApi", action: "delete")
 
 		"/api/v1/users/me/keys"(resources: "keyApi", excludes: ["create", "edit", "update"]) { resourceClass = SecUser }
 		"/api/v1/users/me/products"(controller: "productApi", action: "index") { operation = Permission.Operation.SHARE }


### PR DESCRIPTION
Adding method to UrlMappings enables several HTTP methods for one endpoint. Current mappings are:

- GET "/api/v1/users/me"
- PUT "/api/v1/users/me"
- DELETE "/api/v1/users/me"