### PR TITLE
Hotfix: Make DataUnionOperatorService non-transactional

### DIFF
--- a/grails-app/services/com/unifina/service/DataUnionOperatorService.groovy
+++ b/grails-app/services/com/unifina/service/DataUnionOperatorService.groovy
@@ -26,6 +26,10 @@ import java.nio.charset.StandardCharsets
  * GET /dataunions/{contractAddress}/members/{memberAddress}: returns individual member stats (such as balances and withdraw proofs)
  */
 public class DataUnionOperatorService implements InitializingBean {
+
+	// This service just proxies requests to the DUS, so we don't want to start database transactions
+	static transactional = false
+
 	private static final Logger log = LogManager.getLogger(DataUnionOperatorService.class);
 	private String baseUrl;
 	private CloseableHttpClient client;


### PR DESCRIPTION
Requests that get proxied to DUS currently start database transactions, because by default Grails service methods are transactional. There is no need to consult the database when forwarding requests, so disable the default behavior by setting `transactional = false`.