### PR TITLE
Use InternalAuthenticationMethod to obtain sessionToken

### DIFF
--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -1,9 +1,10 @@
 package com.unifina.service
 
+
 import com.streamr.client.StreamrClient
 import com.streamr.client.authentication.ApiKeyAuthenticationMethod
 import com.streamr.client.authentication.AuthenticationMethod
-import com.streamr.client.authentication.EthereumAuthenticationMethod
+import com.streamr.client.authentication.InternalAuthenticationMethod
 import com.streamr.client.options.EncryptionOptions
 import com.streamr.client.options.SigningOptions
 import com.streamr.client.options.StreamrClientOptions
@@ -18,6 +19,9 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.ReentrantLock
 
 class StreamrClientService {
+
+	EthereumIntegrationKeyService ethereumIntegrationKeyService
+	SessionService sessionService
 
 	private static final Logger log = Logger.getLogger(StreamrClientService)
 
@@ -66,7 +70,14 @@ class StreamrClientService {
 				if (!instanceForThisEngineNode) {
 					String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
 					log.debug("Creating StreamrClient instance for this Engine node. Using private key ${nodePrivateKey?.substring(0, 2)}...")
-					instanceForThisEngineNode = createInstance(new EthereumAuthenticationMethod(nodePrivateKey))
+
+					// Create a custom EthereumAuthenticationMethod which doesn't call the API, but instead uses the internal services to
+					// get a sessionToken. Calling the API here can lead to a deadlock situation in some corner cases, because the
+					// service calls "itself" while blocking in a mutex-lock.
+					InternalAuthenticationMethod authenticationMethod = new InternalAuthenticationMethod(nodePrivateKey, ethereumIntegrationKeyService, sessionService)
+					instanceForThisEngineNode = createInstance(authenticationMethod)
+					// Make sure the instance is authenticated before returning
+					instanceForThisEngineNode.getSessionToken()
 					log.debug("StreamrClient instance created. State: ${instanceForThisEngineNode.getState()}")
 				}
 				return instanceForThisEngineNode

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -1,0 +1,44 @@
+package com.streamr.client.authentication;
+
+import com.google.gson.Gson;
+import com.unifina.domain.security.SecUser;
+import com.unifina.security.SessionToken;
+import com.unifina.service.EthereumIntegrationKeyService;
+import com.unifina.service.SessionService;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
+	private final SessionService sessionService;
+	private final EthereumIntegrationKeyService ethereumIntegrationKeyService;
+
+	public InternalAuthenticationMethod(String ethereumPrivateKey, EthereumIntegrationKeyService ethereumIntegrationKeyService, SessionService sessionService) {
+		super(ethereumPrivateKey);
+		this.ethereumIntegrationKeyService = ethereumIntegrationKeyService;
+		this.sessionService = sessionService;
+	}
+
+	@Override
+	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
+		final SecUser user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
+		final SessionToken sessionToken = sessionService.generateToken(user);
+
+		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass
+		String jsonResponse = new Gson().toJson(sessionToken.toMap());
+		return this.parse(new okio.Buffer().writeString(jsonResponse, Charset.forName("UTF-8")));
+
+		/*
+		new AuthenticationMethod.LoginResponse() {
+			@Override
+			String getSessionToken() {
+				return sessionToken.getToken()
+			}
+			@Override
+			Date getExpiration() {
+				return sessionToken.getExpiration()
+			}
+		}
+		*/
+	}
+}

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -11,17 +11,16 @@ import java.nio.charset.Charset;
 
 public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	private final SessionService sessionService;
-	private final EthereumIntegrationKeyService ethereumIntegrationKeyService;
+	private final SecUser user;
 
 	public InternalAuthenticationMethod(String ethereumPrivateKey, EthereumIntegrationKeyService ethereumIntegrationKeyService, SessionService sessionService) {
 		super(ethereumPrivateKey);
-		this.ethereumIntegrationKeyService = ethereumIntegrationKeyService;
+		this.user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
 		this.sessionService = sessionService;
 	}
 
 	@Override
 	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
-		final SecUser user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
 		final SessionToken sessionToken = sessionService.generateToken(user);
 
 		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -8,6 +8,7 @@ import com.unifina.service.SessionService;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Date;
 
 public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	private final SessionService sessionService;
@@ -22,22 +23,6 @@ public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	@Override
 	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
 		final SessionToken sessionToken = sessionService.generateToken(user);
-
-		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass
-		String jsonResponse = new Gson().toJson(sessionToken.toMap());
-		return this.parse(new okio.Buffer().writeString(jsonResponse, Charset.forName("UTF-8")));
-
-		/*
-		new AuthenticationMethod.LoginResponse() {
-			@Override
-			String getSessionToken() {
-				return sessionToken.getToken()
-			}
-			@Override
-			Date getExpiration() {
-				return sessionToken.getExpiration()
-			}
-		}
-		*/
+		return new AuthenticationMethod.LoginResponse(sessionToken.getToken(), sessionToken.getExpiration());
 	}
 }


### PR DESCRIPTION
Avoids making an API call to the system itself when creating the `StreamrClient` for the EE instance. This can lead to a deadlock when lots of DU join requests are coming in during instance startup.

Re the TODO: The code can be made slightly prettier when [this PR](https://github.com/streamr-dev/streamr-client-java/pull/50) is merged and Java client updated. But it's not terribly hacky as is.