### PR TITLE
CORE-1918 validation endpoints

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -35,6 +35,7 @@ class UrlMappings {
 		"/api/v1/streams/$id/uploadCsvFile"(method: "POST", controller: "streamApi", action: "uploadCsvFile")
 		"/api/v1/streams/$id/confirmCsvFileUpload"(method: "POST", controller: "streamApi", action: "confirmCsvFileUpload")
 		"/api/v1/streams/$id/dataFiles"(controller: "streamApi", action: "dataFiles")
+		"/api/v1/streams/$id/validation"(method: "GET", controller: "streamApi", action: "validation")
 		"/api/v1/streams/$id/publishers"(controller: "streamApi", action: "publishers")
 		"/api/v1/streams/$id/publisher/$address"(controller: "streamApi", action: "publisher")
 		"/api/v1/streams/$id/subscribers"(controller: "streamApi", action: "subscribers")

--- a/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
@@ -174,8 +174,21 @@ class StreamApiController {
 	}
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
+	def validation(String id) {
+		Stream stream = Stream.get(id)
+		if (stream == null) {
+			throw new NotFoundException("Stream", id)
+		} else {
+			render(stream.toValidationMap() as JSON)
+		}
+	}
+
+	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def publishers(String id) {
-		getAuthorizedStream(id, Operation.READ) { Stream stream ->
+		Stream stream = Stream.get(id)
+		if (stream == null) {
+			throw new NotFoundException("Stream", id)
+		} else {
 			Set<String> publisherAddresses = streamService.getStreamEthereumPublishers(stream)
 			render([addresses: publisherAddresses] as JSON)
 		}
@@ -183,7 +196,10 @@ class StreamApiController {
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def subscribers(String id) {
-		getAuthorizedStream(id, Operation.WRITE) { Stream stream ->
+		Stream stream = Stream.get(id)
+		if (stream == null) {
+			throw new NotFoundException("Stream", id)
+		} else {
 			Set<String> subscriberAddresses = streamService.getStreamEthereumSubscribers(stream)
 			render([addresses: subscriberAddresses] as JSON)
 		}
@@ -191,8 +207,11 @@ class StreamApiController {
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def publisher(String id, String address) {
-		getAuthorizedStream(id, Operation.READ) { Stream stream ->
-			if(streamService.isStreamEthereumPublisher(stream, address)) {
+		Stream stream = Stream.get(id)
+		if (stream == null) {
+			throw new NotFoundException("Stream", id)
+		} else {
+			if (streamService.isStreamEthereumPublisher(stream, address)) {
 				render(status: 200)
 			} else {
 				render(status: 404)
@@ -202,8 +221,11 @@ class StreamApiController {
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def subscriber(String id, String address) {
-		getAuthorizedStream(id, Operation.WRITE) { Stream stream ->
-			if(streamService.isStreamEthereumSubscriber(stream, address)) {
+		Stream stream = Stream.get(id)
+		if (stream == null) {
+			throw new NotFoundException("Stream", id)
+		} else {
+			if (streamService.isStreamEthereumSubscriber(stream, address)) {
 				render(status: 200)
 			} else {
 				render(status: 404)

--- a/grails-app/domain/com/unifina/domain/data/Stream.groovy
+++ b/grails-app/domain/com/unifina/domain/data/Stream.groovy
@@ -120,6 +120,19 @@ class Stream implements Comparable {
 		]
 	}
 
+	/**
+	 * Returns only the public fields required for validating messages in streams
+	 */
+	@CompileStatic
+	Map toValidationMap() {
+		[
+			id: id,
+			partitions: partitions,
+			requireSignedData: requireSignedData,
+			requireEncryptedData: requireEncryptedData,
+		]
+	}
+
 	@Override
 	int compareTo(Object arg0) {
 		if (!(arg0 instanceof Stream)) return 0

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -244,9 +244,29 @@ class Streams {
             })
     }
 
+    getValidationInfo(id) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('GET', `streams/${id}/validation`)
+    }
+
     getPublishers(id) {
         return new StreamrApiRequest(this.options)
             .methodAndPath('GET', `streams/${id}/publishers`)
+    }
+
+    getSubscribers(id) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('GET', `streams/${id}/subscribers`)
+    }
+
+    isPublisher(streamId, address) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('GET', `streams/${streamId}/publisher/${address}`)
+    }
+
+    isSubscriber(streamId, address) {
+        return new StreamrApiRequest(this.options)
+            .methodAndPath('GET', `streams/${streamId}/subscriber/${address}`)
     }
 }
 

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -62,21 +62,23 @@ describe('Streams API', () => {
         })
     })
 
-    describe('GET /api/v1/streams/:id/publishers', () => {
-        it('requires authentication for private streams', async () => {
-            const response = await Streamr.api.v1.streams.getPublishers(streamId).call()
-            assert.equal(response.status, 403)
+    describe('GET /api/v1/streams/:id/validation', () => {
+        it('does not require authentication', async () => {
+            const response = await Streamr.api.v1.streams.getValidationInfo(streamId).call()
+            assert.equal(response.status, 200)
         })
-        it('does not require authentication for public streams', async () => {
-            const publicStreamResponse = await Streamr.api.v1.streams
-                .create({
-                    name: 'stream-id-' + Date.now()
-                })
-                .withApiKey(API_KEY)
-                .execute()
-            const permResponse = await Streamr.api.v1.streams.makePublic(publicStreamResponse.id).withApiKey(API_KEY).call()
-            assert.equal(permResponse.status, 201)
-            const response = await Streamr.api.v1.streams.getPublishers(publicStreamResponse.id).call()
+    })
+
+    describe('GET /api/v1/streams/:id/publishers', () => {
+        it('does not require authentication', async () => {
+            const response = await Streamr.api.v1.streams.getPublishers(streamId).call()
+            assert.equal(response.status, 200)
+        })
+    })
+
+    describe('GET /api/v1/streams/:id/subscribers', () => {
+        it('does not require authentication', async () => {
+            const response = await Streamr.api.v1.streams.getSubscribers(streamId).call()
             assert.equal(response.status, 200)
         })
     })


### PR DESCRIPTION
Make the fields necessary for message validation public (=no authentication required). In the future these fields would be on-chain, so public anyway.

Add a new public endpoint `/streams/{id}/validation` that returns only the following fields of a `Stream`:

- `partitions`
- `requireSignedData`
- `requireEncryptedData`

Additionally, make public the endpoints necessary to check valid publishers/subscribers:

- `/streams/{id}/publishers`
- `/streams/{id}/subscribers`
- `/streams/{id}/publisher/{address}`
- `/streams/{id}/subscriber/{address}`