### PR TITLE
bump com.streamr.client to 1.2.1 to fix canvases dropping subscriptions during broker downtime

### DIFF
--- a/.idea/engine-and-editor-grailsPlugins.iml
+++ b/.idea/engine-and-editor-grailsPlugins.iml
@@ -427,7 +427,6 @@
           <root url="jar://$MAVEN_REPOSITORY$/org/xerial/snappy/snappy-java/1.1.4/snappy-java-1.1.4.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/abi/4.4.1/abi-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/core/4.4.1/core-4.4.1.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/com/streamr/client/1.1.6/client-1.1.6.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/tuples/4.4.1/tuples-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/rlp/4.4.1/rlp-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/crypto/4.4.1/crypto-4.4.1.jar!/" />
@@ -435,6 +434,7 @@
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/utils/4.4.1/utils-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/19.0/guava-19.0.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/com/streamr/client/1.2.1/client-1.2.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/.idea/engine-and-editor.iml
+++ b/.idea/engine-and-editor.iml
@@ -409,7 +409,6 @@
           <root url="jar://$MAVEN_REPOSITORY$/org/xerial/snappy/snappy-java/1.1.4/snappy-java-1.1.4.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/abi/4.4.1/abi-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/core/4.4.1/core-4.4.1.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/com/streamr/client/1.1.6/client-1.1.6.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/tuples/4.4.1/tuples-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/rlp/4.4.1/rlp-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/crypto/4.4.1/crypto-4.4.1.jar!/" />
@@ -417,6 +416,7 @@
           <root url="jar://$MAVEN_REPOSITORY$/org/web3j/utils/4.4.1/utils-4.4.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/19.0/guava-19.0.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/com/streamr/client/1.2.1/client-1.2.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -93,7 +93,7 @@ grails.project.dependency.resolution = {
 		compile('org.glassfish.jersey.media:jersey-media-json-jackson:2.27')
 		compile('com.fasterxml.jackson.core:jackson-databind:2.9.6')
 		compile('com.fasterxml.jackson.core:jackson-annotations:2.9.6')
-		compile('com.streamr:client:1.1.7')
+		compile('com.streamr:client:1.2.1')
 
 		compile('com.google.code.gson:gson:2.8.5')
 		runtime('mysql:mysql-connector-java:5.1.20')


### PR DESCRIPTION
Bump `com.streamr.client` to 1.2.1. Tested by hand and looks like it fixes issue in which canvases drop subscriptions to streams during broker downtime.     