### PR TITLE
BACK-6: Anonymous permissions should not be revoked when a stream belongs multiple free products

### DIFF
--- a/grails-app/services/com/unifina/service/ProductStore.groovy
+++ b/grails-app/services/com/unifina/service/ProductStore.groovy
@@ -1,0 +1,14 @@
+package com.unifina.service
+
+import com.unifina.domain.Product
+import com.unifina.domain.Stream
+
+class ProductStore {
+	List<Product> findProductsByStream(Stream s) {
+		return Product.createCriteria().list {
+			streams {
+				idEq(s.id)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes a bug where a stream is removed from a product, but it still belongs to another free product. The stream should retain the anonymous access permission.