### PR TITLE
Use HTTPS instead of HTTP for Maven repo

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -48,7 +48,7 @@ grails.project.dependency.resolution = {
 		mavenLocal()
 
 		// Maven central
-		mavenRepo "http://repo1.maven.org/maven2/"
+		mavenRepo "https://repo1.maven.org/maven2/"
 
 		// Ethereum Repository
 		mavenRepo "https://dl.bintray.com/ethereum/maven/"


### PR DESCRIPTION
There are some intermittent download errors with repo1.maven.org at the moment. I expect them to resolve automatically. This patch uses HTTPS to access repo1.maven.org.
repo1.maven.org will drop HTTP support on 15th of Jan.
