### PR TITLE
Fix invalid send in case of tx error

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
+++ b/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
@@ -542,7 +542,9 @@ public class SendEthereumTransaction extends ModuleWithSideEffects {
 			}
 		} else if (rslt instanceof TransactionResult) {
 			TransactionResult tx = (TransactionResult) rslt;
-			txHash.send(tx.getTransactionHash());
+			if (tx.getTransactionHash() != null) {
+				txHash.send(tx.getTransactionHash());
+			}
 
 			TransactionReceipt txreceipt = tx.getTransactionReceipt();
 			if(txreceipt != null){


### PR DESCRIPTION
I was using `SendEthereumTransaction` a bit. I noticed that if an error occurs (in my case, insufficient ETH for gas), the module will still attempt to send out (at least) the tx hash, which in my case is `null` and causes an exception.