### PR TITLE
create streams/${id}/subscribers endpoint

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -52,6 +52,7 @@ class UrlMappings {
 		"/api/v1/streams/$id/confirmCsvFileUpload"(controller: "streamApi", action: "confirmCsvFileUpload")
 		"/api/v1/streams/$id/dataFiles"(controller: "streamApi", action: "dataFiles")
 		"/api/v1/streams/$id/publishers"(controller: "streamApi", action: "publishers")
+		"/api/v1/streams/$id/subscribers"(controller: "streamApi", action: "subscribers")
 		"/api/v1/streams/$id/status"(controller: "streamApi", action: "status")
 		"/api/v1/streams/$resourceId/keys"(resources: "keyApi", excludes: ["create", "edit", "update"]) { resourceClass = Stream }
 		"/api/v1/streams/$streamId/keys/$keyId"(method: "PUT", controller: "keyApi", action: "updateStreamKey")

--- a/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
@@ -179,6 +179,14 @@ class StreamApiController {
 		}
 	}
 
+	@StreamrApi
+	def subscribers(String id) {
+		getAuthorizedStream(id, Operation.WRITE) { Stream stream ->
+			Set<String> subscriberAddresses = streamService.getStreamEthereumSubscribers(stream)
+			render([addresses: subscriberAddresses] as JSON)
+		}
+	}
+
 	private def getAuthorizedStream(String id, Operation op, Closure action) {
 		def stream = Stream.get(id)
 		if (stream == null) {

--- a/grails-app/services/com/unifina/service/StreamService.groovy
+++ b/grails-app/services/com/unifina/service/StreamService.groovy
@@ -256,6 +256,17 @@ class StreamService {
 		return keys*.idInService as Set
 	}
 
+	Set<String> getStreamEthereumSubscribers(Stream stream) {
+		// This approach might be slow if there are a lot of allowed readers to the Stream
+		List<SecUser> readers = permissionService.getPermissionsTo(stream, Permission.Operation.READ)*.user
+
+		List<IntegrationKey> keys = IntegrationKey.findAll {
+			user.id in readers*.id && service in [IntegrationKey.Service.ETHEREUM, IntegrationKey.Service.ETHEREUM_ID]
+		}
+
+		return keys*.idInService as Set
+	}
+
 	List<Stream> getInboxStreams(List<SecUser> users) {
 		if (users.isEmpty()) return new ArrayList<Stream>()
 		List<IntegrationKey> keys = IntegrationKey.findAll {

--- a/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
@@ -329,6 +329,25 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		]
 	}
 
+	void "returns set of subscriber addresses"() {
+		setup:
+		controller.streamService = streamService = Mock(StreamService)
+		Set<String> addresses = new HashSet<String>()
+		addresses.add('0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6')
+		addresses.add('0x0181ae2f5efe8947eca8c2e9d3f32702cf4be7dd')
+		when:
+		params.id = streamOne.id
+		request.method = "GET"
+		authenticatedAs(me) { controller.subscribers() }
+
+		then:
+		1 * streamService.getStreamEthereumSubscribers(streamOne) >> addresses
+		response.status == 200
+		response.json == [
+			'addresses': addresses.toArray()
+		]
+	}
+
 	void "streams status"() {
 		setup:
 		controller.streamService = Mock(StreamService)

--- a/test/unit/com/unifina/service/StreamServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamServiceSpec.groovy
@@ -449,6 +449,39 @@ class StreamServiceSpec extends Specification {
 		addresses == validAddresses
 	}
 
+	void "getStreamEthereumSubscribers should return Ethereum addresses of users with read permission to the Stream"() {
+		setup:
+		service.permissionService = Mock(PermissionService)
+		SecUser user1 = new SecUser(id: 1, username: "u1").save(failOnError: true, validate: false)
+		IntegrationKey key1 = new IntegrationKey(user: user1, service: IntegrationKey.Service.ETHEREUM_ID,
+			idInService: "0x9fe1ae3f5efe2a01eca8c2e9d3c11102cf4bea57").save(failOnError: true, validate: false)
+		SecUser user2 = new SecUser(id: 2, username: "u2").save(failOnError: true, validate: false)
+		IntegrationKey key2 = new IntegrationKey(user: user2, service: IntegrationKey.Service.ETHEREUM,
+			idInService: "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)
+		SecUser user3 = new SecUser(id: 3, username: "u3").save(failOnError: true, validate: false)
+
+		// User with key but no write permission - this key should not be returned by the query
+		SecUser userWithKeyButNoPermission = new SecUser(id: 4, username: "u4").save(failOnError: true, validate: false)
+		new IntegrationKey(user: userWithKeyButNoPermission, service: IntegrationKey.Service.ETHEREUM_ID,
+			idInService: "0x12345e3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)
+
+		Set<String> validAddresses = new HashSet<String>()
+		validAddresses.add(key1.idInService)
+		validAddresses.add(key2.idInService)
+		Permission p1 = new Permission(user: user1)
+		Permission p2 = new Permission(user: user2)
+		Permission p3 = new Permission(user: user3)
+		List<Permission> perms = [p1, p2, p3]
+		Stream stream = new Stream(name: "name")
+		stream.id = "streamId"
+		stream.save(failOnError: true, validate: false)
+		when:
+		Set<String> addresses = service.getStreamEthereumSubscribers(stream)
+		then:
+		1 * service.permissionService.getPermissionsTo(stream, Permission.Operation.READ) >> perms
+		addresses == validAddresses
+	}
+
 	void "getInboxStreams() returns all inbox streams of the users"() {
 		SecUser user1 = new SecUser(id: 1, username: "u1").save(failOnError: true, validate: false)
 		IntegrationKey key1 = new IntegrationKey(user: user1, service: IntegrationKey.Service.ETHEREUM_ID,

--- a/test/unit/com/unifina/service/StreamServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamServiceSpec.groovy
@@ -460,7 +460,7 @@ class StreamServiceSpec extends Specification {
 			idInService: "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)
 		SecUser user3 = new SecUser(id: 3, username: "u3").save(failOnError: true, validate: false)
 
-		// User with key but no write permission - this key should not be returned by the query
+		// User with key but no read permission - this key should not be returned by the query
 		SecUser userWithKeyButNoPermission = new SecUser(id: 4, username: "u4").save(failOnError: true, validate: false)
 		new IntegrationKey(user: userWithKeyButNoPermission, service: IntegrationKey.Service.ETHEREUM_ID,
 			idInService: "0x12345e3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)


### PR DESCRIPTION
This new endpoint will be used by the streamr-client during the key exchange for encryption. Before sending the group key encrypted with the subscriber's RSA public key, the publisher first verifies that the request comes from a valid subscriber by checking the list of subscribers using this endpoint.

This endpoint is very similar to "streams/${id}/publishers". 