### PR TITLE
Fix integration tests

### DIFF
--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -35,9 +35,12 @@ class StreamrClientService {
 	}
 
 	/**
-	 * Useful for testing, this constructor allows the StreamrClient class to be injected
+	 * Useful for testing, this method allows a StreamrClient class with some mocked methods to be passed
 	 */
-	StreamrClientService(Class<StreamrClient> streamrClientClass) {
+	void setClientClass(Class<StreamrClient> streamrClientClass) {
+		if (instanceForThisEngineNode) {
+			throw new IllegalStateException("StreamrClient instance has already been created. Call setClientClass() before calling getInstanceForThisEngineNode()!")
+		}
 		clientConstructor = streamrClientClass.getConstructor(StreamrClientOptions)
 	}
 

--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -1,9 +1,10 @@
 package com.unifina.service
 
+
 import com.streamr.client.StreamrClient
 import com.streamr.client.authentication.ApiKeyAuthenticationMethod
 import com.streamr.client.authentication.AuthenticationMethod
-import com.streamr.client.authentication.EthereumAuthenticationMethod
+import com.streamr.client.authentication.InternalAuthenticationMethod
 import com.streamr.client.options.EncryptionOptions
 import com.streamr.client.options.SigningOptions
 import com.streamr.client.options.StreamrClientOptions
@@ -18,6 +19,9 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.ReentrantLock
 
 class StreamrClientService {
+
+	EthereumIntegrationKeyService ethereumIntegrationKeyService
+	SessionService sessionService
 
 	private static final Logger log = Logger.getLogger(StreamrClientService)
 
@@ -66,7 +70,14 @@ class StreamrClientService {
 				if (!instanceForThisEngineNode) {
 					String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
 					log.debug("Creating StreamrClient instance for this Engine node. Using private key ${nodePrivateKey?.substring(0, 2)}...")
-					instanceForThisEngineNode = createInstance(new EthereumAuthenticationMethod(nodePrivateKey))
+
+					// Create a custom EthereumAuthenticationMethod which doesn't call the API, but instead uses the internal services to
+					// get a sessionToken. Calling the API here can lead to a deadlock situation in some corner cases, because the
+					// service calls "itself" while blocking in a mutex-lock.
+					InternalAuthenticationMethod authenticationMethod = new InternalAuthenticationMethod(nodePrivateKey, ethereumIntegrationKeyService, sessionService)
+					instanceForThisEngineNode = createInstance(authenticationMethod)
+					// Make sure the instance is authenticated before returning
+					instanceForThisEngineNode.getSessionToken()
 					log.debug("StreamrClient instance created. State: ${instanceForThisEngineNode.getState()}")
 				}
 				return instanceForThisEngineNode

--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -65,7 +65,7 @@ class StreamrClientService {
 	 */
 	StreamrClient getInstanceForThisEngineNode() {
 		// Mutex lock with timeout to avoid race conditions
-		if (instanceForThisEngineNodeLock.tryLock(1L, TimeUnit.SECONDS)) {
+		if (instanceForThisEngineNodeLock.tryLock(3L, TimeUnit.SECONDS)) {
 			try {
 				if (!instanceForThisEngineNode) {
 					String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -1,0 +1,44 @@
+package com.streamr.client.authentication;
+
+import com.google.gson.Gson;
+import com.unifina.domain.security.SecUser;
+import com.unifina.security.SessionToken;
+import com.unifina.service.EthereumIntegrationKeyService;
+import com.unifina.service.SessionService;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
+	private final SessionService sessionService;
+	private final EthereumIntegrationKeyService ethereumIntegrationKeyService;
+
+	public InternalAuthenticationMethod(String ethereumPrivateKey, EthereumIntegrationKeyService ethereumIntegrationKeyService, SessionService sessionService) {
+		super(ethereumPrivateKey);
+		this.ethereumIntegrationKeyService = ethereumIntegrationKeyService;
+		this.sessionService = sessionService;
+	}
+
+	@Override
+	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
+		final SecUser user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
+		final SessionToken sessionToken = sessionService.generateToken(user);
+
+		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass
+		String jsonResponse = new Gson().toJson(sessionToken.toMap());
+		return this.parse(new okio.Buffer().writeString(jsonResponse, Charset.forName("UTF-8")));
+
+		/*
+		new AuthenticationMethod.LoginResponse() {
+			@Override
+			String getSessionToken() {
+				return sessionToken.getToken()
+			}
+			@Override
+			Date getExpiration() {
+				return sessionToken.getExpiration()
+			}
+		}
+		*/
+	}
+}

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -11,17 +11,16 @@ import java.nio.charset.Charset;
 
 public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	private final SessionService sessionService;
-	private final EthereumIntegrationKeyService ethereumIntegrationKeyService;
+	private final SecUser user;
 
 	public InternalAuthenticationMethod(String ethereumPrivateKey, EthereumIntegrationKeyService ethereumIntegrationKeyService, SessionService sessionService) {
 		super(ethereumPrivateKey);
-		this.ethereumIntegrationKeyService = ethereumIntegrationKeyService;
+		this.user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
 		this.sessionService = sessionService;
 	}
 
 	@Override
 	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
-		final SecUser user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(this.getAddress());
 		final SessionToken sessionToken = sessionService.generateToken(user);
 
 		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass

--- a/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
+++ b/src/java/com/streamr/client/authentication/InternalAuthenticationMethod.java
@@ -8,6 +8,7 @@ import com.unifina.service.SessionService;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Date;
 
 public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	private final SessionService sessionService;
@@ -22,22 +23,6 @@ public class InternalAuthenticationMethod extends EthereumAuthenticationMethod {
 	@Override
 	protected AuthenticationMethod.LoginResponse login(String restApiUrl) throws IOException {
 		final SessionToken sessionToken = sessionService.generateToken(user);
-
-		// TODO: replace when AuthenticationMethod.LoginResponse is visible to subclass
-		String jsonResponse = new Gson().toJson(sessionToken.toMap());
-		return this.parse(new okio.Buffer().writeString(jsonResponse, Charset.forName("UTF-8")));
-
-		/*
-		new AuthenticationMethod.LoginResponse() {
-			@Override
-			String getSessionToken() {
-				return sessionToken.getToken()
-			}
-			@Override
-			Date getExpiration() {
-				return sessionToken.getExpiration()
-			}
-		}
-		*/
+		return new AuthenticationMethod.LoginResponse(sessionToken.getToken(), sessionToken.getExpiration());
 	}
 }

--- a/src/java/com/unifina/utils/testutils/FakeStreamrClient.java
+++ b/src/java/com/unifina/utils/testutils/FakeStreamrClient.java
@@ -4,11 +4,16 @@ import com.streamr.client.StreamrClient;
 import com.streamr.client.exceptions.ResourceNotFoundException;
 import com.streamr.client.options.StreamrClientOptions;
 import com.streamr.client.rest.Stream;
+import com.streamr.client.rest.UserInfo;
 import com.streamr.client.utils.UnencryptedGroupKey;
 
 import java.io.IOException;
 import java.util.*;
 
+/**
+ * Helper class to be used in unit tests which use StreamrClient.
+ * Aims to prevent actual http/websocket connections from being opened.
+ */
 public class FakeStreamrClient extends StreamrClient {
 
 	private Map<String, List<SentMessage>> sentMessagesByChannel = new HashMap<>();
@@ -16,8 +21,7 @@ public class FakeStreamrClient extends StreamrClient {
 	StreamrClientOptions optionsPassedToConstructor;
 
 	public FakeStreamrClient(StreamrClientOptions options) {
-		super(new StreamrClientOptions()); // Default options won't connect anywhere immediately, good for unit tests
-		optionsPassedToConstructor = options;
+		super(options);
 	}
 
 	@Override
@@ -33,6 +37,11 @@ public class FakeStreamrClient extends StreamrClient {
 		Stream s = new Stream("", "");
 		s.setId(streamId);
 		return s;
+	}
+
+	@Override
+	public UserInfo getUserInfo() throws IOException {
+		return new UserInfo("test-user", "test-username", "test-id");
 	}
 
 	public Map<String, List<SentMessage>> getAndClearSentMessages() {
@@ -51,9 +60,5 @@ public class FakeStreamrClient extends StreamrClient {
 			this.timestamp = timestamp;
 			this.partitionKey = partitionKey;
 		}
-	}
-
-	public StreamrClientOptions getOptionsPassedToConstructor() {
-		return optionsPassedToConstructor;
 	}
 }

--- a/test/integration/com/unifina/service/StreamrClientServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/StreamrClientServiceIntegrationSpec.groovy
@@ -4,6 +4,8 @@ import com.streamr.client.StreamrClient
 import com.streamr.client.authentication.ApiKeyAuthenticationMethod
 import com.unifina.domain.security.Key
 import com.unifina.domain.security.SecUser
+import com.unifina.security.BCryptPasswordEncoder
+import com.unifina.security.PasswordEncoder
 import com.unifina.utils.testutils.FakeStreamrClient
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -51,6 +53,13 @@ class StreamrClientServiceIntegrationSpec extends Specification {
 	}
 
 	void "getInstanceForThisEngineNode() should return a singleton instance in a race condition"() {
+		service.ethereumIntegrationKeyService = Spy(EthereumIntegrationKeyService)
+		service.ethereumIntegrationKeyService.userService = Spy(UserService)
+		service.ethereumIntegrationKeyService.userService.passwordEncoder = new BCryptPasswordEncoder(5)
+		service.ethereumIntegrationKeyService.userService.permissionService = Spy(PermissionService)
+		service.ethereumIntegrationKeyService.userService.canvasService = Spy(CanvasService)
+		service.ethereumIntegrationKeyService.userService.streamService = Spy(StreamService)
+		service.ethereumIntegrationKeyService.permissionService = Spy(PermissionService)
 		List<StreamrClient> instances = Collections.synchronizedList([])
 		List<Thread> threads = []
 
@@ -76,6 +85,12 @@ class StreamrClientServiceIntegrationSpec extends Specification {
 		service.sessionService = Spy(SessionService)
 		service.sessionService.keyValueStoreService = new KeyValueStoreService()
 		service.ethereumIntegrationKeyService = Spy(EthereumIntegrationKeyService)
+		service.ethereumIntegrationKeyService.userService = Spy(UserService)
+		service.ethereumIntegrationKeyService.userService.passwordEncoder = new BCryptPasswordEncoder(5)
+		service.ethereumIntegrationKeyService.userService.permissionService = Spy(PermissionService)
+		service.ethereumIntegrationKeyService.userService.canvasService = Spy(CanvasService)
+		service.ethereumIntegrationKeyService.userService.streamService = Spy(StreamService)
+		service.ethereumIntegrationKeyService.permissionService = Spy(PermissionService)
 		StreamrClient client
 
 		when:

--- a/test/unit/com/unifina/service/StreamrClientServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamrClientServiceSpec.groovy
@@ -1,0 +1,105 @@
+package com.unifina.service
+
+import com.streamr.client.StreamrClient
+import com.streamr.client.authentication.ApiKeyAuthenticationMethod
+import com.streamr.client.authentication.InternalAuthenticationMethod
+import com.unifina.domain.security.Key
+import com.unifina.domain.security.SecUser
+import com.unifina.security.SessionToken
+import com.unifina.utils.testutils.FakeStreamrClient
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+@TestFor(StreamrClientService)
+@Mock(SecUser)
+class StreamrClientServiceSpec extends Specification {
+	SecUser user
+
+	void setup() {
+		user = new SecUser(
+			username: "StreamrClientServiceIntegrationSpec-${System.currentTimeMillis()}@streamr.invalid",
+			name: "user",
+			password: "password",
+		).save(failOnError: true)
+
+		service.setClientClass(FakeStreamrClient)
+	}
+
+	void "getAuthenticatedInstance() should create a StreamrClient with ApiKeyAuthenticationMethod (user has one Key)"() {
+		new Key(name: "test", user: user).save(failOnError: true, validate: true)
+
+		when:
+		FakeStreamrClient client = (FakeStreamrClient) service.getAuthenticatedInstance(user.id)
+		then:
+		client.getOptions().getAuthenticationMethod() instanceof ApiKeyAuthenticationMethod
+	}
+
+	void "getAuthenticatedInstance() should create a StreamrClient with ApiKeyAuthenticationMethod (user has several Keys)"() {
+		new Key(name: "test", user: user).save(failOnError: true, validate: true)
+		new Key(name: "test2", user: user).save(failOnError: true, validate: true)
+		assert Key.countByUser(user) == 2
+
+		when:
+		FakeStreamrClient client = (FakeStreamrClient) service.getAuthenticatedInstance(user.id)
+		then:
+		client.getOptions().getAuthenticationMethod() instanceof ApiKeyAuthenticationMethod
+	}
+
+	void "getAuthenticatedInstance() should throw if a user doesn't have any Keys (illegal state)"() {
+		when:
+		service.getAuthenticatedInstance(user.id)
+		then:
+		thrown(IllegalStateException)
+	}
+
+	void "getInstanceForThisEngineNode() uses sessionService to generate a sessionToken (instead of making an API call)"() {
+		SecUser eeUser = new SecUser()
+		SessionToken mockToken = Mock(SessionToken)
+
+		service.ethereumIntegrationKeyService = Mock(EthereumIntegrationKeyService)
+		service.sessionService = Mock(SessionService)
+
+		StreamrClient client
+
+		when:
+		client = service.getInstanceForThisEngineNode()
+
+		then:
+		client.getOptions().getAuthenticationMethod() instanceof InternalAuthenticationMethod
+		1 * service.ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(_) >> eeUser
+		1 * service.sessionService.generateToken(eeUser) >> mockToken
+	}
+
+	void "getInstanceForThisEngineNode() should return a singleton instance in a race condition"() {
+		SecUser eeUser = new SecUser()
+		SessionToken mockToken = Mock(SessionToken)
+
+		service.ethereumIntegrationKeyService = Mock(EthereumIntegrationKeyService)
+		service.ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(_) >> eeUser
+
+		service.sessionService = Mock(SessionService)
+		service.sessionService.generateToken(eeUser) >> mockToken
+
+		List<StreamrClient> instances = Collections.synchronizedList([])
+		List<Thread> threads = []
+
+		when:
+		// Create race condition
+		for (int i=0; i<50; i++) {
+			Thread t = Thread.start {
+				instances.add(service.getInstanceForThisEngineNode())
+			}
+			threads.add(t)
+		}
+
+		then:
+		// Wait for all the above threads to finish
+		new PollingConditions().within(60) {
+			threads.find {it.isAlive()} == null
+		}
+		// All instances are the same
+		instances.unique().size() == 1
+	}
+}


### PR DESCRIPTION
Attempt at fixing integration tests.

## First problem:
```
| Failure:  getInstanceForThisEngineNode() uses sessionService to generate a sessionToken (instead of making an API call)(com.unifina.service.StreamrClientServiceIntegrationSpec)
|  Too many invocations for:
1 * service.sessionService.generateToken(_)   (2 invocations)
Matching invocations (ordered by last occurrence):
2 * <SessionService>.generateToken(com.unifina.domain.security.SecUser : 1531)   <-- this triggered the error
	at org.spockframework.mock.runtime.MockInteraction.accept(MockInteraction.java:73)
	at org.spockframework.mock.runtime.MockInteractionDecorator.accept(MockInteractionDecorator.java:46)
	at org.spockframework.mock.runtime.InteractionScope$1.accept(InteractionScope.java:41)
	at org.spockframework.mock.runtime.MockController.handle(MockController.java:39)
	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
	at com.streamr.client.authentication.InternalAuthenticationMethod.login(InternalAuthenticationMethod.java:25)
	at com.streamr.client.authentication.AuthenticationMethod.newSessionToken(AuthenticationMethod.java:27)
	at com.streamr.client.authentication.Session.getSessionToken(Session.java:25)
	at com.streamr.client.authentication.Session.getNewSessionToken(Session.java:32)
	at com.streamr.client.StreamrRESTClient.addAuthenticationHeader(StreamrRESTClient.java:57)
	at com.streamr.client.StreamrRESTClient.executeWithRetry(StreamrRESTClient.java:84)
	at com.streamr.client.StreamrRESTClient.get(StreamrRESTClient.java:94)
	at com.streamr.client.StreamrRESTClient.getStream(StreamrRESTClient.java:118)
	at com.streamr.client.StreamrClient.<init>(StreamrClient.java:108)
	at com.unifina.service.StreamrClientService.createInstance(StreamrClientService.groovy:104)
	at com.unifina.service.StreamrClientService.getInstanceForThisEngineNode(StreamrClientService.groovy:78)
	at com.unifina.service.StreamrClientServiceIntegrationSpec.getInstanceForThisEngineNode() uses sessionService to generate a sessionToken (instead of making an API call)(StreamrClientServiceIntegrationSpec.groovy:97)

Too many invocations for:

1 * service.sessionService.generateToken(_)   (2 invocations)

Matching invocations (ordered by last occurrence):

2 * <SessionService>.generateToken(com.unifina.domain.security.SecUser : 1531)   <-- this triggered the error


Too many invocations for:

1 * service.sessionService.generateToken(_)   (2 invocations)

Matching invocations (ordered by last occurrence):

2 * <SessionService>.generateToken(com.unifina.domain.security.SecUser : 1531)   <-- this triggered the error


	at org.spockframework.mock.runtime.MockInteraction.accept(MockInteraction.java:73)
	at org.spockframework.mock.runtime.MockInteractionDecorator.accept(MockInteractionDecorator.java:46)
	at org.spockframework.mock.runtime.InteractionScope$1.accept(InteractionScope.java:41)
	at org.spockframework.mock.runtime.MockController.handle(MockController.java:39)
	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
	at com.streamr.client.authentication.InternalAuthenticationMethod.login(InternalAuthenticationMethod.java:25)
	at com.streamr.client.authentication.AuthenticationMethod.newSessionToken(AuthenticationMethod.java:27)
	at com.streamr.client.authentication.Session.getSessionToken(Session.java:25)
	at com.streamr.client.authentication.Session.getNewSessionToken(Session.java:32)
	at com.streamr.client.StreamrRESTClient.addAuthenticationHeader(StreamrRESTClient.java:57)
	at com.streamr.client.StreamrRESTClient.executeWithRetry(StreamrRESTClient.java:84)
	at com.streamr.client.StreamrRESTClient.get(StreamrRESTClient.java:94)
	at com.streamr.client.StreamrRESTClient.getStream(StreamrRESTClient.java:118)
	at com.streamr.client.StreamrClient.<init>(StreamrClient.java:108)
	at com.unifina.service.StreamrClientService.createInstance(StreamrClientService.groovy:104)
	at com.unifina.service.StreamrClientService.getInstanceForThisEngineNode(StreamrClientService.groovy:78)
	at com.unifina.service.StreamrClientServiceIntegrationSpec.getInstanceForThisEngineNode() uses sessionService to generate a sessionToken (instead of making an API call)(StreamrClientServiceIntegrationSpec.groovy:97)


```

## Second problem
```
| Error Exception in thread "Thread-27" 
| Error org.hibernate.HibernateException: No Hibernate Session bound to thread, and configuration does not allow creation of non-transactional one here
| Error 	at org.springframework.orm.hibernate3.SpringSessionContext.currentSession(SpringSessionContext.java:65)
| Error 	at org.hibernate.impl.SessionFactoryImpl.getCurrentSession(SessionFactoryImpl.java:687)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.validation.HibernateDomainClassValidator.validate(HibernateDomainClassValidator.java:58)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.metaclass.ValidatePersistentMethod.doInvokeInternal(ValidatePersistentMethod.java:116)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.metaclass.AbstractDynamicPersistentMethod.invoke(AbstractDynamicPersistentMethod.java:64)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.AbstractHibernateGormValidationApi.validate(AbstractHibernateGormValidationApi.groovy:41)
| Error 	at com.unifina.domain.security.SecUser.validate(SecUser.groovy)
| Error 	at com.unifina.domain.security.SecUser$validate$1.call(Unknown Source)
| Error 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
| Error 	at com.unifina.service.UserService.createUser(UserService.groovy:42)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.CGLIB$createUser$0(<generated>)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821$$FastClassByCGLIB$$838c5977.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.createUser(<generated>)
| Error 	at com.unifina.service.UserService.createUser(UserService.groovy)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.CGLIB$createUser$10(<generated>)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821$$FastClassByCGLIB$$838c5977.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.createUser(<generated>)
| Error 	at com.unifina.service.UserService$createUser.call(Unknown Source)
| Error 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
| Error 	at com.unifina.service.EthereumIntegrationKeyService.createEthereumUser(EthereumIntegrationKeyService.groovy:145)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.CGLIB$createEthereumUser$8(<generated>)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c$$FastClassByCGLIB$$f44aaad1.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.createEthereumUser(<generated>)
| Error 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
| Error 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
| Error 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
| Error 	at java.lang.reflect.Method.invoke(Method.java:498)
| Error 	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
| Error 	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
| Error 	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
| Error 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1218)
| Error 	at groovy.lang.ExpandoMetaClass.invokeMethod(ExpandoMetaClass.java:1125)
| Error 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1027)
| Error 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:815)
| Error 	at com.unifina.service.EthereumIntegrationKeyService.invokeMethod(EthereumIntegrationKeyService.groovy)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.CGLIB$invokeMethod$13(<generated>)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c$$FastClassByCGLIB$$f44aaad1.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.invokeMethod(<generated>)
| Error 	at org.codehaus.groovy.runtime.callsite.PogoInterceptableSite.call(PogoInterceptableSite.java:48)
| Error 	at org.codehaus.groovy.runtime.callsite.PogoInterceptableSite.callCurrent(PogoInterceptableSite.java:58)
| Error 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:166)
| Error 	at com.unifina.service.EthereumIntegrationKeyService.getOrCreateFromEthereumAddress(EthereumIntegrationKeyService.groovy:137)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.CGLIB$getOrCreateFromEthereumAddress$7(<generated>)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c$$FastClassByCGLIB$$f44aaad1.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.getOrCreateFromEthereumAddress(<generated>)
| Error 	at com.streamr.client.authentication.InternalAuthenticationMethod.<init>(InternalAuthenticationMethod.java:19)
| Error 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
| Error 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
| Error 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
| Error 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
| Error 	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrConstructorNewInstance(ReflectiveInterceptor.java:1075)
| Error 	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:83)
| Error 	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
| Error 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
| Error 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:263)
| Error 	at com.unifina.service.StreamrClientService.getInstanceForThisEngineNode(StreamrClientService.groovy:77)
| Error 	at com.unifina.service.StreamrClientService$getInstanceForThisEngineNode.call(Unknown Source)
| Error 	at com.unifina.service.StreamrClientServiceIntegrationSpec$__spock_feature_0_3_closure1.doCall(StreamrClientServiceIntegrationSpec.groovy:69)
| Error 	at com.unifina.service.StreamrClientServiceIntegrationSpec$__spock_feature_0_3_closure1.doCall(StreamrClientServiceIntegrationSpec.groovy)
| Error 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
| Error 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
| Error 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
| Error 	at java.lang.reflect.Method.invoke(Method.java:498)
| Error 	at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426)
| Error 	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
| Error 	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
| Error 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1218)
| Error 	at groovy.lang.ExpandoMetaClass.invokeMethod(ExpandoMetaClass.java:1125)
| Error 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1027)
| Error 	at groovy.lang.Closure.call(Closure.java:414)
| Error 	at com.unifina.service.StreamrClientServiceIntegrationSpec$__spock_feature_0_3_closure1.call(StreamrClientServiceIntegrationSpec.groovy)
| Error 	at groovy.lang.Closure.call(Closure.java:408)
| Error 	at com.unifina.service.StreamrClientServiceIntegrationSpec$__spock_feature_0_3_closure1.call(StreamrClientServiceIntegrationSpec.groovy)
| Error 	at groovy.lang.Closure.run(Closure.java:495)
| Error 	at com.unifina.service.StreamrClientServiceIntegrationSpec$__spock_feature_0_3_closure1.run(StreamrClientServiceIntegrationSpec.groovy)
| Error 	at java.lang.Thread.run(Thread.java:748)
| Error Exception in thread "Thread-30" 
| Error org.hibernate.HibernateException: No Hibernate Session bound to thread, and configuration does not allow creation of non-transactional one here
| Error 	at org.springframework.orm.hibernate3.SpringSessionContext.currentSession(SpringSessionContext.java:65)
| Error 	at org.hibernate.impl.SessionFactoryImpl.getCurrentSession(SessionFactoryImpl.java:687)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.validation.HibernateDomainClassValidator.validate(HibernateDomainClassValidator.java:58)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.metaclass.ValidatePersistentMethod.doInvokeInternal(ValidatePersistentMethod.java:116)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.metaclass.AbstractDynamicPersistentMethod.invoke(AbstractDynamicPersistentMethod.java:64)
| Error 	at org.codehaus.groovy.grails.orm.hibernate.AbstractHibernateGormValidationApi.validate(AbstractHibernateGormValidationApi.groovy:41)
| Error 	at com.unifina.domain.security.SecUser.validate(SecUser.groovy)
| Error 	at com.unifina.domain.security.SecUser$validate$1.call(Unknown Source)
| Error 	at com.unifina.service.UserService.createUser(UserService.groovy:42)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.CGLIB$createUser$0(<generated>)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821$$FastClassByCGLIB$$838c5977.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.createUser(<generated>)
| Error 	at com.unifina.service.UserService.createUser(UserService.groovy)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.CGLIB$createUser$10(<generated>)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821$$FastClassByCGLIB$$838c5977.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
| Error 	at org.spockframework.mock.runtime.CglibMockInterceptorAdapter.intercept(CglibMockInterceptorAdapter.java:30)
| Error 	at com.unifina.service.UserService$$EnhancerByCGLIB$$3482e821.createUser(<generated>)
| Error 	at com.unifina.service.UserService$createUser.call(Unknown Source)
| Error 	at com.unifina.service.EthereumIntegrationKeyService.createEthereumUser(EthereumIntegrationKeyService.groovy:145)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c.CGLIB$createEthereumUser$8(<generated>)
| Error 	at com.unifina.service.EthereumIntegrationKeyService$$EnhancerByCGLIB$$86cc089c$$FastClassByCGLIB$$f44aaad1.invoke(<generated>)
| Error 	at net.sf.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
| Error 	at org.spockframework.mock.runtime.CglibRealMethodInvoker.respond(CglibRealMethodInvoker.java:32)
| Error 	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:60)
| Error 	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:29)
| Error 	at org.spockframework.mock.runtime.MockController.handle(MockController.java:49)
| Error 	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
```