### PR TITLE
BACK-38: Separate stress tests

### DIFF
--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -32,9 +32,6 @@ async function CreateClientUser() {
     // Generate a new user to isolate the test and not require any pre-existing resources
     const freshUser = StreamrClient.generateEthereumAccount()
 
-    // Print private key to console in case you need to debug by logging in as this user (import to MetaMask, log in with Ethereum)
-    console.log(`User created: ${JSON.stringify(freshUser)}`)
-
     const client = new StreamrClient({
         url: WS_URL,
         restUrl: REST_URL,

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "repository": "https://github.com/streamr-dev/engine-and-editor",
   "scripts": {
-    "test": "mocha *.test.js --recursive --color false --exit --timeout 5000"
+	"test": "npm run test:e2e && npm run test:stress",
+    "test:e2e": "mocha *.test.js --exclude '*.stress-test.js' --recursive --color false --exit --timeout 5000",
+    "test:stress": "mocha *.stress-test.js --recursive --color false --exit"
   },
   "author": "Streamr developers",
   "license": "AGPL-3.0-only",

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -1,0 +1,75 @@
+const assert = require('chai').assert
+const initStreamrApi = require('./streamr-api-clients')
+const StreamrClient = require('streamr-client')
+const URL = 'http://localhost/api/v1/'
+const LOGGING_ENABLED = false
+const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
+
+describe('POST /api/v1/streams/{id}/permissions', function() {
+
+	this.timeout(120 * 1000)
+
+	let stream
+	let mySessionToken
+
+	before(async () => {
+		const me = StreamrClient.generateEthereumAccount()
+		mySessionToken = await new StreamrClient({
+			restUrl: URL,
+			auth: {
+				privateKey: me.privateKey,
+			}
+		}).session.getSessionToken()
+		stream = await Streamr.api.v1.streams
+			.create({
+				name: `permissions-api.test.js-${Date.now()}`
+			})
+			.withSessionToken(mySessionToken)
+			.execute()
+	})
+
+	describe('race conditions', () => {
+		// The worst case is that there are parallel requests open for all the different operations
+		const operations = [
+			'stream_get',
+			'stream_edit',
+			'stream_subscribe',
+			'stream_publish',
+			'stream_delete',
+			'stream_share',
+		]
+
+		// Tests here are repeated 50 times, as they have some chance of an individual attempt
+		// succeeding even if the race condition is not handled properly
+		const ITERATIONS = 50
+
+		it('survives a race condition when granting multiple permissions to a non-existing user using Ethereum address', async () => {
+			for (let i=0; i<ITERATIONS; i++) {
+				console.log("\titeration: " + (i + 1))
+				const responses = await Promise.all(operations.map((operation) => {
+					return Streamr.api.v1.streams
+						.grant(stream.id, StreamrClient.generateEthereumAccount().address, operation)
+						.withSessionToken(mySessionToken)
+						.call()
+				}))
+				// All response statuses must be 200
+				assert.deepEqual(responses.map((r) => r.status), operations.map((op) => 200), `Race condition test failed on iteration ${i}`)
+			}
+		})
+
+		it('survives a race condition when granting multiple permissions to a non-existing user using email address', async () => {
+			for (let i=0; i<ITERATIONS; i++) {
+				console.log("\titeration: " + (i + 1))
+				const responses = await Promise.all(operations.map((operation) => {
+					return Streamr.api.v1.streams
+						.grant(stream.id, `race-condition-${i}@foobar.invalid`, 'stream_get')
+						.withSessionToken(mySessionToken)
+						.call()
+				}))
+				// All response statuses must be 200
+				assert.deepEqual(responses.map((r) => r.status), operations.map((op) => 200), `Race condition test failed on iteration ${i}`)
+			}
+		})
+	})
+
+})

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -7,7 +7,7 @@ const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
 describe('POST /api/v1/streams/{id}/permissions', function() {
 
-	this.timeout(120 * 1000)
+	this.timeout(200 * 1000)
 
 	let stream
 	let mySessionToken

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -11,9 +11,7 @@ const schemaValidator = new SchemaValidator()
 
 const API_KEY = 'tester1-api-key'
 
-describe('Permissions API', function() { // use "function" instead of arrow because of this.timeout(...)
-    this.timeout(120 * 1000)
-
+describe('Permissions API', () => {
     const me = StreamrClient.generateEthereumAccount()
     const nonExistingUser = StreamrClient.generateEthereumAccount()
     const existingUser = StreamrClient.generateEthereumAccount()
@@ -80,48 +78,6 @@ describe('Permissions API', function() { // use "function" instead of arrow beca
                 .withSessionToken(mySessionToken)
                 .call()
             assert.equal(response.status, 200)
-        })
-
-        describe('race conditions', () => {
-            // The worst case is that there are parallel requests open for all the different operations
-            const operations = [
-                'stream_get',
-                'stream_edit',
-                'stream_subscribe',
-                'stream_publish',
-                'stream_delete',
-                'stream_share',
-            ]
-
-            // Tests here are repeated 50 times, as they have some chance of an individual attempt
-            // succeeding even if the race condition is not handled properly
-            const ITERATIONS = 50
-
-            it('survives a race condition when granting multiple permissions to a non-existing user using Ethereum address', async () => {
-                for (let i=0; i<ITERATIONS; i++) {
-                    const responses = await Promise.all(operations.map((operation) => {
-                        return Streamr.api.v1.streams
-                            .grant(stream.id, StreamrClient.generateEthereumAccount().address, operation)
-                            .withSessionToken(mySessionToken)
-                            .call()
-                    }))
-                    // All response statuses must be 200
-                    assert.deepEqual(responses.map((r) => r.status), operations.map((op) => 200), `Race condition test failed on iteration ${i}`)
-                }
-            })
-
-            it('survives a race condition when granting multiple permissions to a non-existing user using email address', async () => {
-                for (let i=0; i<ITERATIONS; i++) {
-                    const responses = await Promise.all(operations.map((operation) => {
-                        return Streamr.api.v1.streams
-                            .grant(stream.id, `race-condition-${i}@foobar.invalid`, 'stream_get')
-                            .withSessionToken(mySessionToken)
-                            .call()
-                    }))
-                    // All response statuses must be 200
-                    assert.deepEqual(responses.map((r) => r.status), operations.map((op) => 200), `Race condition test failed on iteration ${i}`)
-                }
-            })
         })
     })
 


### PR DESCRIPTION
Separate normal end-to-end tests and stress tests so that we can run either of those test suites easily.

There are three NPM scripts:
- ```npm test``` - all tests
- ```npm test:e2e``` - normal end-to-end tests
- ```npm test:stress``` - stress tests