### PR TITLE
Add uiChannel & canvas restart tests

### DIFF
--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -304,13 +304,14 @@ describe('Canvas API', function() {
     })
 })
 
-describe('clock -> table canvas', function() {
+
+function TestClockTable() {
     let streamrClient
     let sessionToken
     let canvas
 
     // sets timeout on before and all test cases in this suite
-    this.timeout(TIMEOUT)
+    this.timeout(9000)
 
     before(async () => {
         const created = await CreateClientUser()
@@ -363,15 +364,24 @@ describe('clock -> table canvas', function() {
     })
 
     after(async () => {
-        if (canvas) {
+        if (canvas && sessionToken) {
             await Streamr.api.v1.canvases
                 .stop(canvas.id)
                 .withSessionToken(sessionToken)
                 .call()
                 .catch(console.warn) // ignore
         }
-        if (streamrClient.isConnected()) {
+        if (streamrClient && streamrClient.isConnected()) {
             await streamrClient.disconnect()
         }
     })
+}
+
+describe('clock -> table canvas', () => {
+    // repeat test a number of times since it seems to fail intermittently
+    describe('1st time', TestClockTable)
+    describe('2nd time', TestClockTable)
+    describe('3rd time', TestClockTable)
+    describe('4th time', TestClockTable)
+    describe('5th time', TestClockTable)
 })

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -303,7 +303,10 @@ describe('Canvas API', function() {
             })
             await sleep(WAIT_TIME / 5)
             // last message is our message
-            assert.equal(messages[messages.length - 1].nr[1], `${NUM_MESSAGES + 1}.0`)
+            const lastMessage = messages[messages.length - 1]
+            assert.ok(lastMessage, 'has last message')
+            assert.ok(lastMessage.nr, 'last message is new row')
+            assert.equal(lastMessage.nr[1], `${NUM_MESSAGES + 1}.0`)
         })
     })
 })

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -223,7 +223,7 @@ describe('Canvas API', function() {
         let subscription
         before('cycle start/stop, subscribe, start', async () => {
             let done
-            const p = new Promise((resolve) => done = (err) => err ? reject(err) : resolve())
+            const p = new Promise((resolve, reject) => done = (err) => err ? reject(err) : resolve())
             const r1 = await Streamr.api.v1.canvases
                 .start(canvas.id)
                 .withSessionToken(sessionToken)
@@ -238,6 +238,9 @@ describe('Canvas API', function() {
             const table = canvas.modules.find(({ name }) => name === 'Table')
             subscription = streamrClient.subscribe({
                 stream: table.uiChannel.id,
+                resend: {
+                    last: table.options.uiResendLast.value,
+                },
             }, (msg) => {
                 messages.push(msg)
             })
@@ -280,6 +283,7 @@ describe('Canvas API', function() {
         })
 
         it('gets uiResendLast resent messages', (done) => {
+            const table = canvas.modules.find(({ name }) => name === 'Table')
             if (!resentMessages) {
                 // wait for resent if no resent event yet
                 subscription.once('resent', () => {
@@ -309,6 +313,7 @@ function TestClockTable() {
     let streamrClient
     let sessionToken
     let canvas
+    let subscription
 
     // sets timeout on before and all test cases in this suite
     this.timeout(9000)

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -121,6 +121,9 @@ describe('Canvas API', function() {
             }, (msg) => {
                 messages.push(msg)
             })
+            subscription.once('error', (error) => {
+                throw error
+            })
             subscription.once('subscribed', () => done())
         })
 
@@ -234,6 +237,13 @@ describe('Canvas API', function() {
 
             subscription.once('resent', () => {
                 resentMessages = messages.slice()
+            })
+            subscription.once('error', (error) => {
+                throw error
+            })
+
+            subscription.once('no_resend', () => {
+                throw new Error('should not have no_resend')
             })
 
             // wait for subscription before starting again

--- a/rest-e2e-tests/test-data/canvas-api.test.js-canvas-clock.json
+++ b/rest-e2e-tests/test-data/canvas-api.test.js-canvas-clock.json
@@ -1,0 +1,244 @@
+{
+  "id": "kshZR2nkRZaZlKvZF_b5DwrxPlddv2Spy_c-r9GqfDxA",
+  "name": "Untitled Canvas",
+  "created": "2019-11-07T03:59:42Z",
+  "updated": "2019-11-07T03:59:42Z",
+  "adhoc": false,
+  "state": "STOPPED",
+  "hasExports": false,
+  "serialized": false,
+  "modules": [
+    {
+      "params": [
+        {
+          "id": "32a648f1-5b4e-4f79-b88e-c399dca7f6db",
+          "name": "timezone",
+          "longName": "Clock.timezone",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "UTC",
+          "drivingInput": false,
+          "canToggleDrivingInput": true,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "defaultValue": "UTC"
+        },
+        {
+          "id": "39e419fe-9f6c-41a1-a02a-436727a64106",
+          "name": "format",
+          "longName": "Clock.format",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "yyyy-MM-dd HH:mm:ss z",
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "defaultValue": "yyyy-MM-dd HH:mm:ss z",
+          "isTextArea": false
+        },
+        {
+          "id": "b1d1b3dd-d8e0-4a1e-986d-b3f4c3ebdafa",
+          "name": "rate",
+          "longName": "Clock.rate",
+          "type": "Double",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": 1,
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Double"
+          ],
+          "requiresConnection": false,
+          "defaultValue": 1
+        },
+        {
+          "id": "62067d71-c5e6-4961-ad6d-8d2845fbbca6",
+          "name": "unit",
+          "longName": "Clock.unit",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "SECOND",
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "possibleValues": [
+            {
+              "name": "second",
+              "value": "SECOND"
+            },
+            {
+              "name": "minute",
+              "value": "MINUTE"
+            },
+            {
+              "name": "hour",
+              "value": "HOUR"
+            },
+            {
+              "name": "day",
+              "value": "DAY"
+            }
+          ],
+          "defaultValue": "SECOND"
+        }
+      ],
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "d66c0da5-6f20-4c58-acb0-8e6f61627e65",
+          "name": "date",
+          "longName": "Clock.date",
+          "type": "String",
+          "connected": true,
+          "canConnect": true,
+          "export": false,
+          "noRepeat": false,
+          "canBeNoRepeat": true
+        },
+        {
+          "id": "0921ea73-78aa-4618-b615-cbb1a43eff02",
+          "name": "timestamp",
+          "longName": "Clock.timestamp",
+          "type": "Double",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "noRepeat": false,
+          "canBeNoRepeat": true
+        }
+      ],
+      "id": 209,
+      "jsModule": "GenericModule",
+      "type": "module",
+      "name": "Clock",
+      "canClearState": true,
+      "canRefresh": false,
+      "hash": -90411460,
+      "layout": {
+        "position": {
+          "top": "32px",
+          "left": "32px"
+        },
+        "width": "250px",
+        "height": "150px"
+      }
+    },
+    {
+      "params": [],
+      "inputs": [
+        {
+          "id": "34523d9b-78cf-4f9f-a797-bc85aeefe54b",
+          "name": "endpoint-1573099182885",
+          "longName": "Table.date",
+          "type": "Object",
+          "connected": true,
+          "canConnect": true,
+          "export": false,
+          "displayName": "date",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": false,
+            "index": 1
+          },
+          "drivingInput": true,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Object"
+          ],
+          "requiresConnection": true,
+          "sourceId": "d66c0da5-6f20-4c58-acb0-8e6f61627e65"
+        },
+        {
+          "id": "979a8231-c8b6-4e93-92f0-33fa82bb07b3",
+          "name": "endpoint-979a8231-c8b6-4e93-92f0-33fa82bb07b3",
+          "longName": "Table.in2",
+          "type": "Object",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "displayName": "in2",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": true,
+            "index": 2
+          },
+          "drivingInput": true,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Object"
+          ],
+          "requiresConnection": false,
+          "sourceId": null
+        }
+      ],
+      "outputs": [],
+      "id": 527,
+      "jsModule": "TableModule",
+      "type": "module event-table-module",
+      "name": "Table",
+      "canClearState": true,
+      "canRefresh": false,
+      "uiChannel": {
+        "webcomponent": "streamr-table",
+        "name": "Table",
+        "id": "36820df2-7daa-44e3-ba0f-62b59561542c"
+      },
+      "options": {
+        "uiResendLast": {
+          "value": 20,
+          "type": "int"
+        },
+        "maxRows": {
+          "value": 20,
+          "type": "int"
+        },
+        "showOnlyNewValues": {
+          "value": true,
+          "type": "boolean"
+        }
+      },
+      "tableConfig": {
+        "headers": [
+          "timestamp"
+        ],
+        "title": "Table"
+      },
+      "hash": 1493434540,
+      "layout": {
+        "position": {
+          "top": "32px",
+          "left": "32px"
+        },
+        "width": "250px",
+        "height": "150px"
+      }
+    }
+  ],
+  "settings": {
+    "editorState": {
+      "runTab": "#tab-realtime"
+    }
+  },
+  "uiChannel": {
+    "webcomponent": null,
+    "name": "Notifications",
+    "id": "0B2QG50zQR-brZXrgu4aXw"
+  },
+  "startedById": null
+}

--- a/rest-e2e-tests/test-data/canvas-api.test.js-canvas.json
+++ b/rest-e2e-tests/test-data/canvas-api.test.js-canvas.json
@@ -8,7 +8,7 @@
           "name": "numero",
           "canConnect": true,
           "noRepeat": false,
-          "id": "myId_0_1453815974997",
+          "id": "ep_zYI9pHCPTDm4z33iC_ch4Q",
           "type": "Double",
           "export": false,
           "longName": "Stream.numero"
@@ -19,7 +19,7 @@
           "name": "areWeDoneYet",
           "canConnect": true,
           "noRepeat": false,
-          "id": "myId_0_1453815975004",
+          "id": "ep_QCnGbntbQkuBxKn-YTRovg",
           "type": "Boolean",
           "export": false,
           "longName": "Stream.areWeDoneYet"
@@ -217,7 +217,7 @@
       },
       "inputs": [
         {
-          "sourceId": "myId_0_1453815974997",
+          "sourceId": "ep_zYI9pHCPTDm4z33iC_ch4Q",
           "canToggleDrivingInput": true,
           "drivingInput": true,
           "type": "Double",
@@ -313,11 +313,102 @@
       "type": "module",
       "canClearState": true,
       "hash": 3
+    },
+    {
+      "outputs": [],
+      "inputs": [
+        {
+          "sourceId": "ep_zYI9pHCPTDm4z33iC_ch4Q",
+          "canToggleDrivingInput": false,
+          "displayName": "numero",
+          "drivingInput": true,
+          "type": "Object",
+          "connected": true,
+          "requiresConnection": false,
+          "name": "endpoint-1573446921385",
+          "canConnect": true,
+          "id": "3874698d-4ece-41b6-b686-9848b725a261",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": false,
+            "index": 1
+          },
+          "acceptedTypes": [
+            "Object"
+          ],
+          "export": false,
+          "longName": "Table.numero"
+        },
+        {
+          "canToggleDrivingInput": false,
+          "displayName": "in2",
+          "drivingInput": true,
+          "type": "Object",
+          "connected": false,
+          "requiresConnection": false,
+          "name": "endpoint-9a04ee06-c51f-45ca-8f79-ead8e91b2606",
+          "canConnect": true,
+          "id": "9a04ee06-c51f-45ca-8f79-ead8e91b2606",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": true,
+            "index": 2
+          },
+          "acceptedTypes": [
+            "Object"
+          ],
+          "export": false,
+          "longName": "Table.in2"
+        }
+      ],
+      "uiChannel": {
+        "webcomponent": "streamr-table",
+        "name": "Table",
+        "id": "bgZJPowgTVywNbnKCxGFtw"
+      },
+      "canRefresh": false,
+      "params": [],
+      "jsModule": "TableModule",
+      "type": "module event-table-module",
+      "canClearState": true,
+      "layout": {
+        "width": "250px",
+        "position": {
+          "top": "167px",
+          "left": "1022px"
+        },
+        "height": "251px"
+      },
+      "tableConfig": {
+        "headers": [
+          "timestamp",
+          "numero"
+        ],
+        "title": "Table"
+      },
+      "name": "Table",
+      "options": {
+        "maxRows": {
+          "type": "int",
+          "value": 20
+        },
+        "showOnlyNewValues": {
+          "type": "boolean",
+          "value": true
+        },
+        "uiResendLast": {
+          "type": "int",
+          "value": 20
+        }
+      },
+      "id": 527,
+      "hash": 4
     }
   ],
+  "settings": {},
   "uiChannel": {
     "webcomponent": null,
     "name": "Notifications",
-    "id": "K2bPJOACRG6y-jv2GG0S8w"
+    "id": "iwJp1XpaTD6aRS8jba_Pyw"
   }
 }


### PR DESCRIPTION
1. Adds a test checking that uiChannel data is flowing by adding a Table to the existing Stream->Multiply->Sum test canvas.
2. Tests that data still flows after rapidly stopping and starting a canvas.

Variants of these tests were failing over the past few days, seem to be passing consistently now with latest docker images.

3. ~Also adds a failing test for resend data. It appears data flows but uiChannel resends don't seem to work. UI resends seem to be working just fine in the actual app, albeit with a clock->table, so it's possible my test is not correct, please verify my test makes sense @hpihkala.~

Ah nvm about the resend UI issue, my test didn't make sense, its not working because no resend parameters are set on the subscription, it doesn't magically set the resend parameters when you change the options on the module itself. Of course. ~~Will fix that,~~ fixed but I believe the clock canvas test failure is still valid.

~I also want to create a test that uses a Clock but this is now a bit problematic if the test is ever not shut down gracefully since the clock canvas(es) will keep running forever in the background  filling the already noisy backend logs with distracting messages.~ Added this test anyway.

4. Added a test for a Clock -> Table that ensures at least one new row message arrives on the uiChannel after starting the canvas. This test fails intermittently, so I have set it up to repeat multiple times e.g.

![image](https://user-images.githubusercontent.com/43438/68651291-0a8a6f80-0562-11ea-99c6-93c08ef93b5d.png)
