### PR TITLE
promote double and float to BigDecimal when calling web3j function

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
+++ b/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
@@ -403,8 +403,9 @@ public class SendEthereumTransaction extends ModuleWithSideEffects {
 		List args = new ArrayList(chosenFunction.inputs.size());
 		for (int i = 0; i < chosenFunction.inputs.size(); i++) {
 			Object arg = arguments.get(i).getValue();
-			if(arg instanceof Double || arg instanceof Float)
+			if (arg instanceof Double || arg instanceof Float) {
 				arg = BigDecimal.valueOf(((Number) arg).doubleValue());
+			}
 			args.add(arg);
 		}
 		return Web3jHelper.toWeb3jFunction(chosenFunction, args);

--- a/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
+++ b/src/java/com/unifina/signalpath/blockchain/SendEthereumTransaction.java
@@ -402,7 +402,10 @@ public class SendEthereumTransaction extends ModuleWithSideEffects {
 	protected Function createWeb3jFunctionCall() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException, ClassNotFoundException {
 		List args = new ArrayList(chosenFunction.inputs.size());
 		for (int i = 0; i < chosenFunction.inputs.size(); i++) {
-			args.add(arguments.get(i).getValue());
+			Object arg = arguments.get(i).getValue();
+			if(arg instanceof Double || arg instanceof Float)
+				arg = BigDecimal.valueOf(((Number) arg).doubleValue());
+			args.add(arg);
 		}
 		return Web3jHelper.toWeb3jFunction(chosenFunction, args);
 	}


### PR DESCRIPTION
web3j library converts to uint using longValue() when passed floating point args. So args greater than MAX_LONG are clipped. This promotes floating point args to BigDecimal, which are converted to uint via toBigInteger()