### PR TITLE
Show secrets also in full listing

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/CommunitySecretApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/CommunitySecretApiController.groovy
@@ -62,7 +62,7 @@ class CommunitySecretApiController {
 			throw new BadRequestException("name in json is not a valid name")
 		}
 		CommunitySecret secret = communitySecretService.create(communityAddress, cmd)
-		render(secret.toMap(true) as JSON)
+		render(secret.toMap() as JSON)
 	}
 
 	// curl -v -H "Authorization: token tester1-api-key" http://localhost:8081/streamr-core/api/v1/communities/0x6c90aece04198da2d5ca9b956b8f95af8041de37/secrets/L-TvrBkyQTS_JK1ABHFEZAaZ3FHq7-TPqMXe9JNz1x6g
@@ -76,7 +76,7 @@ class CommunitySecretApiController {
 		if (secret == null) {
 			throw new NotFoundException("community secret not found by id")
 		}
-		render(secret.toMap(true) as JSON)
+		render(secret.toMap() as JSON)
 	}
 
 	// curl -v -X PUT -H "Authorization: token tester1-api-key" -H "Content-Type: application/json" -d '{"name":"new name"}' http://localhost:8081/streamr-core/api/v1/communities/0x6c90aece04198da2d5ca9b956b8f95af8041de37/secrets/L-TvrBkyQTS_JK1ABHFEZAaZ3FHq7-TPqMXe9JNz1x6g
@@ -90,7 +90,7 @@ class CommunitySecretApiController {
 			throw new BadRequestException("name in json is not a valid name")
 		}
 		CommunitySecret secret = communitySecretService.update(communityAddress, id, cmd)
-		render(secret.toMap(true) as JSON)
+		render(secret.toMap() as JSON)
 	}
 
 	// curl -v -X DELETE -H "Authorization: token tester1-api-key" http://localhost:8081/streamr-core/api/v1/communities/0x6c90aece04198da2d5ca9b956b8f95af8041de37/secrets/L-TvrBkyQTS_JK1ABHFEZAaZ3FHq7-TPqMXe9JNz1x6g

--- a/grails-app/domain/com/unifina/domain/community/CommunitySecret.groovy
+++ b/grails-app/domain/com/unifina/domain/community/CommunitySecret.groovy
@@ -23,15 +23,11 @@ class CommunitySecret {
 	}
 
 	@GrailsCompileStatic
-	Map toMap(boolean includeSecret = false) {
-		def map = [
-			id: id,
-			name: name,
-			communityAddress: communityAddress,
-		]
-		if (includeSecret) {
-			map.secret = secret
-		}
-		return map
-	}
+	Map toMap() { [
+		id: id,
+		name: name,
+		communityAddress: communityAddress,
+		secret: secret,
+	] }
+
 }

--- a/test/unit/com/unifina/controller/api/CommunitySecretApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/CommunitySecretApiControllerSpec.groovy
@@ -46,7 +46,7 @@ class CommunitySecretApiControllerSpec extends Specification {
 		s1.save(validate: true, failOnError: true)
 		CommunitySecret s2 = new CommunitySecret(
 			name: "secret 2",
-			secret: "secret 2",
+			secret: "secret2",
 			communityAddress: communityAddress,
 		)
 		s2.id = "2"
@@ -64,9 +64,11 @@ class CommunitySecretApiControllerSpec extends Specification {
 		1 * controller.communitySecretService.findAll(communityAddress) >> [s1, s2]
 		response.json[0].id == "1"
 		response.json[0].name == "secret 1"
+		response.json[0].secret == "secret1"
 		response.json[0].communityAddress == communityAddress
 		response.json[1].id == "2"
 		response.json[1].name == "secret 2"
+		response.json[1].secret == "secret2"
 		response.json[1].communityAddress == communityAddress
 	}
 


### PR DESCRIPTION
Main rationale here is: admin access control is enforced already for all endpoints. What's the point of forcing the front-end to do multiple HTTP queries?