### PR TITLE
Grant stream_get on DU join

### DIFF
--- a/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
+++ b/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
@@ -29,6 +29,7 @@ class DataUnionJoinRequestService {
 				log.debug(String.format("user %s already has write permission to %s (%s), skipping grant", c.user.username, s.name, s.id))
 			} else {
 				log.debug(String.format("granting write permission to %s (%s) for %s", s.name, s.id, c.user.username))
+				permissionService.systemGrant(c.user, s, Permission.Operation.STREAM_GET)
 				permissionService.systemGrant(c.user, s, Permission.Operation.STREAM_PUBLISH)
 			}
 		}


### PR DESCRIPTION
The current `broker` version still requires `stream_get` (as well as `stream_publish`) to publish messages. 

This will be fixed in the future, but for the time being let's work around this by granting both `stream_get` as well as `stream_publish` to DU joiners.