### PR TITLE
Core 1723 infura websockets

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -35,15 +35,14 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 
 
 	ContractEventPoller(String rpcUrl, String contractAddress, EventsListener listener) {
-		if(rpcUrl.startsWith("http")){
+		if (rpcUrl.startsWith("http")) {
 			rpc = new HttpEthereumJsonRpc(rpcUrl, this);
-		}
-		else{
+		} else {
 			rpc = new WebsocketEthereumJsonRpc(rpcUrl, this);
 			try {
 				boolean opened = ((WebsocketEthereumJsonRpc) rpc).openConnectionRetryIfFail();
-				if(!opened){
-					throw new RuntimeException("Couldnt open connection to "+rpcUrl);
+				if (!opened) {
+					throw new RuntimeException("Couldnt open connection to " + rpcUrl);
 				}
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);
@@ -101,16 +100,16 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			filterId, contractAddress, id));
 
 	}
+
 	private synchronized void pollChanges() {
-		if(filterId == null){
+		if (filterId == null) {
 			log.info("pollChanges called before filter is set. Doing nothing.");
 			return;
 		}
 		try {
 			log.info(String.format("Polling filter '%s'.", filterId));
 			rpc.rpcCall("eth_getFilterChanges", singletonList(filterId), ID_POLLFILTER);
-		}
-		catch (HttpEthereumJsonRpc.ErrorObjectException e) {
+		} catch (HttpEthereumJsonRpc.ErrorObjectException e) {
 			if (filterDoesNotExist(e.getCode())) {
 				log.info("Resetting filter...");
 				filterId = null;
@@ -120,12 +119,12 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			}
 		} catch (HttpEthereumJsonRpc.RPCException | JSONException e) {
 			listener.onError(e.getMessage());
-		}
-		catch(Exception e){
+		} catch (Exception e) {
 			listener.onError(e.getMessage());
 			throw new RuntimeException(e);
 		}
 	}
+
 	/**
 	 * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges
 	 */
@@ -148,13 +147,13 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 
 		try {
 			rpc.rpcCall("eth_uninstallFilter", singletonList(id), ID_REMOVEFILTER);
-		}
-		catch(Exception e){
+		} catch (Exception e) {
 			listener.onError(e.getMessage());
 			throw new RuntimeException(e);
 		}
 
 	}
+
 	private void processUninstallFilterResponse(JSONObject response) {
 		boolean result;
 
@@ -178,11 +177,17 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 	@Override
 	public void processResponse(JSONObject resp) {
 		int id = resp.getInt("id");
-		switch(id){
-			case ID_ADDFILTER: processAddFilterResponse(resp); return;
-			case ID_REMOVEFILTER: processUninstallFilterResponse(resp); return;
-			case ID_POLLFILTER: processPollChangesResponse(resp); return;
+		switch (id) {
+			case ID_ADDFILTER:
+				processAddFilterResponse(resp);
+				return;
+			case ID_REMOVEFILTER:
+				processUninstallFilterResponse(resp);
+				return;
+			case ID_POLLFILTER:
+				processPollChangesResponse(resp);
+				return;
 		}
-		throw new RuntimeException("Unknown RPC id "+id);
+		throw new RuntimeException("Unknown RPC id " + id);
 	}
 }

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -7,7 +7,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.websocket.DeploymentException;
 import java.io.Closeable;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
@@ -16,22 +19,22 @@ import static java.util.Collections.singletonMap;
 /**
  * Poll Ethereum events of a contract via JSON RPC (https://github.com/ethereum/wiki/wiki/JSON-RPC) using filters.
  */
-class ContractEventPoller implements Closeable, Runnable {
+class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler {
 	private static final Logger log = Logger.getLogger(ContractEventPoller.class);
 	private static final int POLL_INTERVAL_IN_MS = 3000;
 
+	private static final int ID_ADDFILTER = 1;
+	private static final int ID_REMOVEFILTER = 2;
+	private static final int ID_POLLFILTER = 3;
+
 	private final EthereumJsonRpc rpc;
 	private final String contractAddress;
-	private final Listener listener;
+	private final EventsListener listener;
 	private String filterId;
 
-	interface Listener {
-		void onEvent(JSONArray events);
-		void onError(String message);
-	}
 
-	ContractEventPoller(String rpcUrl, String contractAddress, Listener listener) {
-		this.rpc = new EthereumJsonRpc(rpcUrl);
+	ContractEventPoller(String rpcUrl, String contractAddress, EventsListener listener) throws DeploymentException, IOException, URISyntaxException {
+		this.rpc = new WebsocketEthereumJsonRpc(rpcUrl, this);
 		this.contractAddress = contractAddress;
 		this.listener = listener;
 	}
@@ -62,11 +65,15 @@ class ContractEventPoller implements Closeable, Runnable {
 	private void newFilter() {
 		List params = singletonList(singletonMap("address", contractAddress));
 		try {
-			filterId = rpc.rpcCall("eth_newFilter", params).getString("result");
-		} catch (JSONException e) {
+			rpc.rpcCall("eth_newFilter", params, ID_ADDFILTER);
+		} catch (Exception e) {
+			listener.onError(e.getMessage());
 			throw new RuntimeException(e);
 		}
+	}
 
+	protected void processAddFilterResponse(JSONObject resp) {
+		filterId = resp.getString("result");
 		// Logging
 		String id = null;
 		if (listener instanceof AbstractSignalPathModule) {
@@ -77,20 +84,14 @@ class ContractEventPoller implements Closeable, Runnable {
 		}
 		log.info(String.format("Filter '%s' created. Listening to contract '%s' on canvas '%s'.",
 			filterId, contractAddress, id));
-	}
 
-	/**
-	 * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges
-	 */
+	}
 	private synchronized void pollChanges() {
-		log.info(String.format("Polling filter '%s'.", filterId));
 		try {
-			JSONObject response = rpc.rpcCall("eth_getFilterChanges", singletonList(filterId));
-			JSONArray jsonArray = response.getJSONArray("result");
-			if (jsonArray.length() != 0) {
-				listener.onEvent(jsonArray);
-			}
-		} catch (EthereumJsonRpc.ErrorObjectError e) {
+			log.info(String.format("Polling filter '%s'.", filterId));
+			rpc.rpcCall("eth_getFilterChanges", singletonList(filterId), ID_POLLFILTER);
+		}
+		catch (HttpEthereumJsonRpc.ErrorObjectException e) {
 			if (filterDoesNotExist(e.getCode())) {
 				log.info("Resetting filter...");
 				filterId = null;
@@ -98,8 +99,21 @@ class ContractEventPoller implements Closeable, Runnable {
 			} else {
 				listener.onError(e.getMessage());
 			}
-		} catch (EthereumJsonRpc.Error | JSONException e) {
+		} catch (HttpEthereumJsonRpc.RPCException | JSONException e) {
 			listener.onError(e.getMessage());
+		}
+		catch(Exception e){
+			listener.onError(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+	/**
+	 * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges
+	 */
+	private synchronized void processPollChangesResponse(JSONObject response) {
+		JSONArray jsonArray = response.getJSONArray("result");
+		if (jsonArray.length() != 0) {
+			listener.onEvent(jsonArray);
 		}
 	}
 
@@ -114,11 +128,21 @@ class ContractEventPoller implements Closeable, Runnable {
 		filterId = null;
 
 		try {
-			result = rpc.rpcCall("eth_uninstallFilter", singletonList(id)).getBoolean("result");
-		} catch (JSONException e) {
+			rpc.rpcCall("eth_uninstallFilter", singletonList(id), ID_REMOVEFILTER);
+		}
+		catch(Exception e){
+			listener.onError(e.getMessage());
 			throw new RuntimeException(e);
 		}
 
+	}
+	private void processUninstallFilterResponse(JSONObject response) {
+		boolean result;
+
+		// avoid race condition where another close() enters while rpcCall is executing
+		String id = filterId;
+		filterId = null;
+		result = response.getBoolean("result");
 		if (result) {
 			log.info(String.format("Filter '%s' uninstalled.", id));
 		} else {
@@ -129,5 +153,16 @@ class ContractEventPoller implements Closeable, Runnable {
 
 	private static boolean filterDoesNotExist(int code) {
 		return code == -32000;
+	}
+
+	@Override
+	public void processResponse(JSONObject resp) {
+		int id = resp.getInt("id");
+		switch(id){
+			case ID_ADDFILTER: processAddFilterResponse(resp); return;
+			case ID_POLLFILTER: processPollChangesResponse(resp); return;
+			case ID_REMOVEFILTER: processUninstallFilterResponse(resp); return;
+		}
+		throw new RuntimeException("Unknown RPC id "+id);
 	}
 }

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -187,7 +187,8 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			case ID_POLLFILTER:
 				processPollChangesResponse(resp);
 				return;
+			default:
+				throw new RuntimeException("Unknown RPC id " + id);
 		}
-		throw new RuntimeException("Unknown RPC id " + id);
 	}
 }

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -35,7 +35,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 
 
 	ContractEventPoller(String rpcUrl, String contractAddress, EventsListener listener) throws DeploymentException, IOException, URISyntaxException {
-		this.rpc = new WebsocketEthereumJsonRpc(rpcUrl, this);
+		this.rpc = rpcUrl.startsWith("http") ? new HttpEthereumJsonRpc(rpcUrl, this) : new WebsocketEthereumJsonRpc(rpcUrl, this);
 		this.contractAddress = contractAddress;
 		this.listener = listener;
 	}

--- a/src/java/com/unifina/signalpath/blockchain/EthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumJsonRpc.java
@@ -2,85 +2,33 @@ package com.unifina.signalpath.blockchain;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.body.RequestBodyEntity;
 import org.json.JSONObject;
 
 import java.util.List;
 
-class EthereumJsonRpc {
-	private static final int CALL_ID = 123;
-	private final String url;
-
-	EthereumJsonRpc(String url) {
+public abstract class EthereumJsonRpc {
+	protected final String url;
+	protected JsonRpcResponseHandler handler;
+	EthereumJsonRpc(String url, JsonRpcResponseHandler handler) {
 		this.url = url;
+		this.handler = handler;
 	}
 
-	JSONObject rpcCall(String method, List params) throws UnirestError, HttpStatusError, ErrorObjectError {
-		try {
-			HttpResponse<JsonNode> response = formRequest(method, params, CALL_ID).asJson();
+	/*
+		implementation should call handler.processResponse()
+	 */
+	public abstract void rpcCall(String method, List params, int callId) throws Exception;
 
-			if (statusCodeIsNot2XX(response.getStatus())) {
-				throw new HttpStatusError(response.getStatus(), response.getBody());
-			}
-
-			JSONObject responseJson = response.getBody().getObject();
-			if (responseJson.opt("error") != null) {
-				throw new ErrorObjectError(responseJson.optJSONObject("error"));
-			}
-
-			return responseJson;
-		} catch (UnirestException e) {
-			throw new UnirestError(e);
-		}
+	protected String formRequestBody(String method, List params, int callId) {
+		return new Gson().toJson(ImmutableMap.of(
+				"id", callId,
+				"jsonrpc", "2.0",
+				"method", method,
+				"params", params
+			));
 	}
 
-	private RequestBodyEntity formRequest(String method, List params, int callId) {
-		return Unirest.post(url)
-				.header("Content-Type", "application/json")
-				.body(new Gson().toJson(ImmutableMap.of(
-			"id", callId,
-			"jsonrpc", "2.0",
-			"method", method,
-			"params", params
-		)));
-	}
 
-	private static boolean statusCodeIsNot2XX(int code) {
-		return code / 100 != 2;
-	}
-
-	abstract class Error extends RuntimeException {
-		private Error(String message) {
-			super(String.format("JSON RPC error with server '%s': %s", url, message));
-		}
-	}
-
-	class UnirestError extends Error {
-		private UnirestError(UnirestException e) {
-			super(e.getMessage());
-		}
-	}
-
-	class HttpStatusError extends Error {
-		private HttpStatusError(int statusCode, JsonNode body) {
-			super(String.format("unexpected status code %d with content %s", statusCode, body));
-		}
-	}
-
-	class ErrorObjectError extends Error {
-		private final JSONObject errorObject;
-
-		private ErrorObjectError(JSONObject errorObject) {
-			super("response contained error object " + errorObject);
-			this.errorObject = errorObject;
-		}
-
-		public int getCode() {
-			return errorObject.optInt("code");
-		}
-	}
 }

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -9,7 +9,8 @@ import java.io.Serializable;
 import java.util.Map;
 
 public class EthereumModuleOptions implements Serializable {
-	private String network = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
+	private String network = "ropsten";
+	//MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
 	private double gasPriceWei = 20e9; // 20 Gwei
 
 	void writeTo(ModuleOptions options) {
@@ -66,6 +67,13 @@ public class EthereumModuleOptions implements Serializable {
 
 	public String getRpcUrl() {
 		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks." + network);
+		if (url == null) {
+			throw new RuntimeException("No rpcUrl found for Ethereum network " + network);
+		}
+		return url;
+	}
+	public String getWebsocketRpcUri() {
+		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.wss." + network);
 		if (url == null) {
 			throw new RuntimeException("No rpcUrl found for Ethereum network " + network);
 		}

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -4,11 +4,14 @@ import com.unifina.signalpath.ModuleOption;
 import com.unifina.signalpath.ModuleOptions;
 import com.unifina.utils.MapTraversal;
 import grails.util.Holders;
+import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.Map;
 
 public class EthereumModuleOptions implements Serializable {
+	private static final Logger log = Logger.getLogger(EthereumModuleOptions.class);
+
 	private String network = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
 	private double gasPriceWei = 20e9; // 20 Gwei
 
@@ -74,7 +77,7 @@ public class EthereumModuleOptions implements Serializable {
 	public String getWebsocketRpcUri() {
 		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.wss." + network);
 		if (url == null) {
-			throw new RuntimeException("No rpcUrl found for Ethereum network " + network);
+			log.warn("No websockets URI found for Ethereum network " + network);
 		}
 		return url;
 	}

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -9,8 +9,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 public class EthereumModuleOptions implements Serializable {
-	private String network = "ropsten";
-	//MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
+	private String network = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
 	private double gasPriceWei = 20e9; // 20 Gwei
 
 	void writeTo(ModuleOptions options) {

--- a/src/java/com/unifina/signalpath/blockchain/EventsListener.java
+++ b/src/java/com/unifina/signalpath/blockchain/EventsListener.java
@@ -1,0 +1,8 @@
+package com.unifina.signalpath.blockchain;
+
+import org.json.JSONArray;
+
+public interface EventsListener {
+	void onEvent(JSONArray events);
+	void onError(String message);
+}

--- a/src/java/com/unifina/signalpath/blockchain/GetEvents.java
+++ b/src/java/com/unifina/signalpath/blockchain/GetEvents.java
@@ -15,13 +15,15 @@ import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.http.HttpService;
 
+import javax.websocket.DeploymentException;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.*;
 
 /**
  * Get events sent out by given contract in the given transaction
  */
-public class GetEvents extends AbstractSignalPathModule implements ContractEventPoller.Listener, IStartListener, IStopListener {
+public class GetEvents extends AbstractSignalPathModule implements EventsListener, IStartListener, IStopListener {
 	private static final Logger log = Logger.getLogger(GetEvents.class);
 
 	private final EthereumContractInput contract = new EthereumContractInput(this, "contract");
@@ -86,7 +88,11 @@ public class GetEvents extends AbstractSignalPathModule implements ContractEvent
 	public void onStart() {
 		String rpcUrl = ethereumOptions.getRpcUrl();
 		String contractAddress = contract.getValue().getAddress();
-		contractEventPoller = new ContractEventPoller(rpcUrl, contractAddress, this);
+		try {
+			contractEventPoller = new ContractEventPoller(rpcUrl, contractAddress, this);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 		new Thread(contractEventPoller, "ContractEventPoller-Thread").start();
 	}
 

--- a/src/java/com/unifina/signalpath/blockchain/GetEvents.java
+++ b/src/java/com/unifina/signalpath/blockchain/GetEvents.java
@@ -86,7 +86,7 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 
 	@Override
 	public void onStart() {
-		String rpcUrl = ethereumOptions.getRpcUrl();
+		String rpcUrl = ethereumOptions.getWebsocketRpcUri();
 		String contractAddress = contract.getValue().getAddress();
 		try {
 			contractEventPoller = new ContractEventPoller(rpcUrl, contractAddress, this);

--- a/src/java/com/unifina/signalpath/blockchain/GetEvents.java
+++ b/src/java/com/unifina/signalpath/blockchain/GetEvents.java
@@ -87,6 +87,10 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 	@Override
 	public void onStart() {
 		String rpcUrl = ethereumOptions.getWebsocketRpcUri();
+		if(rpcUrl == null){
+			rpcUrl = ethereumOptions.getRpcUrl();
+			log.warn("No websockets URI found in config for network "+ethereumOptions.getNetwork()+". Trying to run GetEvents over https RPC: "+rpcUrl);
+		}
 		String contractAddress = contract.getValue().getAddress();
 		try {
 			contractEventPoller = new ContractEventPoller(rpcUrl, contractAddress, this);

--- a/src/java/com/unifina/signalpath/blockchain/GetEvents.java
+++ b/src/java/com/unifina/signalpath/blockchain/GetEvents.java
@@ -221,6 +221,9 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 	@Override
 	protected void onConfiguration(Map<String, Object> config) {
 		super.onConfiguration(config);
+		ModuleOptions options = ModuleOptions.get(config);
+		ethereumOptions = EthereumModuleOptions.readFrom(options);
+
 		web3j = getWeb3j();
 		outputsByEvent = new HashMap<>();
 		web3jEvents = new HashMap<String, Event>();
@@ -252,8 +255,6 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 			}
 		}
 
-		ModuleOptions options = ModuleOptions.get(config);
-		ethereumOptions = EthereumModuleOptions.readFrom(options);
 	}
 
 	@Override

--- a/src/java/com/unifina/signalpath/blockchain/HttpEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/HttpEthereumJsonRpc.java
@@ -1,0 +1,70 @@
+package com.unifina.signalpath.blockchain;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.mashape.unirest.request.body.RequestBodyEntity;
+import org.json.JSONObject;
+
+import java.util.List;
+
+class HttpEthereumJsonRpc extends EthereumJsonRpc{
+	HttpEthereumJsonRpc(String url, JsonRpcResponseHandler handler) {
+		super(url, handler);
+	}
+
+	@Override
+	public void rpcCall(String method, List params, int callId) throws HttpStatusException, ErrorObjectException, com.mashape.unirest.http.exceptions.UnirestException {
+			HttpResponse<JsonNode> response = formRequest(method, params, callId).asJson();
+
+			if (statusCodeIsNot2XX(response.getStatus())) {
+				throw new HttpStatusException(response.getStatus(), response.getBody());
+			}
+
+			JSONObject responseJson = response.getBody().getObject();
+			if (responseJson.opt("error") != null) {
+				throw new ErrorObjectException(responseJson.optJSONObject("error"));
+			}
+			handler.processResponse(responseJson);
+	}
+
+
+	private RequestBodyEntity formRequest(String method, List params, int callId) {
+		return Unirest. post(url)
+				.header("Content-Type", "application/json")
+				.body(formRequestBody(method, params, callId));
+	}
+
+	private static boolean statusCodeIsNot2XX(int code) {
+		return code / 100 != 2;
+	}
+
+	abstract class RPCException extends Exception {
+		private RPCException(String message) {
+			super(String.format("JSON RPC error with server '%s': %s", url, message));
+		}
+	}
+
+
+	class HttpStatusException extends RPCException {
+		private HttpStatusException(int statusCode, JsonNode body) {
+			super(String.format("unexpected status code %d with content %s", statusCode, body));
+		}
+	}
+
+	class ErrorObjectException extends RPCException {
+		private final JSONObject errorObject;
+
+		private ErrorObjectException(JSONObject errorObject) {
+			super("response contained error object " + errorObject);
+			this.errorObject = errorObject;
+		}
+
+		public int getCode() {
+			return errorObject.optInt("code");
+		}
+	}
+}

--- a/src/java/com/unifina/signalpath/blockchain/JsonRpcResponseHandler.java
+++ b/src/java/com/unifina/signalpath/blockchain/JsonRpcResponseHandler.java
@@ -1,0 +1,11 @@
+package com.unifina.signalpath.blockchain;
+
+import org.json.JSONObject;
+
+/*
+processes raw JSON response
+ */
+
+public interface JsonRpcResponseHandler {
+	public void processResponse(JSONObject resp);
+}

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -2,12 +2,14 @@ package com.unifina.signalpath.blockchain;
 
 import com.google.gson.JsonParser;
 import org.apache.log4j.Logger;
+
 import javax.websocket.*;
 import javax.websocket.Session;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+
 import org.json.JSONObject;
 
 public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
@@ -44,15 +46,14 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 	}
 
 
-
 	@ClientEndpoint
-	protected class EthereumRpcEndpoint{
+	protected class EthereumRpcEndpoint {
 
 		@OnClose
-		public void onClose(Session session, CloseReason reason){
+		public void onClose(Session session, CloseReason reason) {
 			CloseReason.CloseCode code = reason.getCloseCode();
-			log.info("session "+session + "was closed. CloseReason: "+ reason);
-			if(reconnectOnError && code.getCode() != CloseReason.CloseCodes.NORMAL_CLOSURE.getCode() ) {
+			log.info("session " + session + "was closed. CloseReason: " + reason);
+			if (reconnectOnError && code.getCode() != CloseReason.CloseCodes.NORMAL_CLOSURE.getCode()) {
 				try {
 					log.info("Trying reconnect");
 					if (!openConnectionRetryIfFail()) {
@@ -64,10 +65,11 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 				}
 			}
 		}
+
 		@OnError
-		public void onError(Session session, Throwable t){
-			log.error("session "+session+ " reported error "+t.getMessage());
-			if(reconnectOnError) {
+		public void onError(Session session, Throwable t) {
+			log.error("session " + session + " reported error " + t.getMessage());
+			if (reconnectOnError) {
 				try {
 					log.info("Trying reconnect");
 					if (!openConnectionRetryIfFail()) {
@@ -82,7 +84,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 
 		@OnOpen
 		public void onOpen(Session session) {
-			log.info("opening websocket "+session);
+			log.info("opening websocket " + session);
 		}
 
 		@OnMessage
@@ -97,16 +99,16 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		}
 	}
 
-	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler){
-		super(url,handler);
+	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler) {
+		super(url, handler);
 		wsEndpoint = new EthereumRpcEndpoint();
 	}
 
 	public boolean openConnectionRetryIfFail() throws InterruptedException {
-		int attempts=0;
-		while(attemptReconnectionMaxTries < 0 || attempts < attemptReconnectionMaxTries){
+		int attempts = 0;
+		while (attemptReconnectionMaxTries < 0 || attempts < attemptReconnectionMaxTries) {
 			attempts++;
-			log.info("Trying to establish websocket connection to "+url+". Attempt number "+ attempts);
+			log.info("Trying to establish websocket connection to " + url + ". Attempt number " + attempts);
 			try {
 				openConnection();
 			} catch (URISyntaxException e) {
@@ -114,18 +116,18 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 				return false;
 			} catch (IOException | DeploymentException e) {
 				log.error(e);
-				log.info("Waiting "+attemptReconnectionWaittimeMs+"ms");
+				log.info("Waiting " + attemptReconnectionWaittimeMs + "ms");
 				Thread.sleep(attemptReconnectionWaittimeMs);
 				continue;
 			}
 			return true;
 		}
-		log.error("Couldnt establish connection to " + url + " after "+attempts +" attempts. Aborting.");
+		log.error("Couldnt establish connection to " + url + " after " + attempts + " attempts. Aborting.");
 		return false;
 	}
 
 	@Override
-	public void rpcCall(String method, List params, int callId){
+	public void rpcCall(String method, List params, int callId) {
 		wsEndpoint.sendMessage(formRequestBody(method, params, callId));
 	}
 
@@ -135,12 +137,11 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		container.setAsyncSendTimeout(asyncTimeoutMs);
 		try {
 			userSession = container.connectToServer(wsEndpoint, new URI(url));
-		}
-		catch(Exception e){
+		} catch (Exception e) {
 			e.printStackTrace();
 			throw e;
 		}
-		log.info("Websocket connection established to "+url);
+		log.info("Websocket connection established to " + url);
 	}
 
 	public void close() throws IOException {

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -47,6 +47,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler) throws URISyntaxException, IOException, DeploymentException {
 		super(url,handler);
 		wsEndpoint = new EthereumRpcEndpoint();
+		open();
 	}
 
 	public void rpcCall(String method, List params, int callId){

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -23,7 +23,11 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 
 		@OnClose
 		public void onClose(Session session) throws IOException {
-			session.close();
+			log.info("session "+session + "was closed");
+		}
+		@OnError
+		public void onError(Session session, Throwable t){
+			log.error("session "+session+ " reported error "+t.getMessage());
 		}
 
 		@OnOpen
@@ -58,11 +62,10 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 	public void open() throws URISyntaxException, IOException, DeploymentException {
 		WebSocketContainer container = ContainerProvider.getWebSocketContainer();
 		userSession = container.connectToServer(wsEndpoint, new URI(url));
-		wsEndpoint.onOpen(userSession);
 	}
 
 	public void close() throws IOException {
-		wsEndpoint.onClose(userSession);
+		userSession.close();
 	}
 }
 

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -1,0 +1,67 @@
+package com.unifina.signalpath.blockchain;
+
+import com.google.gson.JsonParser;
+import org.apache.log4j.Logger;
+import javax.websocket.*;
+import javax.websocket.Session;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
+	private static final Logger log = Logger.getLogger(WebsocketEthereumJsonRpc.class);
+	private EthereumRpcEndpoint wsEndpoint;
+	Session userSession = null;
+
+	@ClientEndpoint
+	protected class EthereumRpcEndpoint{
+
+		@OnClose
+		public void onClose(Session session) throws IOException {
+			session.close();
+		}
+
+		@OnOpen
+		public void onOpen(Session session) {
+			log.info("opening websocket");
+		//	userSession = session;
+		}
+
+		@OnMessage
+		public void onMessage(String message) {
+			JSONObject jso = new JSONObject((message));
+			handler.processResponse(jso);
+		}
+
+
+		public void sendMessage(String message) {
+			userSession.getAsyncRemote().sendText(message);
+		}
+	}
+
+	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler) throws URISyntaxException, IOException, DeploymentException {
+		super(url,handler);
+		wsEndpoint = new EthereumRpcEndpoint();
+	}
+
+	public void rpcCall(String method, List params, int callId){
+		wsEndpoint.sendMessage(formRequestBody(method, params, callId));
+	}
+
+
+	public void open() throws URISyntaxException, IOException, DeploymentException {
+		WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+		userSession = container.connectToServer(wsEndpoint, new URI(url));
+		wsEndpoint.onOpen(userSession);
+	}
+
+	public void close() throws IOException {
+		wsEndpoint.onClose(userSession);
+	}
+}
+

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -8,26 +8,76 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-
-import com.google.gson.JsonObject;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 	private static final Logger log = Logger.getLogger(WebsocketEthereumJsonRpc.class);
 	private EthereumRpcEndpoint wsEndpoint;
-	Session userSession = null;
+	private long attemptReconnectionWaittimeMs = 60000;
+	private long asyncTimeoutMs = 60000;
+	private int attemptReconnectionMaxTries = -1;
+	private Session userSession = null;
+	private boolean reconnectOnError = true;
+
+	public long getAttemptReconnectionWaittimeMs() {
+		return attemptReconnectionWaittimeMs;
+	}
+
+	public void setAttemptReconnectionWaittimeMs(long attemptReconnectionWaittimeMs) {
+		this.attemptReconnectionWaittimeMs = attemptReconnectionWaittimeMs;
+	}
+
+	public long getAsyncTimeoutMs() {
+		return asyncTimeoutMs;
+	}
+
+	public void setAsyncTimeoutMs(long asyncTimeoutMs) {
+		this.asyncTimeoutMs = asyncTimeoutMs;
+	}
+
+	public int getAttemptReconnectionMaxTries() {
+		return attemptReconnectionMaxTries;
+	}
+
+	public void setAttemptReconnectionMaxTries(int attemptReconnectionMaxTries) {
+		this.attemptReconnectionMaxTries = attemptReconnectionMaxTries;
+	}
+
+
 
 	@ClientEndpoint
 	protected class EthereumRpcEndpoint{
 
 		@OnClose
-		public void onClose(Session session) throws IOException {
-			log.info("session "+session + "was closed");
+		public void onClose(Session session, CloseReason reason){
+			CloseReason.CloseCode code = reason.getCloseCode();
+			log.info("session "+session + "was closed. CloseReason: "+ reason);
+			if(reconnectOnError && code.getCode() != CloseReason.CloseCodes.NORMAL_CLOSURE.getCode() ) {
+				try {
+					log.info("Trying reconnect");
+					if (!openConnectionRetryIfFail()) {
+						String err = "Couldnt reestablish connection to " + url;
+						throw new RuntimeException(err);
+					}
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
 		}
 		@OnError
 		public void onError(Session session, Throwable t){
 			log.error("session "+session+ " reported error "+t.getMessage());
+			if(reconnectOnError) {
+				try {
+					log.info("Trying reconnect");
+					if (!openConnectionRetryIfFail()) {
+						String err = "Couldnt reestablish connection to " + url;
+						throw new RuntimeException(err);
+					}
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
 		}
 
 		@OnOpen
@@ -47,10 +97,31 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		}
 	}
 
-	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler) throws URISyntaxException, IOException, DeploymentException {
+	public WebsocketEthereumJsonRpc(String url, JsonRpcResponseHandler handler){
 		super(url,handler);
 		wsEndpoint = new EthereumRpcEndpoint();
-		open();
+	}
+
+	public boolean openConnectionRetryIfFail() throws InterruptedException {
+		int attempts=0;
+		while(attemptReconnectionMaxTries < 0 || attempts < attemptReconnectionMaxTries){
+			attempts++;
+			log.info("Trying to establish websocket connection to "+url+". Attempt number "+ attempts);
+			try {
+				openConnection();
+			} catch (URISyntaxException e) {
+				log.error(e);
+				return false;
+			} catch (IOException | DeploymentException e) {
+				log.error(e);
+				log.info("Waiting "+attemptReconnectionWaittimeMs+"ms");
+				Thread.sleep(attemptReconnectionWaittimeMs);
+				continue;
+			}
+			return true;
+		}
+		log.error("Couldnt establish connection to " + url + " after "+attempts +" attempts. Aborting.");
+		return false;
 	}
 
 	@Override
@@ -59,9 +130,17 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 	}
 
 
-	public void open() throws URISyntaxException, IOException, DeploymentException {
+	public void openConnection() throws URISyntaxException, IOException, DeploymentException {
 		WebSocketContainer container = ContainerProvider.getWebSocketContainer();
-		userSession = container.connectToServer(wsEndpoint, new URI(url));
+		container.setAsyncSendTimeout(asyncTimeoutMs);
+		try {
+			userSession = container.connectToServer(wsEndpoint, new URI(url));
+		}
+		catch(Exception e){
+			e.printStackTrace();
+			throw e;
+		}
+		log.info("Websocket connection established to "+url);
 	}
 
 	public void close() throws IOException {

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -1,15 +1,11 @@
 package com.unifina.signalpath.blockchain;
 
-import com.google.gson.JsonParser;
-import org.apache.log4j.Logger;
-
-import javax.websocket.*;
-import javax.websocket.Session;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-
+import javax.websocket.*;
+import org.apache.log4j.Logger;
 import org.json.JSONObject;
 
 public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -28,13 +28,12 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 
 		@OnOpen
 		public void onOpen(Session session) {
-			log.info("opening websocket");
-		//	userSession = session;
+			log.info("opening websocket "+session);
 		}
 
 		@OnMessage
 		public void onMessage(String message) {
-			JSONObject jso = new JSONObject((message));
+			JSONObject jso = new JSONObject(message);
 			handler.processResponse(jso);
 		}
 
@@ -50,6 +49,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		open();
 	}
 
+	@Override
 	public void rpcCall(String method, List params, int callId){
 		wsEndpoint.sendMessage(formRequestBody(method, params, callId));
 	}


### PR DESCRIPTION
This PR allows GetEvents to poll event data over websockets instead of http. This is necessary to get event data from Infura nodes, which only support filters over websockets. Here are the major changes:

- I renamed EthereumJsonRpc as HttpEthereumJsonRpc and created a new class WebsocketsEthereumJsonRpc, Both HttpEthereumJsonRpc and WebsocketsEthereumJsonRpc  extend a common abstract base class EthereumJsonRpc. WebsocketsEthereumJsonRpc and HttpEthereumJsonRpc can be easily interchanged.
- rpcCall() no longer returns the RPC response, which is instead handled by an interface JsonRpcResponseHandler that is passed to the EthereumJsonRpc constructor. In the case of WebsocketsEthereumJsonRpc, the handler is called by another thread when the response arrives. In the case of HttpEthereumJsonRpc, the handler is invoked directly by rpcCall() in the same thread. This allows for both sync and async calls.
- ID's are actually used non-trivially now when sending RPC request, and the JsonRpcResponseHandler looks at the ID of the response to figure out which request it corresponds to.
- GetEvents first tries to get the websocket connection by looking at ("streamr.ethereum.wss." + network) config param. If it's not there, it falls back to http.

ContractEventPoller implements JsonRpcResponseHandler and GetEvents implements EventsListener (formerly ContractEventPoller.Listener), which follows only event logs and errors.