### PR TITLE
BACK-31: Add Data Union version field to Product

### DIFF
--- a/grails-app/domain/com/unifina/domain/Product.groovy
+++ b/grails-app/domain/com/unifina/domain/Product.groovy
@@ -32,6 +32,8 @@ class Product {
 	// Product's legal terms of use.
 	TermsOfUse termsOfUse = new TermsOfUse()
 
+	Integer dataUnionVersion
+
 	static embedded = [
 		'contact',
 		'termsOfUse',
@@ -87,6 +89,7 @@ class Product {
 		owner(nullable: false)
 		contact(nullable: true)
 		termsOfUse(nullable: true)
+		dataUnionVersion(nullable: true, validator: { Integer d, p -> (p.type == Type.DATAUNION) ? ((d == 1) || (d == 2) || (d == null)) : (d == null)})
 	}
 
 	static mapping = {
@@ -133,12 +136,15 @@ class Product {
 			JsonSlurper slurper = new JsonSlurper()
 			map.put("pendingChanges", (HashMap<String, Serializable>) slurper.parseText(pendingChanges))
 		}
+		if (type == Type.DATAUNION) {
+			map.put("dataUnionVersion", dataUnionVersion)
+		}
 		return map
 	}
 
 	@GrailsCompileStatic
 	Map toSummaryMap() {
-		[
+		def map = [
 			id: id,
 			type: type.toString(),
 			name: name,
@@ -160,6 +166,10 @@ class Product {
 			minimumSubscriptionInSeconds: minimumSubscriptionInSeconds,
 			owner: owner.name
 		]
+		if (type == Type.DATAUNION) {
+			map.put("dataUnionVersion", dataUnionVersion)
+		}
+		return map;
 	}
 
 	boolean isFree() {

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -152,4 +152,5 @@ databaseChangeLog = {
 	include file: 'core/2020-04-15-user-refactor-username-add-email.groovy'
 	include file: 'core/2020-08-07-mv-secuser-user.groovy'
 	include file: 'core/2020-08-24-add-user-signup-method.groovy'
+	include file: 'core/2020-09-15-add-DU-version-field-to-product.groovy'
 }

--- a/grails-app/migrations/core/2020-09-15-add-DU-version-field-to-product.groovy
+++ b/grails-app/migrations/core/2020-09-15-add-DU-version-field-to-product.groovy
@@ -1,0 +1,15 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "teogeb", id: "add-DU-version-field-to-product-1") {
+		addColumn(tableName: "product") {
+			column(name: "data_union_version", type: "integer")
+		}
+	}
+	changeSet(author: "teogeb", id: "add-DU-version-field-to-product-2") {
+		grailsChange {
+			change {
+				sql.execute("update product set data_union_version=1 where type=1")
+			}
+		}
+	}
+}

--- a/grails-app/services/com/unifina/service/ProductService.groovy
+++ b/grails-app/services/com/unifina/service/ProductService.groovy
@@ -147,6 +147,9 @@ class ProductService {
 
 		Product product = new Product(command.properties)
 		product.owner = currentUser
+		if ((product.type == Product.Type.DATAUNION) && (product.dataUnionVersion == null)) {
+			product.dataUnionVersion = 1
+		}
 		product.save(failOnError: true)
 		permissionService.systemGrantAll(currentUser, product)
 		// A stream that is added when creating a new free product should inherit read access for anonymous user

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -234,7 +234,20 @@ describe('Products API', function() {
                     },
                 })
             })
-        })
+		})
+
+		it('set dataUnionVersion number', async () => {
+			const response = await Streamr.api.v1.products
+				.create({
+					type: 'DATAUNION',
+					dataUnionVersion: 2
+				})
+				.withApiKey(AUTH_TOKEN)
+				.call()
+			assert.equal(response.status, 200)
+			const json = await response.json()
+			assert.equal(json.dataUnionVersion, 2)
+		});
     })
 
     describe('GET /api/v1/products/:id', () => {

--- a/rest-e2e-tests/schemas/product.json
+++ b/rest-e2e-tests/schemas/product.json
@@ -255,6 +255,13 @@
           ]
         }
       }
+    },
+    "dataUnionVersion": {
+      "description": "Data Union version",
+      "oneOf": [
+        { "type": "null" },
+        { "type": "number" }
+      ]
     }
   },
   "additionalProperties": false,

--- a/src/groovy/com/unifina/service/CreateProductCommand.groovy
+++ b/src/groovy/com/unifina/service/CreateProductCommand.groovy
@@ -24,6 +24,8 @@ class CreateProductCommand {
 	Contact contact = new Contact()
 	TermsOfUse termsOfUse = new TermsOfUse()
 
+	Integer dataUnionVersion
+
 	static constraints = {
 		importFrom(Product)
 	}


### PR DESCRIPTION
Added new "dataUnionVersion" field to product and updated POST /api/v1/products to read that from input JSON.