### PR TITLE
Core 1861 perms cleanup

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -50,6 +50,8 @@ class UrlMappings {
 		"/api/v1/dashboards/$resourceId/permissions"(resources: "permissionApi", excludes: ["create", "edit", "update"]) { resourceClass = Dashboard }
 		"/api/v1/dashboards/$resourceId/permissions/me"(controller: "permissionApi", action: "getOwnPermissions") { resourceClass = Dashboard }
 
+		"/api/v1/permissions/cleanup"(method: "DELETE", controller: "permissionApi", action: "cleanup")
+
 		"/api/v1/metrics"(resources: "metricsApi")
 
 		"/api/v1/modules"(resources: "moduleApi")

--- a/grails-app/controllers/com/unifina/controller/api/PermissionApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/PermissionApiController.groovy
@@ -9,6 +9,7 @@ import com.unifina.domain.security.Permission.Operation
 import com.unifina.domain.security.SecUser
 import com.unifina.domain.security.SignupInvite
 import com.unifina.domain.signalpath.Canvas
+import com.unifina.security.AllowRole
 import com.unifina.security.AuthLevel
 import com.unifina.security.StreamrApi
 import com.unifina.service.EthereumIntegrationKeyService
@@ -224,5 +225,11 @@ class PermissionApiController {
 			permissionService.systemRevoke(p)
 			render status: 204
 		}
+	}
+
+	@StreamrApi(allowRoles = AllowRole.DEVOPS)
+	def cleanup() {
+		permissionService.cleanUpExpiredPermissions()
+		render status: 200
 	}
 }

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -524,6 +524,11 @@ class PermissionService {
 		}
 	}
 
+	public void cleanUpExpiredPermissions() {
+		Date now = new Date()
+		Permission.deleteAll(Permission.findAllByEndsAtLessThan(now))
+	}
+
 	private boolean hasPermission(Userish userish, resource, Operation op) {
 		userish = userish?.resolveToUserish()
 		String resourceProp = getResourcePropertyName(resource)

--- a/test/unit/com/unifina/controller/api/PermissionApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/PermissionApiControllerSpec.groovy
@@ -342,4 +342,14 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		1 * permissionService.getPermissionsTo(_, me) >> [canvasPermission]
 		0 * permissionService._
 	}
+
+	void "cleanup calls service to delete expired permissions"() {
+		when:
+		request.method = "DELETE"
+		authenticatedAs(me) { controller.cleanup() }
+
+		then:
+		1 * permissionService.cleanUpExpiredPermissions()
+		response.status == 200
+	}
 }


### PR DESCRIPTION
Admin endpoint to clean up expired permissions (`endsAt` is in the past).