### PR TITLE
CORE-1794-compile-without-account

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/SolidityCompileDeploy.java
+++ b/src/java/com/unifina/signalpath/blockchain/SolidityCompileDeploy.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.unifina.signalpath.*;
 import com.unifina.utils.MapTraversal;
+import jdk.nashorn.internal.codegen.CompilationException;
 import org.apache.log4j.Logger;
 import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.web3j.abi.TypeDecoder;
@@ -42,6 +43,11 @@ public class SolidityCompileDeploy extends ModuleWithUI implements Pullable<Ethe
 	private EthereumModuleOptions ethereumOptions = new EthereumModuleOptions();
 	private Web3j web3j;
 
+	public static class CompilationException extends Exception{
+		public CompilationException(String msg){
+			super(msg);
+		}
+	}
 	@Override
 	public void init() {
 		addInput(ethereumAccount);
@@ -96,23 +102,14 @@ public class SolidityCompileDeploy extends ModuleWithUI implements Pullable<Ethe
 		return result;
 	}
 
-	protected JsonObject compile(String solidity_code) {
+	protected JsonObject compile(String solidity_code) throws IOException, CompilationException {
 		String result = null;
-		String errors = null;
-		try {
-			SolidityCompiler.Result res = SolidityCompiler.compile(solidity_code.getBytes(StandardCharsets.UTF_8), true, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
-			if (res.isFailed()) {
-				errors = res.errors;
-			} else {
-				result = res.output;
-			}
-		} catch (IOException e) {
-			errors = e.getLocalizedMessage();
+		SolidityCompiler.Result res = SolidityCompiler.compile(solidity_code.getBytes(StandardCharsets.UTF_8), true, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+		if (res.isFailed()) {
+			throw new CompilationException(res.errors);
+		} else {
+			result = res.output;
 		}
-		if (errors != null) {
-			throw new RuntimeException("Error compiling contract: " + errors);
-		}
-
 		JsonObject entries = new JsonParser().parse(result).getAsJsonObject().get("contracts").getAsJsonObject();
 		return chooseMainContract(entries);
 	}
@@ -201,18 +198,29 @@ public class SolidityCompileDeploy extends ModuleWithUI implements Pullable<Ethe
 			}
 
 			boolean hasCode = code != null && !code.trim().isEmpty();
-			boolean hasDeployer = ethereumAccount.getAddress() != null;
-			if (hasCode && hasDeployer) {
-				compilationResult = compile(code);
+			if (hasCode) {
+				try {
+					compilationResult = compile(code);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				} catch (CompilationException e) {
+					throw new RuntimeException(e);
+				}
 				contract = new EthereumContract(null, new EthereumABI(new JsonParser().parse(compilationResult.get("abi").getAsString()).getAsJsonArray()), null);
 			}
 		} else if (config.get("code") != null) {
 			code = config.get("code").toString();
 		}
-
-		if (contract != null) {
-			contract.setNetwork(ethereumOptions.getNetwork());
-			if (deployRequested && compilationResult != null) {
+		if (contract == null) {
+			return;
+		}
+		contract.setNetwork(ethereumOptions.getNetwork());
+		if (deployRequested) {
+			if (compilationResult == null) {
+				throw new RuntimeException("Can't deploy contract because contract is not compiled. Doing nothing.");
+			} else if (ethereumAccount.getPrivateKey() == null) {
+				throw new RuntimeException("Can't deploy contract because no private key is selected to sign. Doing nothing.");
+			} else {
 				// transform Streamr params into list of constructor arguments
 				Stack<Object> args = new Stack<>();
 				List<Map> params = (List) config.get("params");
@@ -238,9 +246,9 @@ public class SolidityCompileDeploy extends ModuleWithUI implements Pullable<Ethe
 					throw new RuntimeException(e);
 				}
 			}
-			createContractOutput();
-			createParameters(contract.getABI());
 		}
+		createContractOutput();
+		createParameters(contract.getABI());
 	}
 
 	private void createContractOutput() {

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
@@ -206,7 +206,7 @@ class SolidityCompileDeploySpec extends ModuleTestingSpecification {
 		when:
 		applyConfig.contract.abi[2].payable = true
 		applyConfig.code = payable_constructor
-		applyConfig << [deploy: false]
+		applyConfig.remove("deploy")
 		module = new ModifiedSolidityCompileDeploy(null)
 		module.onConfiguration(applyConfig)
 		byte[] bytes = serializationService.serialize(module)

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
@@ -206,6 +206,7 @@ class SolidityCompileDeploySpec extends ModuleTestingSpecification {
 		when:
 		applyConfig.contract.abi[2].payable = true
 		applyConfig.code = payable_constructor
+		applyConfig << [deploy: false]
 		module = new ModifiedSolidityCompileDeploy(null)
 		module.onConfiguration(applyConfig)
 		byte[] bytes = serializationService.serialize(module)

--- a/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
+++ b/test/unit/com/unifina/signalpath/blockchain/SolidityCompileDeploySpec.groovy
@@ -216,6 +216,30 @@ class SolidityCompileDeploySpec extends ModuleTestingSpecification {
 		module.pullValue(module.getOutput("contract")) != null
 	}
 
+	void "compile works with null ethAccount"() {
+		when:
+		applyConfig.params[0].value = null
+		// set ethereum account
+		module.inputs[0].setConfiguration(applyConfig.params[0])
+		module.onConfiguration(applyConfig)
+
+		then:
+		module.pullValue(module.getOutput("contract")) != null
+	}
+
+	void "deploy doesn't work with null ethAccount"() {
+		when:
+		applyConfig.params[0].value = null
+		applyConfig << [deploy: true]
+		// set ethereum account
+		module.inputs[0].setConfiguration(applyConfig.params[0])
+		module.onConfiguration(applyConfig)
+
+		then:
+		def e = thrown(RuntimeException)
+		e.message.contains("no private key is selected")
+	}
+
 	static Map applyConfig = new Gson().fromJson('''
 {
     "contract":


### PR DESCRIPTION
- Compile button works when no account is selected in SolidityCompileDeploy, So you can see if your code compiles, but not much else. I think a [copy ABI button](https://streamr.atlassian.net/browse/PLATFORM-1023) would be useful here to copy the generated ABI into a GetContractAt module.
- Compile shows errors in this case
- Deploy throws an exception when no account selected. I think it should be **disabled** if no Ethreum account is selected. Why show an option that just throws an error?
