### PR TITLE
NET-88: fix "clock-table" bug

### DIFF
--- a/src/java/com/unifina/signalpath/charts/Chart.java
+++ b/src/java/com/unifina/signalpath/charts/Chart.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 public abstract class Chart extends ModuleWithUI {
 	private String dataGrouping = "min/max";
+	protected boolean headersSent = false;
 
 	@Override
 	public void init() {
@@ -17,17 +18,18 @@ public abstract class Chart extends ModuleWithUI {
 	}
 
 	@Override
-	public void initialize() {
-		super.initialize();
-	}
-
-	@Override
 	public void sendOutput() {
+		if (!headersSent) {
+			sendHeaders();
+			headersSent = true;
+		}
 		Date timestamp = getGlobals().time;
 		if (timestamp != null) {
 			record();
 		}
 	}
+
+	protected abstract void sendHeaders();
 
 	protected abstract void record();
 

--- a/src/java/com/unifina/signalpath/charts/TimeSeriesChart.java
+++ b/src/java/com/unifina/signalpath/charts/TimeSeriesChart.java
@@ -45,9 +45,6 @@ public class TimeSeriesChart extends Chart {
 				it.seriesName = newName;
 			}
 		}
-		if (getGlobals().isRunContext()) {
-			pushToUiChannel(getInitMessage());
-		}
 	}
 
 	protected InitMessage getInitMessage() {
@@ -85,6 +82,11 @@ public class TimeSeriesChart extends Chart {
 		}
 
 		return conn;
+	}
+
+	@Override
+	protected void sendHeaders() {
+		pushToUiChannel(getInitMessage());
 	}
 
 	@Override

--- a/src/java/com/unifina/signalpath/utils/EventTable.java
+++ b/src/java/com/unifina/signalpath/utils/EventTable.java
@@ -11,6 +11,7 @@ public class EventTable extends ModuleWithUI {
 
 	int eventTableInputCount = 1;
 	int maxRows = 20;
+	private boolean headersSent = false;
 
 	public EventTable() {
 		super();
@@ -20,18 +21,17 @@ public class EventTable extends ModuleWithUI {
 	}
 
 	@Override
-	public void initialize() {
-		super.initialize();
-
-		if (getGlobals().isRunContext()) {
+	public void sendOutput() {
+		/*
+		 * Headers must be sent before first message but after DataSourceEventQueue#initTimeReporting has adjusted
+		 * globals.time.
+		 */
+		if (!headersSent) {
 			Map<String, Object> hdrMsg = new HashMap<String, Object>();
 			hdrMsg.put("hdr", getHeaderDefinition());
 			pushToUiChannel(hdrMsg);
+			headersSent = true;
 		}
-	}
-
-	@Override
-	public void sendOutput() {
 		HashMap<String, Object> msg = new HashMap<String, Object>();
 		ArrayList<Object> nr = new ArrayList<>(2);
 		msg.put("nr", nr);
@@ -51,6 +51,7 @@ public class EventTable extends ModuleWithUI {
 
 	@Override
 	public void clearState() {
+		headersSent = false;
 	}
 
 	public Input<Object> createAndAddInput(String name) {

--- a/src/java/com/unifina/signalpath/utils/VariadicEventTable.java
+++ b/src/java/com/unifina/signalpath/utils/VariadicEventTable.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public class VariadicEventTable extends ModuleWithUI {
 
 	private VariadicInput<Object> ins = new VariadicInput<>(this, new EventTableInputInstantiator());
+	private boolean headersSent = false;
 
 	int maxRows = 20;
 	private boolean showOnlyNewValues = true;
@@ -29,18 +30,17 @@ public class VariadicEventTable extends ModuleWithUI {
 	}
 
 	@Override
-	public void initialize() {
-		super.initialize();
-
-		if (getGlobals().isRunContext()) {
+	public void sendOutput() {
+		/*
+		 * Headers must be sent before first message but after DataSourceEventQueue#initTimeReporting has adjusted
+		 * globals.time.
+		 */
+		if (!headersSent) {
 			Map<String, Object> hdrMsg = new HashMap<String, Object>();
 			hdrMsg.put("hdr", getHeaderDefinition());
 			pushToUiChannel(hdrMsg);
+			headersSent = true;
 		}
-	}
-
-	@Override
-	public void sendOutput() {
 		HashMap<String, Object> msg = new HashMap<String, Object>();
 		ArrayList<Object> nr = new ArrayList<>(2);
 		msg.put("nr", nr);
@@ -61,6 +61,7 @@ public class VariadicEventTable extends ModuleWithUI {
 
 	@Override
 	public void clearState() {
+		headersSent = false;
 	}
 
 	@Override

--- a/test/unit/com/unifina/signalpath/charts/TimeSeriesChartSpec.groovy
+++ b/test/unit/com/unifina/signalpath/charts/TimeSeriesChartSpec.groovy
@@ -62,6 +62,9 @@ class TimeSeriesChartSpec extends UiChannelMockingSpecification {
 		new ModuleTestHelper.Builder(module, inputValues, outputValues)
 			.timeToFurtherPerIteration(1000)
 			.uiChannelMessages(channelMessages, getSentMessagesByStreamId())
+			.afterEachTestCase {
+				module.headersSent = false
+			}
 			.test()
 	}
 }


### PR DESCRIPTION
Fix "clock-table" bug.

The bug is caused by invoking `pushToUiChannel` too early in a module, i.e., before `DataSourceEventQueue#initTimeReporting` is executed. Because `globals.time` is used as timestamp in published messages and `globals.time` is adjusted backwards in `initTimeReporting`, if a module uses `pushToUiChannel` in both its `sendOutput()` and `initialize()` implementations, the resulting chain of `(timestamp, sequenceNo)`pairs isn't necessarily monotonically increasing, which is a requirement of message chains in the Streamr network.

Fixed instances where a module would try to `pushToUiChannel` in `initialize`.

Fixes issue that can be replicated by #707. I tried running the test case defined there at least five times without problems against this branch.