### PR TITLE
BACK-20 DU members should have STREAM_GET and STREAM_PUBLISH permissions

### DIFF
--- a/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
+++ b/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
@@ -211,6 +211,7 @@ class DataUnionJoinRequestService {
 		}
 
 		for (Stream s : findStreams(c)) {
+			permissionService.systemRevoke(c.user, s, Permission.Operation.STREAM_GET)
 			permissionService.systemRevoke(c.user, s, Permission.Operation.STREAM_PUBLISH)
 		}
 		sendMessage(c, "part")

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -198,6 +198,9 @@ class ProductService {
 		if (product.type == Product.Type.DATAUNION) {
 			Set<User> users = dataUnionJoinRequestService.findMembers(product.beneficiaryAddress)
 			for (User u : users) {
+				if (!permissionService.check(u, stream, Permission.Operation.STREAM_GET)) {
+					permissionService.systemGrant(u, stream, Permission.Operation.STREAM_GET)
+				}
 				if (!permissionService.check(u, stream, Permission.Operation.STREAM_PUBLISH)) {
 					permissionService.systemGrant(u, stream, Permission.Operation.STREAM_PUBLISH)
 				}
@@ -217,6 +220,9 @@ class ProductService {
 		if (product.type == Product.Type.DATAUNION) {
 			Set<User> users = dataUnionJoinRequestService.findMembers(product.beneficiaryAddress)
 			for (User u : users) {
+				if (permissionService.check(u, stream, Permission.Operation.STREAM_GET)) {
+					permissionService.systemRevoke(u, stream, Permission.Operation.STREAM_GET)
+				}
 				if (permissionService.check(u, stream, Permission.Operation.STREAM_PUBLISH)) {
 					permissionService.systemRevoke(u, stream, Permission.Operation.STREAM_PUBLISH)
 				}

--- a/test/integration/com/unifina/service/DataUnionJoinRequestServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/DataUnionJoinRequestServiceIntegrationSpec.groovy
@@ -258,9 +258,14 @@ class DataUnionJoinRequestServiceIntegrationSpec extends Specification {
 		1 * service.ethereumService.fetchJoinPartStreamID(contractAddress) >> joinPartStream.id
 		1 * streamrClientMock.publish(_, [type: "part", addresses: [r.memberAddress]])
 		1 * service.permissionService.systemRevoke(me, s1, Permission.Operation.STREAM_PUBLISH)
+		1 * service.permissionService.systemRevoke(me, s1, Permission.Operation.STREAM_GET)
 		1 * service.permissionService.systemRevoke(me, s2, Permission.Operation.STREAM_PUBLISH)
+		1 * service.permissionService.systemRevoke(me, s2, Permission.Operation.STREAM_GET)
 		1 * service.permissionService.systemRevoke(me, s3, Permission.Operation.STREAM_PUBLISH)
+		1 * service.permissionService.systemRevoke(me, s3, Permission.Operation.STREAM_GET)
 		1 * service.permissionService.systemRevoke(me, s4, Permission.Operation.STREAM_PUBLISH)
+		1 * service.permissionService.systemRevoke(me, s4, Permission.Operation.STREAM_GET)
+		0 * service.permissionService._
 		DataUnionJoinRequest.findById(r.id) == null
 	}
 

--- a/test/unit/com/unifina/service/ProductServiceSpec.groovy
+++ b/test/unit/com/unifina/service/ProductServiceSpec.groovy
@@ -719,16 +719,17 @@ class ProductServiceSpec extends Specification {
 		t.termsName == "legal terms for site.org"
 	}
 
-	void "addStreamToProduct() verifies Stream via PermissionService#verifyShare"() {
+	void "addStreamToProduct() verifies Stream via PermissionService#verify"() {
 		setupStreams()
 		setupProduct()
 		service.subscriptionService = Stub(SubscriptionService)
-		def permissionService = service.permissionService = Mock(PermissionService)
+		service.permissionService = Mock(PermissionService)
 		def user = new User()
 		when:
 		service.addStreamToProduct(product, s4, user)
 		then:
-		1 * permissionService.verify(user, s4, Permission.Operation.STREAM_SHARE)
+		1 * service.permissionService.verify(user, s4, Permission.Operation.STREAM_SHARE)
+		0 * service.permissionService._
 	}
 
 	void "addStreamToProduct() adds Stream to Product"() {
@@ -758,7 +759,10 @@ class ProductServiceSpec extends Specification {
 		when:
 		service.addStreamToProduct(product, s4, user)
 		then:
+		1 * service.permissionService.verify(user, s4, Permission.Operation.STREAM_SHARE)
 		1 * service.permissionService.systemGrantAnonymousAccess(s4, Permission.Operation.STREAM_GET)
+		1 * service.permissionService.systemGrantAnonymousAccess(s4, Permission.Operation.STREAM_SUBSCRIBE)
+		0 * service.permissionService._
 	}
 
 	void "addStreamToProduct() invokes subscriptionService#afterProductUpdated"() {
@@ -797,6 +801,8 @@ class ProductServiceSpec extends Specification {
 		service.removeStreamFromProduct(product, s1)
 		then:
 		1 * service.permissionService.systemRevokeAnonymousAccess(s1, Permission.Operation.STREAM_GET)
+		1 * service.permissionService.systemRevokeAnonymousAccess(s1, Permission.Operation.STREAM_SUBSCRIBE)
+		0 * service.permissionService._
 	}
 
 	void "removeStreamFromProduct() invokes subscriptionService#afterProductUpdated"() {


### PR DESCRIPTION
The backend manages the permissions of DU members, giving them `STREAM_GET` and `STREAM_PUBLISH` permissions when they join. However, when they leave or when Streams are added/removed from the Product, I noticed that only `STREAM_PUBLISH` was updated. This PR adds `STREAM_GET` management also, so that the two always go hand in hand.

@kare @teogeb could you take over and update the tests please?