### PR TITLE
CORE-1724: CassandraService: limit in getLatestStreamMessage

### DIFF
--- a/grails-app/services/com/unifina/service/CassandraService.groovy
+++ b/grails-app/services/com/unifina/service/CassandraService.groovy
@@ -91,6 +91,8 @@ class CassandraService implements DisposableBean {
 	}
 
 	StreamMessage getLatestStreamMessage(Stream stream, int partition) {
+		// TODO: ts >= ? condition added to prevent timeouts of cassandra queries. A more efficient approach to finding
+		// the latest message is needed. (CORE-1724)
 		ResultSet resultSet = getSession()
 			.execute("SELECT payload FROM stream_data WHERE id = ? AND partition = ? AND ts >= ? ORDER BY ts DESC, sequence_no DESC LIMIT 1",
 				stream.getId(), partition, System.currentTimeMillis() - ONE_YEAR_IN_MS)

--- a/grails-app/services/com/unifina/service/CassandraService.groovy
+++ b/grails-app/services/com/unifina/service/CassandraService.groovy
@@ -26,6 +26,8 @@ class CassandraService implements DisposableBean {
 
 	private static final int FETCH_SIZE = 5000;
 
+	static final long ONE_YEAR_IN_MS = 365 * 24 * 60 * 60 * 1000
+
 	// Thread-safe
 	private Session session
 
@@ -89,7 +91,9 @@ class CassandraService implements DisposableBean {
 	}
 
 	StreamMessage getLatestStreamMessage(Stream stream, int partition) {
-		ResultSet resultSet = getSession().execute("SELECT payload FROM stream_data WHERE id = ? AND partition = ? ORDER BY ts DESC, sequence_no DESC LIMIT 1", stream.getId(), partition)
+		ResultSet resultSet = getSession()
+			.execute("SELECT payload FROM stream_data WHERE id = ? AND partition = ? AND ts >= ? ORDER BY ts DESC, sequence_no DESC LIMIT 1",
+				stream.getId(), partition, System.currentTimeMillis() - ONE_YEAR_IN_MS)
 		Row row = resultSet.one()
 		if (row) {
 			return StreamMessage.fromJson(new String(row.getBytes("payload").array(), StandardCharsets.UTF_8))


### PR DESCRIPTION
Method `StreamApiController#status` invokes `getLatestStreamMessage` to fetch the latest stream message from Cassandra. In many cases, such as the tram demo, the query times out in production. Put in an extra `ts >= now - 1 year` condition to avoid having to sort the entire result set of a stream/partition-pair. Or at least this prevents the query from not timing out.

Tested locally that this doesn't break the status API endpoint. 