### PR TITLE
Fix time reporting in DataSourceEventQueue

### DIFF
--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -267,6 +267,9 @@ describe('Canvas API', function() {
                     .withSessionToken(sessionToken)
                     .call()
                 assert.equal(r3.status, 200)
+
+                // reduce flakiness by allowing the subscriptions of the canvas some time to get set up
+                await sleep(5000)
                 done()
             })
             return p
@@ -293,13 +296,15 @@ describe('Canvas API', function() {
             if (!resentMessages) {
                 // wait for resent if no resent event yet
                 subscription.once('resent', () => {
-                    assert.equal(resentMessages && resentMessages.length, table.options.uiResendLast.value)
+                    assert.equal(resentMessages && resentMessages.length, table.options.uiResendLast.value,
+                        `Resent messages (waited): ${resentMessages.map((msg) => JSON.stringify(msg))}`)
                     done()
                 })
                 return
             }
 
-            assert.equal(resentMessages && resentMessages.length, table.options.uiResendLast.value)
+            assert.equal(resentMessages && resentMessages.length, table.options.uiResendLast.value,
+                `Resent messages (didn't wait): ${resentMessages.map((msg) => JSON.stringify(msg))}`)
             done()
         })
 
@@ -313,8 +318,10 @@ describe('Canvas API', function() {
                     messageEmitter.removeListener('message', onMessage) // clean up
                     done()
                     return
+                } else {
+                    // Ignore other messages or log them for debugging
+                    // console.log(`Got other message: ${JSON.stringify(msg)}`)
                 }
-                // ignore other messages
             }
             messageEmitter.on('message', onMessage)
 

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -11,7 +11,7 @@ const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
 
-const TIMEOUT = 60 * 1000
+const TIMEOUT = 30 * 1000
 
 const NUM_MESSAGES = 50
 
@@ -216,7 +216,7 @@ describe('Canvas API', function() {
         })
     })
 
-    describe('restarting canvas', () => {
+    function TestRestartingCanvas() {
         const messages = []
         let resentMessages
         let subscription
@@ -322,6 +322,14 @@ describe('Canvas API', function() {
             }
             messageEmitter.on('message', onMessage)
         })
+    }
+
+    describe('restarting canvas', () => {
+        describe('1st time', TestRestartingCanvas)
+        describe('2nd time', TestRestartingCanvas)
+        describe('3rd time', TestRestartingCanvas)
+        describe('4th time', TestRestartingCanvas)
+        describe('5th time', TestRestartingCanvas)
     })
 })
 

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -304,10 +304,6 @@ describe('Canvas API', function() {
         })
 
         it('can get new messages', (done) => {
-            streamrClient.publish(stream.id, {
-                numero: NUM_MESSAGES + 1,
-            })
-
             const expected = `${NUM_MESSAGES + 1}.0`
 
             const onMessage = (msg) => {
@@ -321,6 +317,10 @@ describe('Canvas API', function() {
                 // ignore other messages
             }
             messageEmitter.on('message', onMessage)
+
+            streamrClient.publish(stream.id, {
+                numero: NUM_MESSAGES + 1,
+            })
         })
     }
 

--- a/rest-e2e-tests/canvas-api.test.js
+++ b/rest-e2e-tests/canvas-api.test.js
@@ -11,7 +11,7 @@ const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
 
-const TIMEOUT = 30 * 1000
+const TIMEOUT = 60 * 1000
 
 const NUM_MESSAGES = 50
 

--- a/rest-e2e-tests/test-data/canvas-api.test.js-canvas-clock.json
+++ b/rest-e2e-tests/test-data/canvas-api.test.js-canvas-clock.json
@@ -1,0 +1,244 @@
+{
+  "id": "kshZR2nkRZaZlKvZF_b5DwrxPlddv2Spy_c-r9GqfDxA",
+  "name": "Untitled Canvas",
+  "created": "2019-11-07T03:59:42Z",
+  "updated": "2019-11-07T03:59:42Z",
+  "adhoc": false,
+  "state": "STOPPED",
+  "hasExports": false,
+  "serialized": false,
+  "modules": [
+    {
+      "params": [
+        {
+          "id": "32a648f1-5b4e-4f79-b88e-c399dca7f6db",
+          "name": "timezone",
+          "longName": "Clock.timezone",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "UTC",
+          "drivingInput": false,
+          "canToggleDrivingInput": true,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "defaultValue": "UTC"
+        },
+        {
+          "id": "39e419fe-9f6c-41a1-a02a-436727a64106",
+          "name": "format",
+          "longName": "Clock.format",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "yyyy-MM-dd HH:mm:ss z",
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "defaultValue": "yyyy-MM-dd HH:mm:ss z",
+          "isTextArea": false
+        },
+        {
+          "id": "b1d1b3dd-d8e0-4a1e-986d-b3f4c3ebdafa",
+          "name": "rate",
+          "longName": "Clock.rate",
+          "type": "Double",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": 1,
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Double"
+          ],
+          "requiresConnection": false,
+          "defaultValue": 1
+        },
+        {
+          "id": "62067d71-c5e6-4961-ad6d-8d2845fbbca6",
+          "name": "unit",
+          "longName": "Clock.unit",
+          "type": "String",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "value": "SECOND",
+          "drivingInput": false,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "String"
+          ],
+          "requiresConnection": false,
+          "possibleValues": [
+            {
+              "name": "second",
+              "value": "SECOND"
+            },
+            {
+              "name": "minute",
+              "value": "MINUTE"
+            },
+            {
+              "name": "hour",
+              "value": "HOUR"
+            },
+            {
+              "name": "day",
+              "value": "DAY"
+            }
+          ],
+          "defaultValue": "SECOND"
+        }
+      ],
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "d66c0da5-6f20-4c58-acb0-8e6f61627e65",
+          "name": "date",
+          "longName": "Clock.date",
+          "type": "String",
+          "connected": true,
+          "canConnect": true,
+          "export": false,
+          "noRepeat": false,
+          "canBeNoRepeat": true
+        },
+        {
+          "id": "0921ea73-78aa-4618-b615-cbb1a43eff02",
+          "name": "timestamp",
+          "longName": "Clock.timestamp",
+          "type": "Double",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "noRepeat": false,
+          "canBeNoRepeat": true
+        }
+      ],
+      "id": 209,
+      "jsModule": "GenericModule",
+      "type": "module",
+      "name": "Clock",
+      "canClearState": true,
+      "canRefresh": false,
+      "hash": -90411460,
+      "layout": {
+        "position": {
+          "top": "32px",
+          "left": "32px"
+        },
+        "width": "250px",
+        "height": "150px"
+      }
+    },
+    {
+      "params": [],
+      "inputs": [
+        {
+          "id": "34523d9b-78cf-4f9f-a797-bc85aeefe54b",
+          "name": "endpoint-1573099182885",
+          "longName": "Table.date",
+          "type": "Object",
+          "connected": true,
+          "canConnect": true,
+          "export": false,
+          "displayName": "date",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": false,
+            "index": 1
+          },
+          "drivingInput": true,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Object"
+          ],
+          "requiresConnection": true,
+          "sourceId": "d66c0da5-6f20-4c58-acb0-8e6f61627e65"
+        },
+        {
+          "id": "979a8231-c8b6-4e93-92f0-33fa82bb07b3",
+          "name": "endpoint-979a8231-c8b6-4e93-92f0-33fa82bb07b3",
+          "longName": "Table.in2",
+          "type": "Object",
+          "connected": false,
+          "canConnect": true,
+          "export": false,
+          "displayName": "in2",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": true,
+            "index": 2
+          },
+          "drivingInput": true,
+          "canToggleDrivingInput": false,
+          "acceptedTypes": [
+            "Object"
+          ],
+          "requiresConnection": false,
+          "sourceId": null
+        }
+      ],
+      "outputs": [],
+      "id": 527,
+      "jsModule": "TableModule",
+      "type": "module event-table-module",
+      "name": "Table",
+      "canClearState": true,
+      "canRefresh": false,
+      "uiChannel": {
+        "webcomponent": "streamr-table",
+        "name": "Table",
+        "id": "36820df2-7daa-44e3-ba0f-62b59561542c"
+      },
+      "options": {
+        "uiResendLast": {
+          "value": 20,
+          "type": "int"
+        },
+        "maxRows": {
+          "value": 20,
+          "type": "int"
+        },
+        "showOnlyNewValues": {
+          "value": true,
+          "type": "boolean"
+        }
+      },
+      "tableConfig": {
+        "headers": [
+          "timestamp"
+        ],
+        "title": "Table"
+      },
+      "hash": 1493434540,
+      "layout": {
+        "position": {
+          "top": "32px",
+          "left": "32px"
+        },
+        "width": "250px",
+        "height": "150px"
+      }
+    }
+  ],
+  "settings": {
+    "editorState": {
+      "runTab": "#tab-realtime"
+    }
+  },
+  "uiChannel": {
+    "webcomponent": null,
+    "name": "Notifications",
+    "id": "0B2QG50zQR-brZXrgu4aXw"
+  },
+  "startedById": null
+}

--- a/rest-e2e-tests/test-data/canvas-api.test.js-canvas.json
+++ b/rest-e2e-tests/test-data/canvas-api.test.js-canvas.json
@@ -8,7 +8,7 @@
           "name": "numero",
           "canConnect": true,
           "noRepeat": false,
-          "id": "myId_0_1453815974997",
+          "id": "ep_zYI9pHCPTDm4z33iC_ch4Q",
           "type": "Double",
           "export": false,
           "longName": "Stream.numero"
@@ -19,7 +19,7 @@
           "name": "areWeDoneYet",
           "canConnect": true,
           "noRepeat": false,
-          "id": "myId_0_1453815975004",
+          "id": "ep_QCnGbntbQkuBxKn-YTRovg",
           "type": "Boolean",
           "export": false,
           "longName": "Stream.areWeDoneYet"
@@ -217,7 +217,7 @@
       },
       "inputs": [
         {
-          "sourceId": "myId_0_1453815974997",
+          "sourceId": "ep_zYI9pHCPTDm4z33iC_ch4Q",
           "canToggleDrivingInput": true,
           "drivingInput": true,
           "type": "Double",
@@ -313,11 +313,102 @@
       "type": "module",
       "canClearState": true,
       "hash": 3
+    },
+    {
+      "outputs": [],
+      "inputs": [
+        {
+          "sourceId": "ep_zYI9pHCPTDm4z33iC_ch4Q",
+          "canToggleDrivingInput": false,
+          "displayName": "numero",
+          "drivingInput": true,
+          "type": "Object",
+          "connected": true,
+          "requiresConnection": false,
+          "name": "endpoint-1573446921385",
+          "canConnect": true,
+          "id": "3874698d-4ece-41b6-b686-9848b725a261",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": false,
+            "index": 1
+          },
+          "acceptedTypes": [
+            "Object"
+          ],
+          "export": false,
+          "longName": "Table.numero"
+        },
+        {
+          "canToggleDrivingInput": false,
+          "displayName": "in2",
+          "drivingInput": true,
+          "type": "Object",
+          "connected": false,
+          "requiresConnection": false,
+          "name": "endpoint-9a04ee06-c51f-45ca-8f79-ead8e91b2606",
+          "canConnect": true,
+          "id": "9a04ee06-c51f-45ca-8f79-ead8e91b2606",
+          "jsClass": "VariadicInput",
+          "variadic": {
+            "isLast": true,
+            "index": 2
+          },
+          "acceptedTypes": [
+            "Object"
+          ],
+          "export": false,
+          "longName": "Table.in2"
+        }
+      ],
+      "uiChannel": {
+        "webcomponent": "streamr-table",
+        "name": "Table",
+        "id": "bgZJPowgTVywNbnKCxGFtw"
+      },
+      "canRefresh": false,
+      "params": [],
+      "jsModule": "TableModule",
+      "type": "module event-table-module",
+      "canClearState": true,
+      "layout": {
+        "width": "250px",
+        "position": {
+          "top": "167px",
+          "left": "1022px"
+        },
+        "height": "251px"
+      },
+      "tableConfig": {
+        "headers": [
+          "timestamp",
+          "numero"
+        ],
+        "title": "Table"
+      },
+      "name": "Table",
+      "options": {
+        "maxRows": {
+          "type": "int",
+          "value": 20
+        },
+        "showOnlyNewValues": {
+          "type": "boolean",
+          "value": true
+        },
+        "uiResendLast": {
+          "type": "int",
+          "value": 20
+        }
+      },
+      "id": 527,
+      "hash": 4
     }
   ],
+  "settings": {},
   "uiChannel": {
     "webcomponent": null,
     "name": "Notifications",
-    "id": "K2bPJOACRG6y-jv2GG0S8w"
+    "id": "iwJp1XpaTD6aRS8jba_Pyw"
   }
 }

--- a/src/java/com/unifina/data/HistoricalEventQueue.java
+++ b/src/java/com/unifina/data/HistoricalEventQueue.java
@@ -30,7 +30,7 @@ public class HistoricalEventQueue extends DataSourceEventQueue {
 	public HistoricalEventQueue(Globals globals, DataSource dataSource, int capacity) {
 		super(globals, dataSource, capacity, false);
 		speed = readSpeedConfiguration(globals);
-		simTimeStart = globals.getStartDate().getTime() - (globals.getStartDate().getTime() % 1000);
+		simTimeStart = globals.getTime().getTime();
 	}
 
 	/**
@@ -43,8 +43,6 @@ public class HistoricalEventQueue extends DataSourceEventQueue {
 
 	@Override
 	protected void beforeStart() {
-		// Set start time to simulation start time
-		initTimeReporting(simTimeStart);
 		// Remember wall-clock time to control playback speed
 		realTimeStart = System.currentTimeMillis();
 	}


### PR DESCRIPTION
Timestamps smaller than the initial value of `globals.time` were being reported to `ITimeListener`s in realtime mode. This lead to problems in case time listeners (such as the `Clock` module) read time when the module is initialized, because the first reported clock tick was less than the time at initialization.

This PR includes a slight refactoring to start the time ticking from the next full second that follows the initial value of `globals.time`.

This PR is an alternative solution to #711 by @harbu, which requires modules to guard against the bug in time reporting. Assuming that this PR does indeed fix the underlying bug, the modules don't need to guard against this issue anymore.

@timoxley 's tests added in #707 seem to pass with this branch. Would be good if you guys could do some further validation.