### PR TITLE
add endpoints and tests

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -52,7 +52,9 @@ class UrlMappings {
 		"/api/v1/streams/$id/confirmCsvFileUpload"(controller: "streamApi", action: "confirmCsvFileUpload")
 		"/api/v1/streams/$id/dataFiles"(controller: "streamApi", action: "dataFiles")
 		"/api/v1/streams/$id/publishers"(controller: "streamApi", action: "publishers")
+		"/api/v1/streams/$id/publisher/$address"(controller: "streamApi", action: "publisher")
 		"/api/v1/streams/$id/subscribers"(controller: "streamApi", action: "subscribers")
+		"/api/v1/streams/$id/subscriber/$address"(controller: "streamApi", action: "subscriber")
 		"/api/v1/streams/$id/status"(controller: "streamApi", action: "status")
 		"/api/v1/streams/$resourceId/keys"(resources: "keyApi", excludes: ["create", "edit", "update"]) { resourceClass = Stream }
 		"/api/v1/streams/$streamId/keys/$keyId"(method: "PUT", controller: "keyApi", action: "updateStreamKey")

--- a/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
@@ -187,6 +187,28 @@ class StreamApiController {
 		}
 	}
 
+	@StreamrApi
+	def publisher(String id, String address) {
+		getAuthorizedStream(id, Operation.READ) { Stream stream ->
+			if(streamService.isStreamEthereumPublisher(stream, address)) {
+				response.status = 200
+			} else {
+				response.status = 404
+			}
+		}
+	}
+
+	@StreamrApi
+	def subscriber(String id, String address) {
+		getAuthorizedStream(id, Operation.WRITE) { Stream stream ->
+			if(streamService.isStreamEthereumSubscriber(stream, address)) {
+				response.status = 200
+			} else {
+				response.status = 404
+			}
+		}
+	}
+
 	private def getAuthorizedStream(String id, Operation op, Closure action) {
 		def stream = Stream.get(id)
 		if (stream == null) {

--- a/grails-app/services/com/unifina/service/StreamService.groovy
+++ b/grails-app/services/com/unifina/service/StreamService.groovy
@@ -256,6 +256,14 @@ class StreamService {
 		return keys*.idInService as Set
 	}
 
+	boolean isStreamEthereumPublisher(Stream stream, String ethereumAddress) {
+		IntegrationKey key = IntegrationKey.findByIdInService(ethereumAddress)
+		if (key == null || key.user == null) {
+			return false
+		}
+		return permissionService.canWrite(key.user, stream)
+	}
+
 	Set<String> getStreamEthereumSubscribers(Stream stream) {
 		// This approach might be slow if there are a lot of allowed readers to the Stream
 		List<SecUser> readers = permissionService.getPermissionsTo(stream, Permission.Operation.READ)*.user
@@ -265,6 +273,14 @@ class StreamService {
 		}
 
 		return keys*.idInService as Set
+	}
+
+	boolean isStreamEthereumSubscriber(Stream stream, String ethereumAddress) {
+		IntegrationKey key = IntegrationKey.findByIdInService(ethereumAddress)
+		if (key == null || key.user == null) {
+			return false
+		}
+		return permissionService.canRead(key.user, stream)
 	}
 
 	List<Stream> getInboxStreams(List<SecUser> users) {

--- a/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
@@ -329,6 +329,36 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		]
 	}
 
+	void "return 200 if valid publisher"() {
+		setup:
+		controller.streamService = streamService = Mock(StreamService)
+		String address = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		when:
+		params.id = streamOne.id
+		params.address = address
+		request.method = "GET"
+		authenticatedAs(me) { controller.publisher() }
+
+		then:
+		1 * streamService.isStreamEthereumPublisher(streamOne, address) >> true
+		response.status == 200
+	}
+
+	void "return 404 if invalid publisher"() {
+		setup:
+		controller.streamService = streamService = Mock(StreamService)
+		String address = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		when:
+		params.id = streamOne.id
+		params.address = address
+		request.method = "GET"
+		authenticatedAs(me) { controller.publisher() }
+
+		then:
+		1 * streamService.isStreamEthereumPublisher(streamOne, address) >> false
+		response.status == 404
+	}
+
 	void "returns set of subscriber addresses"() {
 		setup:
 		controller.streamService = streamService = Mock(StreamService)
@@ -346,6 +376,36 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		response.json == [
 			'addresses': addresses.toArray()
 		]
+	}
+
+	void "return 200 if valid subscriber"() {
+		setup:
+		controller.streamService = streamService = Mock(StreamService)
+		String address = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		when:
+		params.id = streamOne.id
+		params.address = address
+		request.method = "GET"
+		authenticatedAs(me) { controller.subscriber() }
+
+		then:
+		1 * streamService.isStreamEthereumSubscriber(streamOne, address) >> true
+		response.status == 200
+	}
+
+	void "return 404 if invalid subscriber"() {
+		setup:
+		controller.streamService = streamService = Mock(StreamService)
+		String address = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		when:
+		params.id = streamOne.id
+		params.address = address
+		request.method = "GET"
+		authenticatedAs(me) { controller.subscriber() }
+
+		then:
+		1 * streamService.isStreamEthereumSubscriber(streamOne, address) >> false
+		response.status == 404
 	}
 
 	void "streams status"() {

--- a/test/unit/com/unifina/service/StreamServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamServiceSpec.groovy
@@ -449,6 +449,30 @@ class StreamServiceSpec extends Specification {
 		addresses == validAddresses
 	}
 
+	void "isStreamEthereumPublisher should return true iff user has write permission to the stream"() {
+		setup:
+		service.permissionService = Mock(PermissionService)
+		SecUser user1 = new SecUser(id: 1, username: "u1").save(failOnError: true, validate: false)
+		String address1 = "0x9fe1ae3f5efe2a01eca8c2e9d3c11102cf4bea57"
+		new IntegrationKey(user: user1, service: IntegrationKey.Service.ETHEREUM_ID,
+			idInService: address1).save(failOnError: true, validate: false)
+		SecUser user2 = new SecUser(id: 2, username: "u2").save(failOnError: true, validate: false)
+		String address2 = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		new IntegrationKey(user: user2, service: IntegrationKey.Service.ETHEREUM,
+			idInService: address2).save(failOnError: true, validate: false)
+		Stream stream = new Stream(name: "name")
+		stream.id = "streamId"
+		stream.save(failOnError: true, validate: false)
+		when:
+		boolean result1 = service.isStreamEthereumPublisher(stream, address1)
+		boolean result2 = service.isStreamEthereumPublisher(stream, address2)
+		then:
+		1 * service.permissionService.canWrite(user1, stream) >> true
+		result1
+		1 * service.permissionService.canWrite(user2, stream) >> false
+		!result2
+	}
+
 	void "getStreamEthereumSubscribers should return Ethereum addresses of users with read permission to the Stream"() {
 		setup:
 		service.permissionService = Mock(PermissionService)
@@ -480,6 +504,30 @@ class StreamServiceSpec extends Specification {
 		then:
 		1 * service.permissionService.getPermissionsTo(stream, Permission.Operation.READ) >> perms
 		addresses == validAddresses
+	}
+
+	void "isStreamEthereumSubscriber should return true iff user has read permission to the stream"() {
+		setup:
+		service.permissionService = Mock(PermissionService)
+		SecUser user1 = new SecUser(id: 1, username: "u1").save(failOnError: true, validate: false)
+		String address1 = "0x9fe1ae3f5efe2a01eca8c2e9d3c11102cf4bea57"
+		new IntegrationKey(user: user1, service: IntegrationKey.Service.ETHEREUM_ID,
+			idInService: address1).save(failOnError: true, validate: false)
+		SecUser user2 = new SecUser(id: 2, username: "u2").save(failOnError: true, validate: false)
+		String address2 = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
+		new IntegrationKey(user: user2, service: IntegrationKey.Service.ETHEREUM,
+			idInService: address2).save(failOnError: true, validate: false)
+		Stream stream = new Stream(name: "name")
+		stream.id = "streamId"
+		stream.save(failOnError: true, validate: false)
+		when:
+		boolean result1 = service.isStreamEthereumSubscriber(stream, address1)
+		boolean result2 = service.isStreamEthereumSubscriber(stream, address2)
+		then:
+		1 * service.permissionService.canRead(user1, stream) >> true
+		result1
+		1 * service.permissionService.canRead(user2, stream) >> false
+		!result2
 	}
 
 	void "getInboxStreams() returns all inbox streams of the users"() {


### PR DESCRIPTION
2 new endpoints to check if an Ethereum address is a valid publisher/subscriber. Uses HTTP codes 200 and 404 as responses.

This is needed to optimise both signature verification and the key exchange mechanism.