### PR TITLE
replace murmur3 with md5

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JSCodeStyleSettings version="0">
+    <JSCodeStyleSettings>
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
       <option name="USE_DOUBLE_QUOTES" value="false" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="FLOW" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0.171-oracle" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="FLOW" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0.171-oracle" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/java/com/unifina/data/StreamPartitioner.java
+++ b/src/java/com/unifina/data/StreamPartitioner.java
@@ -1,16 +1,15 @@
 package com.unifina.data;
 
-import com.google.common.hash.HashFunction;
 import com.unifina.domain.data.Stream;
 
 import javax.annotation.Nullable;
-import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class StreamPartitioner{
-
-	private static HashFunction murmur3_32 = com.google.common.hash.Hashing.murmur3_32(0);
 	private static final Charset utf8 = Charset.forName("UTF-8");
 
 	public static int partition(Stream stream, @Nullable String partitionKey) {
@@ -22,17 +21,21 @@ public class StreamPartitioner{
 			// Fast common case
 			return 0;
 		} else if (partitionKey != null) {
-			byte[] result = murmur3_32.newHasher()
-					.putBytes(partitionKey)
-					.hash()
-					.asBytes();
-
-			// Big-endian interpretation of the result as int
-			int intHash = ((result[0] & 0xFF) << 24) | ((result[1] & 0xFF) << 16) | ((result[2] & 0xFF) << 8) | (result[3] & 0xFF);
+			int intHash = hash(partitionKey);
 			return Math.abs(intHash) % partitionCount;
 		} else {
 			// Fallback to random partition if no key
 			return ThreadLocalRandom.current().nextInt(partitionCount);
 		}
+	}
+
+	private static int hash(byte[] partitionKey) {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("MD5");
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException(e);
+		}
+		return ByteBuffer.wrap(md.digest(partitionKey)).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt();
 	}
 }

--- a/src/java/com/unifina/signalpath/utils/MessageChainUtil.java
+++ b/src/java/com/unifina/signalpath/utils/MessageChainUtil.java
@@ -8,9 +8,6 @@ import com.unifina.data.StreamPartitioner;
 import com.unifina.domain.data.Stream;
 import com.unifina.domain.security.SecUser;
 import com.unifina.utils.IdGenerator;
-import org.apache.log4j.Logger;
-
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
@@ -26,8 +23,6 @@ public class MessageChainUtil implements Serializable {
 	private Long userId;
 	private String msgChainId;
 	private transient SecUser user;
-
-	private static final Logger log = Logger.getLogger(MessageChainUtil.class);
 
 	public MessageChainUtil(Long userId) {
 		this.userId = userId;

--- a/test/unit/com/unifina/data/StreamPartitionerSpec.groovy
+++ b/test/unit/com/unifina/data/StreamPartitionerSpec.groovy
@@ -14,7 +14,10 @@ class StreamPartitionerSpec extends Specification {
 	void "partition() produces the expected partitioning"() {
 		List<String> keys = (0..99).collect { "key-$it" }
 		// Results must be the same as those produced by streamr-http-api/lib/partitioner.js
-		List correctResults = [5, 6, 3, 9, 3, 0, 2, 8, 2, 6, 9, 5, 5, 8, 5, 0, 0, 7, 2, 8, 5, 6, 8, 1, 7, 9, 2, 1, 8, 5, 6, 4, 3, 3, 1, 7, 1, 5, 2, 8, 3, 3, 8, 6, 8, 7, 4, 8, 2, 3, 5, 2, 8, 8, 8, 9, 8, 2, 7, 7, 0, 8, 8, 5, 9, 9, 9, 7, 2, 7, 0, 4, 4, 6, 4, 8, 5, 5, 0, 8, 2, 5, 1, 8, 6, 8, 8, 1, 2, 0, 7, 3, 2, 2, 5, 7, 9, 6, 4, 7]
+		List correctResults = [6, 7, 4, 4, 9, 1, 8, 0, 6, 6, 7, 6, 7, 3, 2, 2, 0, 9, 4, 9, 9, 5, 5, 1, 7, 3,
+							   0, 6, 5, 6, 3, 6, 3, 5, 6, 2, 3, 6, 7, 2, 1, 3, 2, 7, 1, 1, 5, 1, 4, 0, 1, 9,
+							   7, 4, 2, 3, 2, 9, 7, 7, 4, 3, 5, 4, 5, 3, 9, 0, 4, 8, 1, 7, 4, 8, 1, 2, 9, 9,
+							   5, 3, 5, 0, 9, 4, 3, 9, 6, 7, 8, 6, 4, 6, 0, 1, 1, 5, 8, 3, 9, 7]
 		Stream stream = new Stream()
 		stream.partitions = 10
 


### PR DESCRIPTION
Replace the murmur3 hash function with md5 when converting `partitionKey` to `streamPartition` to reflect the same changes made in the JS and Java clients.