### PR TITLE
CORE-1846: Fix ConnectionPoolTimeoutException

### DIFF
--- a/grails-app/services/com/unifina/service/CommunityOperatorService.groovy
+++ b/grails-app/services/com/unifina/service/CommunityOperatorService.groovy
@@ -14,7 +14,6 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.util.EntityUtils
 
 import java.nio.charset.StandardCharsets
-
 /**
  * Engine and editor proxies the following endpoints to the Community Product server:
  *
@@ -42,10 +41,7 @@ class CommunityOperatorService {
 		int statusCode
 	}
 
-	protected ProxyResponse proxy(String url) {
-		HttpClient client = HttpClientBuilder.create()
-			.setDefaultRequestConfig(config)
-			.build()
+	protected ProxyResponse proxy(HttpClient client, String url) {
 		ProxyResponse result = new ProxyResponse()
 		CloseableHttpResponse response
 		try {
@@ -80,17 +76,26 @@ class CommunityOperatorService {
 	}
 
 	ProxyResponse stats(String communityAddress) {
+		HttpClient client = HttpClientBuilder.create()
+			.setDefaultRequestConfig(config)
+			.build()
 		String url = String.format("%s%s/stats", baseUrl, communityAddress)
-		return proxy(url)
+		return proxy(client, url)
 	}
 
 	ProxyResponse members(String communityAddress) {
+		HttpClient client = HttpClientBuilder.create()
+			.setDefaultRequestConfig(config)
+			.build()
 		String url = String.format("%s%s/members", baseUrl, communityAddress)
-		return proxy(url)
+		return proxy(client, url)
 	}
 
 	ProxyResponse memberStats(String communityAddress, String memberAddress) {
+		HttpClient client = HttpClientBuilder.create()
+			.setDefaultRequestConfig(config)
+			.build()
 		String url = String.format("%s%s/members/%s", baseUrl, communityAddress, memberAddress)
-		return proxy(url)
+		return proxy(client, url)
 	}
 }

--- a/test/unit/com/unifina/service/CommunityOperatorServiceSpec.groovy
+++ b/test/unit/com/unifina/service/CommunityOperatorServiceSpec.groovy
@@ -18,21 +18,24 @@ class CommunityOperatorServiceSpec extends Specification {
 	CloseableHttpResponse response
 	HttpEntity entity
 	StatusLine status
+	HttpClient client
+
+	private static interface CloseableHttpClient extends HttpClient, Closeable {}
 
 	void setup() {
 		response = Mock(CloseableHttpResponse)
 		entity = Mock(HttpEntity)
 		status = Mock(StatusLine)
-		service.client = Mock(HttpClient)
+		client = Mock(CloseableHttpClient)
 	}
 
 	void "test execute"() {
 		setup:
 		String expected = """{"result":[]}"""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 200
 		1 * response.getEntity() >> entity
@@ -47,9 +50,9 @@ class CommunityOperatorServiceSpec extends Specification {
 		setup:
 		String expected = ""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 400
 		1 * response.getEntity() >> null
@@ -62,9 +65,9 @@ class CommunityOperatorServiceSpec extends Specification {
 		setup:
 		String expected = """{"error":"bad community address format"}"""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 400
 		1 * response.getEntity() >> entity
@@ -77,9 +80,9 @@ class CommunityOperatorServiceSpec extends Specification {
 
 	void "test community server not responding"() {
 		when:
-		service.proxy(url)
+		service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> { throw new ConnectException("mocked: server down") }
+		1 * client.execute(_ as HttpGet) >> { throw new ConnectException("mocked: server down") }
 		def e = thrown(ProxyException)
 		e.message == "Community server is not responding"
 		e.code == "PROXY_ERROR"
@@ -90,9 +93,9 @@ class CommunityOperatorServiceSpec extends Specification {
 		setup:
 		String expected = """{"error":"community address not found"}"""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 404
 		1 * response.getEntity() >> entity
@@ -107,9 +110,9 @@ class CommunityOperatorServiceSpec extends Specification {
 		setup:
 		String expected = ""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 500
 		1 * response.close()
@@ -121,9 +124,9 @@ class CommunityOperatorServiceSpec extends Specification {
 		setup:
 		String expected = ""
 		when:
-		CommunityOperatorService.ProxyResponse result = service.proxy(url)
+		CommunityOperatorService.ProxyResponse result = service.proxy(client, url)
 		then:
-		1 * service.client.execute(_ as HttpGet) >> response
+		1 * client.execute(_ as HttpGet) >> response
 		1 * response.getStatusLine() >> status
 		1 * status.getStatusCode() >> 418
 		1 * response.close()


### PR DESCRIPTION
```
2019-11-18 11:30:57,447 [http-nio-8080-exec-68] ERROR api.ErrorController  - Unexpected error occurred on request to GET http://tomcat/grails/error/index.dispatch, returning status code 500
org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:286)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:263)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:55)
	at com.unifina.service.CommunityOperatorService.proxy(CommunityOperatorService.groovy:56)
	at com.unifina.service.CommunityOperatorService.memberStats(CommunityOperatorService.groovy:86)
	at com.unifina.controller.api.CommunityOperatorApiController.memberStats(CommunityOperatorApiController.groovy:48)
	at grails.plugin.springsecurity.web.filter.GrailsAnonymousAuthenticationFilter.doFilter(GrailsAnonymousAuthenticationFilter.java:53)
	at grails.plugin.springsecurity.web.authentication.logout.MutableLogoutFilter.doFilter(MutableLogoutFilter.java:62)
	at grails.plugin.springsecurity.web.SecurityRequestHolderFilter.doFilter(SecurityRequestHolderFilter.java:59)
	at com.brandseye.cors.CorsFilter.doFilter(CorsFilter.java:82)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748
```