### PR TITLE
Getevent bugfixes minimal pr 20191105

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -86,7 +86,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			log.info("adding new filter to contract address " + contractAddress);
 		} catch (Exception e) {
 			listener.onError(e.getMessage());
-			throw new RuntimeException(e);
+			log.error(e.getMessage());
 		}
 	}
 
@@ -113,11 +113,9 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 		try {
 			log.debug(String.format("Polling filter '%s'.", filterId));
 			rpc.rpcCall("eth_getFilterChanges", singletonList(filterId), ID_POLLFILTER);
-		}  catch (HttpEthereumJsonRpc.RPCException | JSONException e) {
+		}  catch (Exception e) {
 			listener.onError(e.getMessage());
-		} catch (Exception e) {
-			listener.onError(e.getMessage());
-			throw new RuntimeException(e);
+			log.error(e.getMessage());
 		}
 	}
 
@@ -145,7 +143,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			rpc.rpcCall("eth_uninstallFilter", singletonList(id), ID_REMOVEFILTER);
 		} catch (Exception e) {
 			listener.onError(e.getMessage());
-			throw new RuntimeException(e);
+			log.error(e.getMessage());
 		}
 
 	}

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -86,7 +86,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			log.info("adding new filter to contract address " + contractAddress);
 		} catch (Exception e) {
 			listener.onError(e.getMessage());
-			log.error(e.getMessage());
+			throw new RuntimeException(e);
 		}
 	}
 
@@ -115,7 +115,7 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			rpc.rpcCall("eth_getFilterChanges", singletonList(filterId), ID_POLLFILTER);
 		}  catch (Exception e) {
 			listener.onError(e.getMessage());
-			log.error(e.getMessage());
+			log.error("pollChanges threw exception. This might be normal if websocket connection is reopening. Error: " + e.getMessage());
 		}
 	}
 
@@ -143,9 +143,8 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			rpc.rpcCall("eth_uninstallFilter", singletonList(id), ID_REMOVEFILTER);
 		} catch (Exception e) {
 			listener.onError(e.getMessage());
-			log.error(e.getMessage());
+			throw new RuntimeException(e);
 		}
-
 	}
 
 	private void processUninstallFilterResponse(JSONObject response) {

--- a/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
+++ b/src/java/com/unifina/signalpath/blockchain/ContractEventPoller.java
@@ -44,13 +44,9 @@ class ContractEventPoller implements Closeable, Runnable, JsonRpcResponseHandler
 			rpc = new HttpEthereumJsonRpc(rpcUrl, this);
 		} else {
 			rpc = new WebsocketEthereumJsonRpc(rpcUrl, this);
-			try {
-				boolean opened = ((WebsocketEthereumJsonRpc) rpc).openConnectionRetryIfFail();
-				if (!opened) {
-					throw new RuntimeException("Couldnt open connection to " + rpcUrl);
-				}
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e);
+			boolean opened = ((WebsocketEthereumJsonRpc) rpc).openConnectionRetryIfFail();
+			if (!opened) {
+				throw new RuntimeException("Couldnt open connection to " + rpcUrl);
 			}
 		}
 	}

--- a/src/java/com/unifina/signalpath/blockchain/GetEvents.java
+++ b/src/java/com/unifina/signalpath/blockchain/GetEvents.java
@@ -195,9 +195,9 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 			if (valueList == null) {
 				throw new RuntimeException("Failed to get event params");
 			}
-
-			if (abiEvent.inputs.size() > 0) {
-				for (EventValues ev : valueList) {
+			//valueList contains only the events of type abiEvent
+			for (EventValues ev : valueList) {
+				if (abiEvent.inputs.size() > 0) {
 					// indexed and non-indexed event args are saved differently in logs and must be retrieved by different methods
 					// see https://solidity.readthedocs.io/en/v0.5.3/contracts.html#events
 					int nextIndexed = 0, nextNonIndexed = 0;
@@ -212,10 +212,10 @@ public class GetEvents extends AbstractSignalPathModule implements EventsListene
 						}
 						convertAndSend(output, value);
 					}
+				} else{
+					// events with no arguments just get a true sent as a sign of event being triggered
+					eventOutputs.get(0).send(Boolean.TRUE);
 				}
-			} else {
-				// events with no arguments just get a true sent as a sign of event being triggered
-				eventOutputs.get(0).send(Boolean.TRUE);
 			}
 		}
 	}

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -112,7 +112,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 					log.error("Thread was interrupted while sleeping.");
 					//why is this thread interrupted in E&E when sleeping?
 					log.error(ie.getMessage());
-					Thread.interrupted();
+					Thread.currentThread().interrupt();
 				}
 				continue;
 			}

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -114,6 +114,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 					log.error("Thread was interrupted while sleeping.");
 					//why is this thread interrupted in E&E when sleeping?
 					log.error(ie.getMessage());
+					Thread.interrupted();
 				}
 				continue;
 			}

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -99,8 +99,6 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 			log.info("Trying to establish websocket connection to " + url + ". Attempt number " + attempts);
 			try {
 				openConnection();
-				//in the case of ContractEventPoller, handler.init() installs filter
-				handler.init();
 			} catch (URISyntaxException e) {
 				log.error(e);
 				return false;
@@ -139,6 +137,8 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 			e.printStackTrace();
 			throw e;
 		}
+		//in the case of ContractEventPoller, handler.init() installs filter
+		handler.init();
 		log.info("Websocket connection established to " + url);
 	}
 

--- a/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
+++ b/src/java/com/unifina/signalpath/blockchain/WebsocketEthereumJsonRpc.java
@@ -50,14 +50,10 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 			CloseReason.CloseCode code = reason.getCloseCode();
 			log.info("session " + session + "was closed. CloseReason: " + reason);
 			if (reconnectOnError && code.getCode() != CloseReason.CloseCodes.NORMAL_CLOSURE.getCode()) {
-				try {
-					log.info("Trying reconnect");
-					if (!openConnectionRetryIfFail()) {
-						String err = "Couldnt reestablish connection to " + url;
-						throw new RuntimeException(err);
-					}
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
+				log.info("Trying reconnect");
+				if (!openConnectionRetryIfFail()) {
+					String err = "Couldnt reestablish connection to " + url;
+					throw new RuntimeException(err);
 				}
 			}
 		}
@@ -66,14 +62,10 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		public void onError(Session session, Throwable t) {
 			log.error("session " + session + " reported error " + t.getMessage());
 			if (reconnectOnError) {
-				try {
-					log.info("Trying reconnect");
-					if (!openConnectionRetryIfFail()) {
-						String err = "Couldnt reestablish connection to " + url;
-						throw new RuntimeException(err);
-					}
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
+				log.info("Trying reconnect");
+				if (!openConnectionRetryIfFail()) {
+					String err = "Couldnt reestablish connection to " + url;
+					throw new RuntimeException(err);
 				}
 			}
 		}
@@ -100,7 +92,7 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 		wsEndpoint = new EthereumRpcEndpoint();
 	}
 
-	public boolean openConnectionRetryIfFail() throws InterruptedException {
+	public boolean openConnectionRetryIfFail() {
 		int attempts = 0;
 		while (attemptReconnectionMaxTries < 0 || attempts < attemptReconnectionMaxTries) {
 			attempts++;
@@ -112,10 +104,17 @@ public class WebsocketEthereumJsonRpc extends EthereumJsonRpc {
 			} catch (URISyntaxException e) {
 				log.error(e);
 				return false;
-			} catch (IOException | DeploymentException e) {
+			} catch (IOException | DeploymentException | RuntimeException e) {
 				log.error(e);
 				log.info("Waiting " + attemptReconnectionWaittimeMs + "ms");
-				Thread.sleep(attemptReconnectionWaittimeMs);
+				try {
+					Thread.sleep(attemptReconnectionWaittimeMs);
+				}
+				catch(InterruptedException ie){
+					log.error("Thread was interrupted while sleeping.");
+					//why is this thread interrupted in E&E when sleeping?
+					log.error(ie.getMessage());
+				}
 				continue;
 			}
 			return true;


### PR DESCRIPTION
This PR has the bugfixes from https://github.com/streamr-dev/engine-and-editor/pull/696, without the Ethereum modules refactor that Juuso did. 

Contains the following bugfixes:
1. fixed bug where 0 parameter event was always sent, even if another event was triggered.
2. RuntimeException caught in WebsocketEthereumJsonRpc.openConnectionRetryIfFail(). DNS lookup failure causes a RuntimeException, which wasn't caught.
3. InterruptedException caught when sleeping between connection retries. I'm not sure why thread was interrupted, but I've seen this in E&E.
4. No RuntimeExceptions thrown when polling to closed WS. This happens when ContractEventPoller polls the RPC while the websocket is closed and attempting reopen.