### PR TITLE
CORE-1892: Remove Grails plugin cache-headers 1.1.7

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -117,7 +117,6 @@ grails.project.dependency.resolution = {
 		}
 
 		compile(":mail:1.0.7")
-		compile(":cache-headers:1.1.7")
 
 		runtime(':hibernate:3.6.10.19') // or :hibernate4:4.3.10
 		runtime(":cors:1.1.8") {


### PR DESCRIPTION
It's unused.