### PR TITLE
Retry transaction receipt

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -266,21 +266,21 @@ environments {
  * Streamr-web3 Ethereum bridge address
  */
 streamr.ethereum.defaultNetwork = "rinkeby"
-streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks")) : [
+streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks"), Map) : [
 	ropsten: "http://10.200.10.1:3000",
 	rinkeby: "http://10.200.10.1:3001"
 ]
-streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls")) : [
+streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls"), Map) : [
 	ropsten: "http://localhost:8545",
 	rinkeby: "http://localhost:8546"
 ]
 environments {
 	production {
-		streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks")) : [
+		streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks"), Map) : [
 			ropsten: "http://ropsten:3000",
 			rinkeby: "http://rinkeby:3001"
 		]
-		streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls")) : [
+		streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls"), Map) : [
 			ropsten: "http://94.130.70.249:8545",
 			rinkeby: "http://94.130.70.249:8546"
 		]

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -263,29 +263,23 @@ environments {
 }
 
 /**
- * Streamr-web3 Ethereum bridge address
+ * Ethereum networks configuration (RPC urls)
+ *
+ * Can be configured via JVM system properties. Example command line flags:
+ *
+ * -Dstreamr.ethereum.defaultNetwork=someNetwork
+ * -Dstreamr.ethereum.networks.someNetwork=http://some-network-rpc-url
+ * -Dstreamr.ethereum.networks.anotherNetwork=http://some-network-rpc-url
  */
-streamr.ethereum.defaultNetwork = "rinkeby"
-streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks"), Map) : [
-	ropsten: "http://10.200.10.1:3000",
-	rinkeby: "http://10.200.10.1:3001"
-]
-streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls"), Map) : [
-	ropsten: "http://localhost:8545",
-	rinkeby: "http://localhost:8546"
-]
-environments {
-	production {
-		streamr.ethereum.networks = System.getProperty("streamr.ethereum.networks") ? new Gson().fromJson(System.getProperty("streamr.ethereum.networks"), Map) : [
-			ropsten: "http://ropsten:3000",
-			rinkeby: "http://rinkeby:3001"
-		]
-		streamr.ethereum.rpcUrls = System.getProperty("streamr.ethereum.rpcUrls") ? new Gson().fromJson(System.getProperty("streamr.ethereum.rpcUrls"), Map) : [
-			ropsten: "http://94.130.70.249:8545",
-			rinkeby: "http://94.130.70.249:8546"
-		]
-	}
-}
+streamr.ethereum.defaultNetwork = System.getProperty("streamr.ethereum.defaultNetwork") ?: "local"
+streamr.ethereum.networks = System.getProperties().findAll {key, val-> key.toString().startsWith("streamr.ethereum.networks.")}.isEmpty() ?
+	// Default value
+	[local: "http://localhost:8545"] :
+	// Else collect system properties to Map
+	System.getProperties().findAll {key, val-> key.toString().startsWith("streamr.ethereum.networks.")}
+		.collectEntries {key, val ->
+			[(key.toString().replace("streamr.ethereum.networks.", "")): val]
+		}
 
 /**
  * Kafka config

--- a/src/java/com/unifina/signalpath/blockchain/EthereumCall.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumCall.java
@@ -25,6 +25,7 @@ import java.util.Map;
 /**
  * Send out a call to specified function in Ethereum block chain
  */
+@Deprecated // replaced by SendEthereumTransaction
 public class EthereumCall extends AbstractHttpModule {
 
 	private EthereumModuleOptions ethereumOptions = new EthereumModuleOptions();
@@ -253,7 +254,7 @@ public class EthereumCall extends AbstractHttpModule {
 				args.put("value", valueWei.toBigInteger().toString());
 			}
 
-			request = new HttpPost(ethereumOptions.getServer() + "/call");
+			request = new HttpPost(ethereumOptions.getRpcUrl() + "/call");
 
 		} else {
 			// fallback function selected: send ether
@@ -263,7 +264,7 @@ public class EthereumCall extends AbstractHttpModule {
 			} else {
 				args.put("value", "0");
 			}
-			request = new HttpPost(ethereumOptions.getServer() + "/send");
+			request = new HttpPost(ethereumOptions.getRpcUrl() + "/send");
 		}
 
 		String jsonString = gson.toJson(args);

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -48,7 +48,7 @@ public class EthereumModuleOptions implements Serializable {
 		ModuleOption networkOption = ModuleOption.createString("network", network);
 
 		// Add all configured networks
-		Map<String, Object> networks = MapTraversal.getMap(Holders.getConfig(), "streamr.ethereum.networks");
+		Map<String, Object> networks = MapTraversal.getMap(Holders.getConfig(), "streamr.ethereum.rpcUrls");
 		for (String network : networks.keySet()) {
 			networkOption.addPossibleValue(network, network);
 		}

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -64,6 +64,8 @@ public class EthereumModuleOptions implements Serializable {
 		}
 	}
 
+	// TODO: remove when old Ethereum modules are removed. Should be unused then.
+	@Deprecated
 	public String getServer() {
 		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks." + network);
 		if (url == null) {

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -48,7 +48,7 @@ public class EthereumModuleOptions implements Serializable {
 		ModuleOption networkOption = ModuleOption.createString("network", network);
 
 		// Add all configured networks
-		Map<String, Object> networks = MapTraversal.getMap(Holders.getConfig(), "streamr.ethereum.rpcUrls");
+		Map<String, Object> networks = MapTraversal.getMap(Holders.getConfig(), "streamr.ethereum.networks");
 		for (String network : networks.keySet()) {
 			networkOption.addPossibleValue(network, network);
 		}
@@ -60,24 +60,14 @@ public class EthereumModuleOptions implements Serializable {
 		ModuleOption networkOption = options.getOption("network");
 		if (networkOption != null) {
 			network = networkOption.getString();
-			getServer(); // Throws if the network not valid
+			getRpcUrl(); // Throws if the network not valid
 		}
-	}
-
-	// TODO: remove when old Ethereum modules are removed. Should be unused then.
-	@Deprecated
-	public String getServer() {
-		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks." + network);
-		if (url == null) {
-			throw new RuntimeException("No url found for Ethereum bridge to network " + network);
-		}
-		return url;
 	}
 
 	public String getRpcUrl() {
-		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.rpcUrls." + network);
+		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks." + network);
 		if (url == null) {
-			throw new RuntimeException("No rpcUrl found for Ethereum bridge to network " + network);
+			throw new RuntimeException("No rpcUrl found for Ethereum network " + network);
 		}
 		return url;
 	}

--- a/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
+++ b/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
@@ -296,7 +296,6 @@ public class SendEthereumTransaction extends ModuleWithSideEffects {
 		 */
 		protected void enqueueConfirmedTx() throws IOException {
 			final FunctionCallResult fncall = this;
-			int tries = 0;
 			receipt = Web3jHelper.waitForTransactionReceipt(web3j,web3jTx.getTransactionHash(), check_result_waitms, check_result_max_tries);
 			if (receipt != null) {
 				transaction = web3j.ethGetTransactionByHash(web3jTx.getTransactionHash()).send().getResult();

--- a/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
+++ b/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
@@ -296,26 +296,16 @@ public class SendEthereumTransaction extends ModuleWithSideEffects {
 		 */
 		protected void enqueueConfirmedTx() throws IOException {
 			final FunctionCallResult fncall = this;
-				int tries = 0;
-				while (tries++ < check_result_max_tries) {
-					EthGetTransactionReceipt get = web3j.ethGetTransactionReceipt(web3jTx.getTransactionHash()).send();
-					if ((receipt = get.getResult()) != null) {
-						transaction = web3j.ethGetTransactionByHash(web3jTx.getTransactionHash()).send().getResult();
-						log.info("Receipt found for txHash: " + web3jTx.getTransactionHash());
-						enqueueEvent(fncall);
-						return;
-					}
-					log.info("No receipt found for txHash: " + web3jTx.getTransactionHash());
-					if(tries == check_result_max_tries)
-						continue;
-					try {
-						log.info(". Waiting "+check_result_waitms+"ms");
-						Thread.sleep(check_result_waitms);
-					} catch (InterruptedException e) {
-						throw new RuntimeException(e);
-					}
-				}
+			int tries = 0;
+			receipt = Web3jHelper.waitForTransactionReceipt(web3j,web3jTx.getTransactionHash(), check_result_waitms, check_result_max_tries);
+			if (receipt != null) {
+				transaction = web3j.ethGetTransactionByHash(web3jTx.getTransactionHash()).send().getResult();
+				log.info("Receipt found for txHash: " + web3jTx.getTransactionHash());
+				enqueueEvent(fncall);
+			}
+			else{
 				log.error("Couldnt find receipt for txHash: " + web3jTx.getTransactionHash());
+			}
 		}
 
 		@Override

--- a/src/java/com/unifina/signalpath/blockchain/SolidityCompileDeploy.java
+++ b/src/java/com/unifina/signalpath/blockchain/SolidityCompileDeploy.java
@@ -155,20 +155,9 @@ public class SolidityCompileDeploy extends ModuleWithUI implements Pullable<Ethe
 		String txhash = tx.getTransactionHash();
 		log.debug("TX response: " + txhash);
 
-		TransactionReceipt receipt = null;
-		int retry = 0;
-		while (receipt == null && retry < MAX_RETRIES) {
-			receipt = web3j.ethGetTransactionReceipt(txhash).send().getResult();
-			if (receipt == null) {
-				retry++;
-				log.info("Couldn't get transaction receipt for tx " + txhash + ". Retry " + retry);
-				try {
-					Thread.sleep(SLEEP_BETWEEN_RETRIES_MILLIS);
-				} catch (InterruptedException e) { /* ignore */ }
-			}
-		}
+		TransactionReceipt receipt = Web3jHelper.waitForTransactionReceipt(web3j, txhash, SLEEP_BETWEEN_RETRIES_MILLIS, MAX_RETRIES);
 
-		if (retry >= MAX_RETRIES) {
+		if (receipt == null) {
 			throw new RuntimeException("Couldn't get transaction receipt from Ethereum node. Transaction may not have been broadcasted to the network.");
 		} else {
 			log.info("Got transaction receipt for tx " + txhash + ".");

--- a/src/java/com/unifina/signalpath/blockchain/SolidityModule.java
+++ b/src/java/com/unifina/signalpath/blockchain/SolidityModule.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+@Deprecated // replaced by SolidityCompileDeploy
 public class SolidityModule extends ModuleWithUI implements Pullable<EthereumContract> {
 
 	private static final Logger log = Logger.getLogger(SolidityModule.class);
@@ -127,7 +128,7 @@ public class SolidityModule extends ModuleWithUI implements Pullable<EthereumCon
 	}
 	
 	protected StreamrWeb3Interface createWeb3Interface() {
-		return new StreamrWeb3Interface(ethereumOptions.getServer(), ethereumOptions.getGasPriceWei());
+		return new StreamrWeb3Interface(ethereumOptions.getRpcUrl(), ethereumOptions.getGasPriceWei());
 	}
 
 	private void createContractOutput() {

--- a/test/unit/com/unifina/signalpath/blockchain/SendEthereumTransactionSpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SendEthereumTransactionSpec.groovy
@@ -378,16 +378,12 @@ class SendEthereumTransactionSpec extends ModuleTestingSpecification {
     "network": {
       "possibleValues": [
         {
-          "text": "ropsten",
-          "value": "ropsten"
-        },
-        {
-          "text": "rinkeby",
-          "value": "rinkeby"
+          "text": "local",
+          "value": "local"
         }
       ],
       "type": "string",
-      "value": "rinkeby"
+      "value": "local"
     }
   },
   "canRefresh": false,

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
@@ -438,14 +438,11 @@ class SolidityCompileDeploySpec extends ModuleTestingSpecification {
         {
             "possibleValues": [
             {
-                "text": "ropsten",
-                "value": "ropsten"
-            },
-            {
-                "text": "rinkeby",
-                "value": "rinkeby"
-            }],
-            "value": "rinkeby",
+                "text": "local",
+                "value": "local"
+            }
+            ],
+            "value": "local",
             "type": "string"
         },
         "gasPriceGWei":

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityModuleSpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityModuleSpec.groovy
@@ -286,14 +286,11 @@ class SolidityModuleSpec extends ModuleTestingSpecification {
         {
             "possibleValues": [
             {
-                "text": "ropsten",
-                "value": "ropsten"
-            },
-            {
-                "text": "rinkeby",
-                "value": "rinkeby"
-            }],
-            "value": "rinkeby",
+                "text": "local",
+                "value": "local"
+            }
+            ],
+            "value": "local",
             "type": "string"
         },
         "gasPriceGWei":


### PR DESCRIPTION
Handle the situation where a tx receipt is not immediately available after submitting a transaction to an Ethereum node to deploy a contract. Old code often produced NPE. New code retries periodically until tx receipt is non-null or max retries is reached.

There should be a test for this, but I don't have time to add it right now. @isentropy please feel free to contribute a test.

If the beta launch draws nearer and we want to merge this without adding a test, we can create a technical debt ticket to add the test later.