### PR TITLE
CORE-1921: updating recreates permissions

### DIFF
--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -69,6 +69,12 @@ class PermissionService {
 		return id != null && hasPermission(userish, resource, op)
 	}
 
+	boolean checkAnonymousAccess(Object resource, Operation op) {
+		String resourceProp = getResourcePropertyName(resource)
+		List<Permission> permissions = getPermissionsTo(resource, op)
+		return permissions.stream().filter{Permission p -> p.anonymous}.findAny().isPresent()
+	}
+
 	/**
 	 * Throws an exception if user is not allowed to perform specified operation on a resource.
 	 */

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -70,9 +70,7 @@ class PermissionService {
 	}
 
 	boolean checkAnonymousAccess(Object resource, Operation op) {
-		String resourceProp = getResourcePropertyName(resource)
-		List<Permission> permissions = getPermissionsTo(resource, op)
-		return permissions.stream().filter{Permission p -> p.anonymous}.findAny().isPresent()
+		return check(null, resource, op)
 	}
 
 	/**

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -174,11 +174,14 @@ class ProductService {
 
 		// A stream that is added when editing an existing free product should inherit read access for anonymous user
 		// TODO if the stream is removed from one free product, but is still in some other free product, should we remove the permission?
-		// TODO if the permission is already there, we should not add it again?
 		if (product.isFree()) {
 			def permissions = [Permission.Operation.STREAM_GET, Permission.Operation.STREAM_SUBSCRIBE]
 			permissions.each { permission ->
-				addedStreams.each { s -> permissionService.systemGrantAnonymousAccess(s, permission) }
+				addedStreams.each { s ->
+					if (!permissionService.checkAnonymousAccess(s, permission)) {
+						permissionService.systemGrantAnonymousAccess(s, permission)
+					}
+				}
 				removedStreams.each { s -> permissionService.systemRevokeAnonymousAccess(s, permission) }
 			}
 		}

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -166,8 +166,8 @@ class ProductService {
 		}
 
 		Product product = findById(id, currentUser, Permission.Operation.PRODUCT_EDIT)
-		Set<Stream> addedStreams = command.streams.stream().filter{Stream s -> !product.streams.contains(s)}.collect(toSet()) as Set<Stream>
-		Set<Stream> removedStreams = product.streams.stream().filter{Stream s -> !command.streams.contains(s)}.collect(toSet())
+		Set<Stream> addedStreams = (command.streams as Set<Stream>).findAll{!product.streams.contains(it)}
+		Set<Stream> removedStreams = product.streams.findAll{!command.streams.contains(it)}
 
 		command.updateProduct(product, currentUser, permissionService)
 		product.save(failOnError: true)

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -173,7 +173,8 @@ class ProductService {
 		product.save(failOnError: true)
 
 		// A stream that is added when editing an existing free product should inherit read access for anonymous user
-		// TODO if the stream is removed from one free product, but is still in some other free product, should we remove the permission?
+		// TODO if a stream is removed from a free product, but still belongs to another free product, we should not
+		// remove the permission (this will be fixed in BACK-6)
 		if (product.isFree()) {
 			def permissions = [Permission.Operation.STREAM_GET, Permission.Operation.STREAM_SUBSCRIBE]
 			permissions.each { permission ->

--- a/test/integration/com/unifina/service/PermissionServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/PermissionServiceIntegrationSpec.groovy
@@ -483,4 +483,19 @@ class PermissionServiceIntegrationSpec extends IntegrationSpec {
 		def e = thrown(AccessControlException)
 		e.message == "Cannot revoke only SHARE permission of ${stream}"
 	}
+
+	void "check anonymous permission"() {
+		expect:
+		service.checkAnonymousAccess(uiChannelStream, Permission.Operation.STREAM_GET) == false
+
+		when:
+		service.systemGrantAnonymousAccess(uiChannelStream, Permission.Operation.STREAM_GET)
+		then:
+		service.checkAnonymousAccess(uiChannelStream, Permission.Operation.STREAM_GET) == true
+
+		when:
+		service.systemRevokeAnonymousAccess(uiChannelStream, Permission.Operation.STREAM_GET)
+		then:
+		service.checkAnonymousAccess(uiChannelStream, Permission.Operation.STREAM_GET) == false
+	}
 }

--- a/test/unit/com/unifina/service/ProductServiceSpec.groovy
+++ b/test/unit/com/unifina/service/ProductServiceSpec.groovy
@@ -533,16 +533,12 @@ class ProductServiceSpec extends Specification {
 
 		// revoke streams old permissions
 		1 * permissionService.systemRevokeAnonymousAccess(s1, Permission.Operation.STREAM_GET)
-		1 * permissionService.systemRevokeAnonymousAccess(s2, Permission.Operation.STREAM_GET)
 		1 * permissionService.systemRevokeAnonymousAccess(s3, Permission.Operation.STREAM_GET)
 		1 * permissionService.systemRevokeAnonymousAccess(s1, Permission.Operation.STREAM_SUBSCRIBE)
-		1 * permissionService.systemRevokeAnonymousAccess(s2, Permission.Operation.STREAM_SUBSCRIBE)
 		1 * permissionService.systemRevokeAnonymousAccess(s3, Permission.Operation.STREAM_SUBSCRIBE)
 
 		// grant permissions for new streams
-		1 * permissionService.systemGrantAnonymousAccess(s2, Permission.Operation.STREAM_GET)
 		1 * permissionService.systemGrantAnonymousAccess(s4, Permission.Operation.STREAM_GET)
-		1 * permissionService.systemGrantAnonymousAccess(s2, Permission.Operation.STREAM_SUBSCRIBE)
 		1 * permissionService.systemGrantAnonymousAccess(s4, Permission.Operation.STREAM_SUBSCRIBE)
 
 		0 * permissionService._


### PR DESCRIPTION
Sending a PUT to the /products/id endpoint seems to recreate the public Permission rows, if the product is a free product.

This PR fixes the issue, but there is a separate bug BACK-6 which will be fixed in another PR.