### PR TITLE
fix: omitting defaultNetwork crashed the whole thing, just choose one…

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -216,11 +216,11 @@ streamr.ethereum.datacoinAddress = System.getProperty("streamr.ethereum.datacoin
  * -Dstreamr.ethereum.networks.someNetwork=http://some-network-rpc-url
  * -Dstreamr.ethereum.networks.anotherNetwork=http://some-network-rpc-url
  */
-streamr.ethereum.defaultNetwork = System.getProperty("streamr.ethereum.defaultNetwork") ?: "local"
 streamr.ethereum.networks = PropertiesUtil.matchingPropertiesToMap("streamr.ethereum.networks.", System.getProperties()) ?: [ local: "http://localhost:8545" ]
 streamr.ethereum.wss = PropertiesUtil.matchingPropertiesToMap("streamr.ethereum.wss.", System.getProperties()) ?: [ local: "ws://localhost:8545" ]
 // Ethereum identity of this instance. Don't use this silly development private key for anything.
 streamr.ethereum.nodePrivateKey = System.getProperty("streamr.ethereum.nodePrivateKey", "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
+streamr.ethereum.defaultNetwork = System.getProperty("streamr.ethereum.defaultNetwork") ?: streamr.ethereum.networks.keySet().first()
 
 /**
  * Redis config


### PR DESCRIPTION
… instead

some bean somewhere wouldn't initialize

omitting it shouldn't be a problem, that's just silly. Current functionality is equivalent to old, it will pick "local" by default.