### PR TITLE
Find out in more detail how join request service is doing

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -139,6 +139,8 @@ log4j.main = {
 
 	warn 'org.mortbay.log',
 		'org.codehaus.groovy.grails.domain.GrailsDomainClassCleaner'
+
+	debug 'com.unifina.service.DataUnionJoinRequestService'
 }
 
 /**


### PR DESCRIPTION
This is to debug an issue noticed in 2020-08-19 where join had stopped working for 0x3650b99D107d581eF8ff004365A4Ada8DA6bf62F (still working for 0x600Ee6e7bB9Cbfe21efd41969ec5F26d00F98155). EE doesn't log anything, but data isn't received by stream listeners anywhere.