### PR TITLE
Fix error message

### DIFF
--- a/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/api/StreamApiController.groovy
@@ -58,7 +58,7 @@ class StreamApiController {
 		if (permissionService.check(userish, stream, Permission.Operation.STREAM_GET)) {
 			render(stream.toMap() as JSON)
 		} else {
-			throw new NotPermittedException(null, "Stream", id, Permission.Operation.STREAM_GET.id)
+			throw new NotPermittedException(request?.apiUser?.username, "Stream", id, Permission.Operation.STREAM_GET.id)
 		}
 	}
 

--- a/src/java/com/unifina/api/NotPermittedException.java
+++ b/src/java/com/unifina/api/NotPermittedException.java
@@ -47,4 +47,20 @@ public class NotPermittedException extends ApiException {
 		}
 		return e;
 	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getOp() {
+		return op;
+	}
 }

--- a/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/api/StreamApiControllerSpec.groovy
@@ -186,7 +186,8 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		authenticatedAs(me) { controller.show() }
 
 		then:
-		thrown NotPermittedException
+		NotPermittedException ex = thrown(NotPermittedException)
+		ex.getUser() == me.getUsername()
 	}
 
 	void "shows a Stream of logged in Key"() {


### PR DESCRIPTION
Fix the error message when user makes a request to the `/streams/{id}` endpoint, but is missing the `stream_get` permission. Reported by @mondoreale [here](https://github.com/streamr-dev/streamr-platform/pull/1013#issuecomment-637405757)