### PR TITLE
CORE-1778: Improve canvas sharing email message

### DIFF
--- a/grails-app/views/emails/_email_share_invite.gsp
+++ b/grails-app/views/emails/_email_share_invite.gsp
@@ -1,9 +1,7 @@
 <p>Hello,<br></p>
 
-<p>${sharer} wants to share a document with you on <a href="streamr.com">Streamr</a> real-time data platform.<br>
-We are honored to invite you to join us!</p>
-
-<p>Please <g:link controller="register" action="register" absolute="true" params="[invite:invite.code]">complete your registration</g:link> to view the document.</p>
+<p>${sharer} wants to share a canvas with you on the <a href="https://www.streamr.com/core/">Streamr Core</a> real-time data app.<br/>
+Please <g:link controller="register" action="register" absolute="true" params="[invite:invite.code]">complete your registration</g:link> to view the canvas.</p>
 
 <p></p>
 


### PR DESCRIPTION
Email looks like this:
![image](https://user-images.githubusercontent.com/68578/63263191-973dce00-c290-11e9-9cbf-d8bc81444ee6.png)

I changed Streamr Core link to point to https://www.streamr.com/core/