### PR TITLE
Add `dataType` to HTTP module

### DIFF
--- a/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
+++ b/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
@@ -345,20 +345,6 @@ public abstract class AbstractHttpModule extends ModuleWithSideEffects implement
 	@Override
 	public void clearState() {}
 
-	public static class DataTypeParameter extends StringParameter {
-		private List<PossibleValue> possibleValues;
-
-		public DataTypeParameter(AbstractSignalPathModule owner, String name, String defaultValue, List<PossibleValue> options) {
-			super(owner, name, defaultValue);
-			possibleValues = options;
-		}
-
-		@Override
-		protected List<PossibleValue> getPossibleValues() {
-			return possibleValues;
-		}
-	}
-
 	public static class VerbParameter extends StringParameter {
 		public VerbParameter(AbstractSignalPathModule owner, String name) {
 			super(owner, name, "POST"); //this.getValueList()[0]);

--- a/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
+++ b/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
@@ -345,6 +345,20 @@ public abstract class AbstractHttpModule extends ModuleWithSideEffects implement
 	@Override
 	public void clearState() {}
 
+	public static class DataTypeParameter extends StringParameter {
+		private List<PossibleValue> possibleValues;
+
+		public DataTypeParameter(AbstractSignalPathModule owner, String name, String defaultValue, List<PossibleValue> options) {
+			super(owner, name, defaultValue);
+			possibleValues = options;
+		}
+
+		@Override
+		protected List<PossibleValue> getPossibleValues() {
+			return possibleValues;
+		}
+	}
+
 	public static class VerbParameter extends StringParameter {
 		public VerbParameter(AbstractSignalPathModule owner, String name) {
 			super(owner, name, "POST"); //this.getValueList()[0]);

--- a/src/java/com/unifina/signalpath/remote/Http.java
+++ b/src/java/com/unifina/signalpath/remote/Http.java
@@ -154,12 +154,12 @@ public class Http extends AbstractHttpModule {
 						dt = getDataType(entity);
 					}
 
-					if (dt.equals("binary")) {
+					if ("binary".equals(dt)) {
 						responseData.send(EntityUtils.toByteArray(entity));
 					} else {
 						String responseString = EntityUtils.toString(entity, "UTF-8");
 
-						if (dt.equals("text")) {
+						if ("text".equals(dt)) {
 							responseData.send(responseString);
 						} else {
 							if (responseString.isEmpty()) {

--- a/src/java/com/unifina/signalpath/remote/Http.java
+++ b/src/java/com/unifina/signalpath/remote/Http.java
@@ -208,4 +208,18 @@ public class Http extends AbstractHttpModule {
 	protected String getDummyNotificationMessage() {
 		return "HTTP " + verb.getValue() + " request sent to " + URL.getValue();
 	}
+
+	public static class DataTypeParameter extends StringParameter {
+		private List<PossibleValue> possibleValues;
+
+		public DataTypeParameter(AbstractSignalPathModule owner, String name, String defaultValue, List<PossibleValue> options) {
+			super(owner, name, defaultValue);
+			possibleValues = options;
+		}
+
+		@Override
+		protected List<PossibleValue> getPossibleValues() {
+			return possibleValues;
+		}
+	}
 }


### PR DESCRIPTION
Hi guys,

I wanna use the HTTP module for public site's blog section. The problem is that it doesn't handle non-JSON responses very well. I've managed to squeeze the first 13 bytes out of the body of what's clearly an XML but that's all. And it's also kinda weird that our JSON parser lets it be, at all. 13 bytes? A bit confusing. Here's an example of the "13":

![Oct-16-2019 10-44-00](https://user-images.githubusercontent.com/320066/66904245-0b33f280-f004-11e9-9144-da35653274c0.gif)

_URL: https://medium.com/feed/streamrblog_

—

Anyway, in this PR I add another parameter to the HTTP module aiming at making it more useful. I named it `dataType`. It starts off being set to `auto` which more or less mimics the previous behaviour. Next to it stands: `json`, `text` and `binary`. Here's what I initially expected to see (which now works!):

![Oct-16-2019 10-53-22](https://user-images.githubusercontent.com/320066/66904354-33bbec80-f004-11e9-8e52-3e353deb906c.gif)

So, in short, use
- `auto` for the previous behaviour,
- `binary` to get what `toByteArray` gives (binary streams),
- `text` for a utf-8 representation of the response data, and
- `json` for the old default.

Let me know your thoughts.