### PR TITLE
Logging tweaks

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -121,6 +121,9 @@ log4j.main = {
 		info 'stdout'
 	}
 
+	// No need to log all exceptions thrown in API calls. For example, InvalidAPIKeyExceptions easily pollute the logs.
+	fatal 'org.codehaus.groovy.grails.web.errors.GrailsExceptionResolver'
+
 	error 'org.codehaus.groovy.grails.web.servlet',  //  controllers
 		'org.codehaus.groovy.grails.web.pages', //  GSP
 		'org.codehaus.groovy.grails.web.sitemesh', //  layouts

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -140,6 +140,7 @@ log4j.main = {
 	warn 'org.mortbay.log',
 		'org.codehaus.groovy.grails.domain.GrailsDomainClassCleaner'
 
+	// Turn on debug logging for a few classes to debug join issue in prod
 	debug 'com.streamr.client',
 		'com.unifina.service.CommunityJoinRequestService',
 		'com.unifina.service.StreamrClientService'

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -139,6 +139,10 @@ log4j.main = {
 
 	warn 'org.mortbay.log',
 		'org.codehaus.groovy.grails.domain.GrailsDomainClassCleaner'
+
+	debug 'com.streamr.client',
+		'com.unifina.service.CommunityJoinRequestService',
+		'com.unifina.service.StreamrClientService'
 }
 
 /**

--- a/grails-app/conf/com/unifina/filters/UnifinaCoreAPIFilters.groovy
+++ b/grails-app/conf/com/unifina/filters/UnifinaCoreAPIFilters.groovy
@@ -48,11 +48,6 @@ class UnifinaCoreAPIFilters {
 	}
 
 	def filters = {
-		apiFilter(uri: '/api/**') {
-			before = {
-				request.isApiAction = true
-			}
-		}
 		authenticationFilter(uri: '/api/**', uriExclude: '/api/v1/login/**') {
 			before = {
 				StreamrApi annotation = getApiAnnotation(controllerName, actionName)

--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -63,7 +63,7 @@ class ErrorController {
 		}
 
 		// Log internal errors
-		if (apiError.statusCode == 500) {
+		if (apiError.statusCode >= 500 && apiError.statusCode < 600) {
 			log.error("Unexpected error occurred, returning status code 500", exception)
 		}
 

--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -40,11 +40,7 @@ class ErrorController {
 	def index() {
 		try {
 			Exception exception = request.exception.cause ?: request.exception
-			if (request.isApiAction) {
-				renderAsJson(exception)
-			} else {
-				[exception: exception]
-			}
+			renderAsJson(exception)
 		} catch (Exception e) {
 			// Avoid infinite loop by catching any "error while showing error" -type of situation
 			log.error("Failed to render exception!", e)

--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -66,6 +66,11 @@ class ErrorController {
 			apiError = new ApiError(500, exception.class.simpleName, exception.getMessage())
 		}
 
+		// Log internal errors
+		if (apiError.statusCode == 500) {
+			log.error("Unexpected error occurred, returning status code 500", exception)
+		}
+
 		response.status = apiError.statusCode
 		render(apiError.toMap() as JSON)
 	}

--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -10,10 +10,13 @@ import com.streamr.client.options.StreamrClientOptions
 import com.unifina.domain.security.Key
 import com.unifina.utils.MapTraversal
 import grails.util.Holders
+import org.apache.log4j.Logger
 
 import java.lang.reflect.Constructor
 
 class StreamrClientService {
+
+	private static final Logger log = Logger.getLogger(StreamrClientService)
 
 	StreamrClient instanceForThisEngineNode
 	Constructor<StreamrClient> clientConstructor
@@ -52,7 +55,9 @@ class StreamrClientService {
 	StreamrClient getInstanceForThisEngineNode() {
 		if (!instanceForThisEngineNode) {
 			String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
+			log.debug("Creating StreamrClient instance for this Engine node. Using private key ${nodePrivateKey?.substring(0,2)}...")
 			instanceForThisEngineNode = createInstance(new EthereumAuthenticationMethod(nodePrivateKey))
+			log.debug("StreamrClient instance created. State: ${instanceForThisEngineNode.getState()}")
 		}
 		return instanceForThisEngineNode
 	}

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -115,7 +115,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			return;
 		}
 		try {
-			log.info(String.format("Polling filter '%s'.", filterId));
+			log.debug(String.format("Polling filter '%s'.", filterId));
 			rpc.rpcCall("eth_getFilterChanges", singletonList(filterId), ID_POLLFILTER);
 		}  catch (HttpEthereumJsonRpc.RPCException | JSONException e) {
 			listener.onError(e.getMessage());

--- a/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
+++ b/src/java/com/unifina/signalpath/remote/AbstractHttpModule.java
@@ -212,7 +212,7 @@ public abstract class AbstractHttpModule extends ModuleWithSideEffects implement
 			if (getRootSignalPath() != null && getRootSignalPath().getCanvas() != null) {
 				canvasId = getRootSignalPath().getCanvas().getId();
 			}
-			log.info("HTTP request " + request.toString() + " from canvas " + canvasId);
+			log.debug("HTTP request " + request.toString() + " from canvas " + canvasId);
 		} catch (Exception e) {
 			response.errors.add("Constructing HTTP request failed");
 			response.errors.add(e.getMessage());
@@ -294,17 +294,16 @@ public abstract class AbstractHttpModule extends ModuleWithSideEffects implement
 			}
 		});
 
-		// TODO: remove
 		if (!hasDebugLogged && getRootSignalPath() != null && getRootSignalPath().getCanvas() != null) {
 			hasDebugLogged = true;
-			log.info("Created HttpClient from canvas " + getRootSignalPath().getCanvas().getId());
+			log.debug("Created HttpClient from canvas " + getRootSignalPath().getCanvas().getId());
 			Set<Thread> threads = Thread.getAllStackTraces().keySet();
 			for (Thread t : threads) {
 				if (t.getName().startsWith("I/O dispatcher")) {
-					log.info(t.getName());
+					log.debug(t.getName());
 				}
 			}
-			log.info("end of threads.");
+			log.debug("end of threads.");
 		}
 
 		if (!isAsync) {

--- a/test/integration/com/unifina/service/CommunityJoinRequestServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/CommunityJoinRequestServiceIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 package com.unifina.service
 
 import com.streamr.client.StreamrClient
+import com.streamr.client.options.StreamrClientOptions
 import com.unifina.api.NotFoundException
 import com.unifina.api.UpdateCommunityJoinRequestCommand
 import com.unifina.domain.community.CommunityJoinRequest
@@ -44,6 +45,7 @@ class CommunityJoinRequestServiceIntegrationSpec extends Specification {
 		service.streamrClientService = Mock(StreamrClientService)
 		streamrClientMock = Mock(StreamrClient)
 		streamrClientMock.getStream(joinPartStream.id) >> joinPartStream
+		streamrClientMock.getOptions() >> Mock(StreamrClientOptions)
 		service.streamrClientService.getInstanceForThisEngineNode() >> streamrClientMock
 
 		service.ethereumService = Mock(EthereumService)

--- a/test/unit/com/unifina/controller/api/ErrorControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/ErrorControllerSpec.groovy
@@ -12,7 +12,6 @@ class ErrorControllerSpec extends Specification {
 	void "Generic exception rendering"() {
 		when:
 		request.exception = new Exception(new RuntimeException("test message"))
-		request.isApiAction = true
 		controller.index()
 
 		then:
@@ -23,7 +22,6 @@ class ErrorControllerSpec extends Specification {
 	void "APIExceptions must be rendered using the status code and string code provided"() {
 		when:
 		request.exception = new Exception(new ApiException(404, "TEST_CODE", "test message"))
-		request.isApiAction = true
 		controller.index()
 
 		then:
@@ -34,7 +32,6 @@ class ErrorControllerSpec extends Specification {
 	void "Some exceptions can have special rendering"() {
 		when:
 		request.exception = new Exception(new CanvasUnreachableException())
-		request.isApiAction = true
 		controller.index()
 
 		then:
@@ -45,7 +42,6 @@ class ErrorControllerSpec extends Specification {
 	void "Use the top-level exception if no cause is given"() {
 		when:
 		request.exception = new CanvasUnreachableException()
-		request.isApiAction = true
 		controller.index()
 
 		then:
@@ -56,7 +52,6 @@ class ErrorControllerSpec extends Specification {
 	void "Must catch exceptions that occur during rendering of an error"() {
 		when:
 		request.exception = new Exception(new ThrowingApiException(500, "CODE", "MESSAGE"))
-		request.isApiAction = true
 		controller.index()
 
 		then:

--- a/test/unit/com/unifina/service/CommunityJoinRequestServiceSpec.groovy
+++ b/test/unit/com/unifina/service/CommunityJoinRequestServiceSpec.groovy
@@ -1,6 +1,7 @@
 package com.unifina.service
 
 import com.streamr.client.StreamrClient
+import com.streamr.client.options.StreamrClientOptions
 import com.unifina.BeanMockingSpecification
 import com.unifina.api.ApiException
 import com.unifina.api.CommunityJoinRequestCommand
@@ -38,6 +39,7 @@ class CommunityJoinRequestServiceSpec extends BeanMockingSpecification {
 
 		streamrClientMock = Mock(StreamrClient)
 		streamrClientMock.getStream(joinPartStream.id) >> joinPartStream
+		streamrClientMock.getOptions() >> Mock(StreamrClientOptions)
 		service.streamrClientService.getInstanceForThisEngineNode() >> streamrClientMock
 
 		me = new SecUser(


### PR DESCRIPTION
- Reduce noise from `AbstractHttpModule` and `ContractEventPoller`
- Cleanup code related to exception logging
- Only log unexpected exceptions (status code `500` basically) to reduce noise
- Add debug logging to `CommunityJoinRequestService` and `StreamrClientService`
- Turn on debug logging for above classes and `StreamrClient` to debug join issues in production

This PR includes PR #682.