### PR TITLE
CORE-1863: change PROXY_ERROR to 503 if CPS is not responding

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/ErrorController.groovy
@@ -67,6 +67,13 @@ class ErrorController {
 			log.error("Unexpected error occurred on request to ${request?.getMethod()} ${request?.getRequestURL()}, returning status code 500", exception)
 		}
 
+		def extraHeaders = apiError.getHeaders()
+		if (extraHeaders != null) {
+			extraHeaders.each { key, value ->
+				response.setHeader(key, value)
+			}
+		}
+
 		response.status = apiError.statusCode
 		render(apiError.toMap() as JSON)
 	}

--- a/grails-app/services/com/unifina/service/CommunityOperatorService.groovy
+++ b/grails-app/services/com/unifina/service/CommunityOperatorService.groovy
@@ -63,9 +63,9 @@ public class CommunityOperatorService implements InitializingBean {
 			try {
 				response = client.execute(req);
 			} catch (ConnectException e) {
-				String msg = "Community server is not responding";
+				String msg = "Community server is busy or not responding";
 				log.error(msg, e);
-				throw new ProxyException(msg);
+				throw new ProxyException(503, msg, ["Retry-After": "60"]);	// 1 minute
 			} catch (SocketTimeoutException e) {
 				String msg = "Community server gateway timeout";
 				log.error(msg, e);

--- a/src/java/com/unifina/api/ApiError.java
+++ b/src/java/com/unifina/api/ApiError.java
@@ -8,24 +8,32 @@ import java.util.Map;
  */
 public class ApiError {
 	private final int statusCode;
-	private final Map<String, String> map = new HashMap<>();
+	private final Map<String, String> body = new HashMap<>();
+	private final Map<String, String> headers;
 
 	public ApiError(int statusCode, String code, String message) {
+		this(statusCode, code, message, null);
+	}
+	public ApiError(int statusCode, String code, String message, Map<String, String> headers) {
 		this.statusCode = statusCode;
-		map.put("code", code);
-		map.put("message", message);
+		body.put("code", code);
+		body.put("message", message);
+		this.headers = headers;
 	}
 
 	public void addEntry(String key, String value) {
-		map.put(key, value);
+		body.put(key, value);
 	}
 
 	/** JSON object that is returned as message body */
 	public Map<String, String> toMap() {
-		return map;
+		return body;
 	}
 
 	public int getStatusCode() {
 		return statusCode;
+	}
+	public Map<String, String> getHeaders() {
+		return headers;
 	}
 }

--- a/src/java/com/unifina/api/ApiError.java
+++ b/src/java/com/unifina/api/ApiError.java
@@ -21,11 +21,11 @@ public class ApiError {
 		this.headers = headers;
 	}
 
-	public void addEntry(String key, String value) {
+	public void addToBody(String key, String value) {
 		body.put(key, value);
 	}
 
-	/** JSON object that is returned as message body */
+	/** @return Map that is turned into HTTP response body JSON object */
 	public Map<String, String> toMap() {
 		return body;
 	}

--- a/src/java/com/unifina/api/CsvParseUnknownSchemaException.java
+++ b/src/java/com/unifina/api/CsvParseUnknownSchemaException.java
@@ -14,8 +14,8 @@ public class CsvParseUnknownSchemaException extends ApiException {
 	@Override
 	public ApiError asApiError() {
 		ApiError apiError = super.asApiError();
-		apiError.addEntry("fileUrl", fileUrl);
-		apiError.addEntry("schema", schema);
+		apiError.addToBody("fileUrl", fileUrl);
+		apiError.addToBody("schema", schema);
 		return apiError;
 	}
 }

--- a/src/java/com/unifina/api/InvalidArgumentsException.java
+++ b/src/java/com/unifina/api/InvalidArgumentsException.java
@@ -1,7 +1,5 @@
 package com.unifina.api;
 
-import java.util.Map;
-
 public class InvalidArgumentsException extends ApiException {
 	/** Name of the faulty argument */
 	private String fault;
@@ -21,8 +19,8 @@ public class InvalidArgumentsException extends ApiException {
 	public ApiError asApiError() {
 		ApiError e = super.asApiError();
 		if (fault != null && value != null) {
-			e.addEntry("fault", fault);
-			e.addEntry(fault, value);
+			e.addToBody("fault", fault);
+			e.addToBody(fault, value);
 		}
 		return e;
 	}

--- a/src/java/com/unifina/api/NotFoundException.java
+++ b/src/java/com/unifina/api/NotFoundException.java
@@ -22,9 +22,9 @@ public class NotFoundException extends ApiException {
 	public ApiError asApiError() {
 		ApiError e = super.asApiError();
 		if (type != null && id != null) {
-			e.addEntry("type", type);
-			e.addEntry("fault", "id");
-			e.addEntry("id", id);
+			e.addToBody("type", type);
+			e.addToBody("fault", "id");
+			e.addToBody("id", id);
 		}
 		return e;
 	}

--- a/src/java/com/unifina/api/NotPermittedException.java
+++ b/src/java/com/unifina/api/NotPermittedException.java
@@ -35,14 +35,14 @@ public class NotPermittedException extends ApiException {
 	public ApiError asApiError() {
 		ApiError e = super.asApiError();
 		if (type != null && id != null) {
-			e.addEntry("user", user != null ? user : "<not authenticated>");
-			e.addEntry("resource", type);
-			e.addEntry("id", id);
+			e.addToBody("user", user != null ? user : "<not authenticated>");
+			e.addToBody("resource", type);
+			e.addToBody("id", id);
 			if (op == null) {
-				e.addEntry("fault", "id");
+				e.addToBody("fault", "id");
 			} else {
-				e.addEntry("fault", "operation");
-				e.addEntry("operation", op);
+				e.addToBody("fault", "operation");
+				e.addToBody("operation", op);
 			}
 		}
 		return e;

--- a/src/java/com/unifina/api/ProxyException.groovy
+++ b/src/java/com/unifina/api/ProxyException.groovy
@@ -1,11 +1,21 @@
 package com.unifina.api
 
 class ProxyException extends ApiException {
+	final Map extraHeaders = null
+
+	ProxyException(int code, String message, Map headers) {
+		super(code, "PROXY_ERROR", message)
+		extraHeaders = headers;
+	}
 	ProxyException(int code, String message) {
 		super(code, "PROXY_ERROR", message)
 	}
-
 	ProxyException(String message) {
 		super(500, "PROXY_ERROR", message)
+	}
+
+	@Override
+	public ApiError asApiError() {
+		return new ApiError(getStatusCode(), getCode(), getMessage(), extraHeaders)
 	}
 }

--- a/test/unit/com/unifina/service/CommunityOperatorServiceSpec.groovy
+++ b/test/unit/com/unifina/service/CommunityOperatorServiceSpec.groovy
@@ -70,9 +70,10 @@ class CommunityOperatorServiceSpec extends Specification {
 			e = err
 		}
 		then:
-		e.message == "Community server is not responding"
+		e.message == "Community server is busy or not responding"
 		e.code == "PROXY_ERROR"
-		e.statusCode == 500
+		e.statusCode == 503
+		e.extraHeaders == ["Retry-After": "60"]
 	}
 
 	void "test execute returns 404"() {


### PR DESCRIPTION
TODO still to check timeouts (can be as low as 1 sec) and connection queue capacity (can be as small as 100 or even 10 concurrent pending connections).

Hand-tested working (no integration test to extend):
```
$ curl -v http://localhost:8081/streamr-core/api/v1/communities
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8081 (#0)
> GET /streamr-core/api/v1/communities HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 503 Service Unavailable
< Server: Apache-Coyote/1.1
< Retry-After: 60
< Content-Type: application/json;charset=UTF-8
< Transfer-Encoding: chunked
< Date: Mon, 13 Jan 2020 11:53:27 GMT
< Connection: close
<
* Closing connection 0
{"code":"PROXY_ERROR","message":"Community server is busy or not responding"}
```