### PR TITLE
Clarify allowed and disallowed product updates to the database

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -7,6 +7,7 @@ import com.unifina.api.CannotRemoveEthereumKeyException
 import com.unifina.api.CanvasCommunicationException
 import com.unifina.api.ChallengeVerificationFailedException
 import com.unifina.api.DisabledUserException
+import com.unifina.api.FieldCannotBeUpdatedException
 import com.unifina.api.InvalidAPIKeyException
 import com.unifina.api.InvalidSessionTokenException
 import com.unifina.api.InvalidStateException
@@ -32,6 +33,7 @@ class ErrorController {
 		InvalidUsernameAndPasswordException: { InvalidUsernameAndPasswordException e -> new ApiError(401, "INVALID_USERNAME_PASSWORD_ERROR", e.message)},
 		InvalidAPIKeyException: { InvalidAPIKeyException e -> new ApiError(401, "INVALID_API_KEY_ERROR", e.message)},
 		BadRequestException: { BadRequestException e -> new ApiError(400, "PARAMETER_MISSING", e.message)},
+		FieldCannotBeUpdatedException: { FieldCannotBeUpdatedException e -> new ApiError(422, "FIELD_CANNOT_BE_UPDATED", e.message)}
 	]
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)

--- a/src/groovy/com/unifina/api/UpdateProductCommand.groovy
+++ b/src/groovy/com/unifina/api/UpdateProductCommand.groovy
@@ -24,6 +24,23 @@ class UpdateProductCommand {
 	Product.Currency priceCurrency
 	Long minimumSubscriptionInSeconds
 
+	public static final List<String> offChainFields = [
+		"name",
+		"description",
+		"streams",
+		"category",
+		"previewStream",
+		"previewConfigJson"
+	]
+
+	public static final List<String> onChainFields = [
+		"ownerAddress",
+		"beneficiaryAddress",
+		"pricePerSecond",
+		"priceCurrency",
+		"minimumSubscriptionInSeconds"
+	]
+
 	static constraints = {
 		name(blank: false)
 		description(blank: false)
@@ -39,20 +56,28 @@ class UpdateProductCommand {
 
 	@GrailsCompileStatic
 	void updateProduct(Product product) {
-		product.name = name
-		product.description = description
-		product.streams = streams
-		product.category = category
-		product.previewStream = previewStream
-		product.previewConfigJson = previewConfigJson
+		// Always update off-chain fields if given
+		offChainFields.forEach { String fieldName ->
+			product[fieldName] = this[fieldName]
+		}
 
-		// These fields can only be changed by the user in NOT_DEPLOYED state
-		if (product.state == Product.State.NOT_DEPLOYED) {
-			product.ownerAddress = ownerAddress
-			product.beneficiaryAddress = beneficiaryAddress
-			product.pricePerSecond = pricePerSecond
-			product.priceCurrency = priceCurrency
-			product.minimumSubscriptionInSeconds = minimumSubscriptionInSeconds
+		// Prevent deployed products from changing from free to paid
+		if (product.pricePerSecond == 0 && product.state == Product.State.DEPLOYED && this.pricePerSecond > 0) {
+			throw new FieldCannotBeUpdatedException("Published products can't be changed from free to paid.")
+		}
+
+		// Prevent the user from changing on-chain fields of paid deployed products.
+		// They must be updated on the smart contract and updated by the watcher.
+		List changedOnChainFields = onChainFields.findAll {this[it] != null && this[it] != product[it]}
+		if (product.pricePerSecond > 0 && product.state == Product.State.DEPLOYED && !changedOnChainFields.isEmpty()) {
+			throw new FieldCannotBeUpdatedException("For published paid products, the following fields can only be updated on the smart contract: ${onChainFields}. You tried to change fields: ${changedOnChainFields}")
+		}
+
+		// Otherwise all good. Update on-chain fields only if given (they can be omitted).
+		onChainFields.forEach { String fieldName ->
+			if (this[fieldName] != null) {
+				product[fieldName] = this[fieldName]
+			}
 		}
 	}
 }

--- a/src/java/com/unifina/api/FieldCannotBeUpdatedException.java
+++ b/src/java/com/unifina/api/FieldCannotBeUpdatedException.java
@@ -1,0 +1,9 @@
+package com.unifina.api;
+
+public class FieldCannotBeUpdatedException extends RuntimeException {
+
+	public FieldCannotBeUpdatedException(String message) {
+		super(message);
+	}
+
+}

--- a/test/unit/com/unifina/api/UpdateProductCommandSpec.groovy
+++ b/test/unit/com/unifina/api/UpdateProductCommandSpec.groovy
@@ -62,15 +62,32 @@ class UpdateProductCommandSpec extends Specification {
 		)
 	}
 
-	void "updateProduct() updates only non-blockchain fields of deployed Products"() {
+	void "updateProduct() throws when trying to update on-chain fields on a deployed paid product"() {
 		product.state = Product.State.DEPLOYED
+		product.pricePerSecond = 5
+
+		when:
+		command.updateProduct(product)
+
+		then:
+		thrown(FieldCannotBeUpdatedException)
+	}
+
+	void "updateProduct() updates all off-chain fields on a deployed paid product"() {
+		product.state = Product.State.DEPLOYED
+		product.pricePerSecond = 5
+
+		// Don't provide any of the on-chain fields
+		UpdateProductCommand.onChainFields.each {
+			command[it] = null
+		}
 
 		when:
 		command.updateProduct(product)
 
 		then:
 		product.toMap() == [
-		    id: "product-id",
+			id: "product-id",
 			type: "NORMAL",
 			state: "DEPLOYED",
 			created: null,
@@ -93,8 +110,9 @@ class UpdateProductCommandSpec extends Specification {
 		]
 	}
 
-	void "updateProduct() updates non-blockchain and blockchain fields of undeployed Products"() {
+	void "updateProduct() updates both on-chain and off-chain fields on non-deployed paid Products"() {
 		product.state = Product.State.NOT_DEPLOYED
+		product.pricePerSecond = 5
 
 		when:
 		command.updateProduct(product)
@@ -123,4 +141,50 @@ class UpdateProductCommandSpec extends Specification {
 			minimumSubscriptionInSeconds: 10L
 		]
 	}
+
+	void "updateProduct() updates both on-chain and off-chain fields on deployed free Products"() {
+		product.state = Product.State.DEPLOYED
+		product.pricePerSecond = 0
+		command.pricePerSecond = 0
+
+		when:
+		command.updateProduct(product)
+
+		then:
+		product.toMap() == [
+			id: "product-id",
+			type: "NORMAL",
+			state: "DEPLOYED",
+			created: null,
+			updated: null,
+			owner: "John Doe",
+			name: "new name",
+			description: "new description",
+			imageUrl: "image.jpg",
+			thumbnailUrl: "thumb.jpg",
+			category: "new-category-id",
+			streams: ["new-stream-id"],
+			previewStream: "new-stream-id",
+			previewConfigJson: "{newConfig: true}",
+			ownerAddress: "0xA",
+			beneficiaryAddress: "0xF",
+			pricePerSecond: "0",
+			isFree: true,
+			priceCurrency: "USD",
+			minimumSubscriptionInSeconds: 10L
+		]
+	}
+
+	void "updateProduct() throws when trying to change a free product to paid product when in deployed state"() {
+		product.state = Product.State.DEPLOYED
+		product.pricePerSecond = 0
+		command.pricePerSecond = 5
+
+		when:
+		command.updateProduct(product)
+
+		then:
+		thrown(FieldCannotBeUpdatedException)
+	}
+
 }


### PR DESCRIPTION
After chatting with @juhah, I went through the backend code related to updating `Product` objects, and tweaked and clarified it a little:

- The backend now throws if the user tries to change any of the on-chain fields of deployed paid products. This will help the front-end devs by informing they're trying to do something illegal.
- When updating a deployed paid product, the frontend can avoid the exception by either omitting the on-chain fields completely, or providing values equal to the old values. Neither approach will trigger the exception.

To summarize, the rules are:

- Updating on-chain fields of `DEPLOYED` paid products is always illegal.
- Updating off-chain fields is always allowed.
- Updating all fields of `NOT_DEPLOYED` products is always allowed.
- Updating all fields of free products is allowed **except** changing their price to a nonzero value.
