### PR TITLE
BACK-12: Convert api keys to Ethereum IDs

### DIFF
--- a/grails-app/controllers/com/unifina/controller/LoginApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/LoginApiController.groovy
@@ -6,7 +6,9 @@ import com.unifina.domain.SignupMethod
 import com.unifina.domain.User
 import com.unifina.domain.Userish
 import com.unifina.security.Challenge
+import com.unifina.security.ApiKeyConverter
 import com.unifina.service.*
+import com.unifina.api.InvalidAPIKeyException
 import grails.converters.JSON
 
 class LoginApiController {
@@ -50,13 +52,16 @@ class LoginApiController {
 		if (cmd.hasErrors()) {
 			throw new InvalidArgumentsException(cmd.errors.getFieldErrors().collect {it.field+" expected."}.join(" "))
 		}
-		// returns either a User or a Key (anonymous key)
-		Userish userish = userService.getUserishFromApiKey(cmd.apiKey)
-		if (userish instanceof User) {
-			assertEnabled((User) userish)
+		String privateKey = ApiKeyConverter.createEthereumPrivateKey(cmd.apiKey);
+		String address = "0x" + EthereumIntegrationKeyService.getAddress(privateKey);
+		User user = ethereumIntegrationKeyService.getEthereumUser(address);
+		if (user != null) {
+			assertEnabled(user)
+			SessionToken token = sessionService.generateToken(user)
+			render(token.toMap() as JSON)
+		} else {
+			throw new InvalidAPIKeyException("Invalid API key")
 		}
-		SessionToken token = sessionService.generateToken(userish)
-		render(token.toMap() as JSON)
 	}
 
 	private void assertEnabled(User user) {

--- a/grails-app/domain/com/unifina/domain/SignupMethod.groovy
+++ b/grails-app/domain/com/unifina/domain/SignupMethod.groovy
@@ -8,7 +8,8 @@ import javax.servlet.http.HttpServletRequest
 enum SignupMethod {
 	API,
 	CORE,
-	UNKNOWN
+	UNKNOWN,
+	MIGRATED
 
 	private final static String SERVER_URL_CONFIG_KEY = "grails.serverURL"
 

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -154,4 +154,5 @@ databaseChangeLog = {
 	include file: 'core/2020-08-24-add-user-signup-method.groovy'
 	include file: 'core/2020-09-11-add-stream-storage-node.groovy'
 	include file: 'core/2020-09-15-add-DU-version-field-to-product.groovy'
+	include file: 'core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy'
 }

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -185,73 +185,13 @@ databaseChangeLog = {
 		}
 	}
 
-	// create inbox streams for the integration keys
-	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-5") {
-		grailsChange {
-			change {
-				sql.execute("""
-					INSERT INTO stream (version, id, name, date_created, last_updated, partitions, require_signed_data, auto_configure, storage_days, inbox, inactivity_threshold_hours, example_type, require_encrypted_data)
-					SELECT
-						0,
-						account_address,
-						account_address,
-						CURRENT_TIMESTAMP(),
-						CURRENT_TIMESTAMP(),
-						1,
-						false,
-						false,
-						?,
-						true,
-						?,
-						?,
-						false
-					FROM tmp_apikey_lookup
-				""", [Stream.DEFAULT_STORAGE_DAYS, Stream.DEFAULT_INACTIVITY_THRESHOLD_HOURS, ExampleType.NOT_SET.value])
-			}
-		}
-	}
-
-	// create permissions for the inbox streams
-	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-6") {
-		grailsChange {
-			change {
-				List<Permission.Operation> permissionOperations = [
-					Permission.Operation.STREAM_GET,
-					Permission.Operation.STREAM_EDIT,
-					Permission.Operation.STREAM_DELETE,
-					Permission.Operation.STREAM_PUBLISH,
-					Permission.Operation.STREAM_SUBSCRIBE,
-					Permission.Operation.STREAM_SHARE,
-				];
-				sql.execute("""
-					INSERT INTO permission (version, operation, stream_id, anonymous, user_id)
-					SELECT
-						0,
-						permission_id,
-						account_address,
-						false,
-						user_id
-					FROM tmp_apikey_lookup
-					JOIN (
-						(SELECT ? as permission_id FROM DUAL) UNION ALL
-						(SELECT ? as permission_id FROM DUAL) UNION ALL
-						(SELECT ? as permission_id FROM DUAL) UNION ALL
-						(SELECT ? as permission_id FROM DUAL) UNION ALL
-						(SELECT ? as permission_id FROM DUAL) UNION ALL
-						(SELECT ? as permission_id FROM DUAL)
-					) as permission_ids
-				""", permissionOperations.collect { it.id })
-			}
-		}
-	}
-
 	// delete keys
-	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-7") {
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-5") {
 		sql('DELETE FROM `key`')
 	}
 
 	// drop lookup table
-	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-8") {
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-6") {
 		dropTable(tableName: "tmp_apikey_lookup")
 	}
 }

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -1,0 +1,83 @@
+package core
+
+import com.unifina.domain.IntegrationKey
+import com.unifina.utils.IdGenerator
+import com.unifina.security.ApiKeyConverter
+import com.unifina.service.EthereumIntegrationKeyService
+import com.unifina.utils.AlphanumericStringGenerator
+import grails.converters.JSON
+
+def getAccountAddress(String apiKeyId) {
+	String privateKey = ApiKeyConverter.createEthereumPrivateKey(apiKeyId)
+	return EthereumIntegrationKeyService.getAddress(privateKey)
+}
+
+databaseChangeLog = {
+
+	// For each API key that is attached to a user:
+	// - create a new IntegrationKey for the user
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-1") {
+		grailsChange {
+			change {
+				sql.eachRow('SELECT id, name, user_id FROM `key` where user_id is not null') { row ->
+					String apiKeyId = row['id']
+					String apiKeyName = row['name']
+					String userId = row['user_id']
+					String accountAddress = getAccountAddress(apiKeyId)
+					String integrationKeyName = 'Converted from API key: ' + apiKeyName
+					Date now = new Date()
+					sql.executeInsert("INSERT INTO integration_key (id, version, name, json, user_id, service, id_in_service, date_created, last_updated) VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+						IdGenerator.get(),
+						0,
+						integrationKeyName,
+						([ address: accountAddress ] as JSON).toString(),
+						userId,
+						IntegrationKey.Service.ETHEREUM_ID.name(),
+						accountAddress,
+						now,
+						now
+					])
+				}
+			}
+		}
+	}
+
+	// For each anonymous API key:
+	// - create a new Ethereum user
+	// - migrate the key’s permissions to that user
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-2") {
+		grailsChange {
+			change {
+				sql.eachRow('SELECT id, name, user_id FROM `key` where user_id is null') { row ->
+					String apiKeyId = row['id']
+					String accountAddress = getAccountAddress(apiKeyId)
+					def insertResult = sql.executeInsert("INSERT INTO user (version, account_expired, account_locked, enabled, name, password, password_expired, username, signup_method) VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+							0,
+							false,
+							false,
+							true,
+							"Anonymous User",
+							AlphanumericStringGenerator.getRandomAlphanumericString(32),
+							false,
+							accountAddress,
+							'UNKNOWN'  // TODO: what value we should use?
+					]);
+					int userId = insertResult[0][0]
+					sql.execute("UPDATE permission SET user_id = ?, key_id = null WHERE key_id = ?", [ userId, apiKeyId])
+				}
+			}
+		}
+	}
+
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-3") {
+		dropForeignKeyConstraint(baseTableName: "permission", constraintName: "FKE125C5CF8EE35041")
+	}
+
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-4") {
+		dropColumn(tableName: "permission", columnName: "key_id")
+	}
+
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-5") {
+		dropTable(tableName: "key")
+	}
+}

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -108,7 +108,7 @@ databaseChangeLog = {
 						AlphanumericStringGenerator.getRandomAlphanumericString(32),
 						false,
 						accountAddress,
-						SignupMethod.UNKNOWN.name()
+						SignupMethod.MIGRATED.name()
 					]);
 					int userId = insertResult[0][0]
 					sql.execute("UPDATE permission SET user_id = ?, key_id = null WHERE key_id = ?", [ userId, apiKeyId])

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -72,7 +72,6 @@ databaseChangeLog = {
 
 	// For each API key that is attached to a user:
 	// - create a new IntegrationKey for the user
-	// - delete the permissions attached to the key
 	// - delete the key
 	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-1") {
 		grailsChange {
@@ -84,7 +83,6 @@ databaseChangeLog = {
 					String accountAddress = getAccountAddress(apiKeyId)
 					String integrationKeyName = 'Converted from API key: ' + apiKeyName
 					createIntegrationKey(integrationKeyName, accountAddress, userId, sql)
-					sql.execute("DELETE FROM permission WHERE key_id = ?", [apiKeyId])
 				}
 			}
 		}

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -31,27 +31,6 @@ class GetAccountAddressTask implements Callable<String> {
 	}
 }
 
-def convertUserKeysToIntegrationKeys(Sql sql) {
-	String statement = """
-		INSERT INTO
-			integration_key (id, version, name, json, user_id, service, id_in_service, date_created, last_updated)
-		SELECT
-			generated_integration_key_id,
-			0,
-			CONCAT('Converted from API key: ',key_id),
-			CONCAT(CONCAT('{\"address\":\"',account_address),'\"}'),
-			user_id,
-			?,
-			account_address,
-			CURRENT_TIMESTAMP(),
-			CURRENT_TIMESTAMP()
-		FROM `key`
-		LEFT JOIN tmp_apikey_lookup ON tmp_apikey_lookup.key_id = `key`.id
-		WHERE `key`.user_id is not null
-	"""
-	sql.execute(statement, [IntegrationKey.Service.ETHEREUM_ID.name()])
-}
-
 databaseChangeLog = {
 
 	// fill a lookup table

--- a/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
+++ b/grails-app/migrations/core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy
@@ -11,112 +11,247 @@ import com.unifina.service.EthereumIntegrationKeyService
 import com.unifina.utils.AlphanumericStringGenerator
 import grails.converters.JSON
 import groovy.sql.Sql
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Callable
+import java.util.concurrent.Future
+import java.lang.Runtime
 
-def getAccountAddress(String apiKeyId) {
-	String privateKey = ApiKeyConverter.createEthereumPrivateKey(apiKeyId)
-	return "0x" + EthereumIntegrationKeyService.getAddress(privateKey)
-}
+class GetAccountAddressTask implements Callable<String> {
+	private String apiKey
 
-def createIntegrationKey(String integrationKeyName, String accountAddress, Integer userId, Sql sql) {
-	Date now = new Date()
-	return sql.executeInsert("INSERT INTO integration_key (id, version, name, json, user_id, service, id_in_service, date_created, last_updated) VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
-		IdGenerator.get(),
-		0,
-		integrationKeyName,
-		([ address: accountAddress ] as JSON).toString(),
-		userId,
-		IntegrationKey.Service.ETHEREUM_ID.name(),
-		accountAddress,
-		now,
-		now
-	]);
-}
-
-def createInboxStream(long userId, String accountAddress, Sql sql) {
-	Date now = new Date();
-	sql.executeInsert('INSERT INTO stream (version, id, name, date_created, last_updated, partitions, require_signed_data, auto_configure, storage_days, inbox, inactivity_threshold_hours, example_type, require_encrypted_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
-		0,
-		accountAddress,
-		accountAddress,
-		now,
-		now,
-		1,
-		false,
-		false,
-		Stream.DEFAULT_STORAGE_DAYS,
-		true,
-		Stream.DEFAULT_INACTIVITY_THRESHOLD_HOURS,
-		ExampleType.NOT_SET.value,
-		false
-	]);
-	List<Permission.Operation> permissionOperations = [
-		Permission.Operation.STREAM_GET,
-		Permission.Operation.STREAM_EDIT,
-		Permission.Operation.STREAM_DELETE,
-		Permission.Operation.STREAM_PUBLISH,
-		Permission.Operation.STREAM_SUBSCRIBE,
-		Permission.Operation.STREAM_SHARE,
-	];
-	permissionOperations.each { op ->
-		sql.executeInsert('INSERT INTO permission (version, operation, stream_id, anonymous, user_id) VALUES (?, ?, ?, ?, ?)', [
-			0,
-			op.id,
-			accountAddress,
-			false,
-			userId
-		]);
+	GetAccountAddressTask(String apiKey) {
+		this.apiKey = apiKey
 	}
+
+	@Override
+	String call() throws Exception {
+		String privateKey = ApiKeyConverter.createEthereumPrivateKey(apiKey)
+		return "0x" + EthereumIntegrationKeyService.getAddress(privateKey)
+	}
+}
+
+def convertUserKeysToIntegrationKeys(Sql sql) {
+	String statement = """
+		INSERT INTO
+			integration_key (id, version, name, json, user_id, service, id_in_service, date_created, last_updated)
+		SELECT
+			generated_integration_key_id,
+			0,
+			CONCAT('Converted from API key: ',key_id),
+			CONCAT(CONCAT('{\"address\":\"',account_address),'\"}'),
+			user_id,
+			?,
+			account_address,
+			CURRENT_TIMESTAMP(),
+			CURRENT_TIMESTAMP()
+		FROM `key`
+		LEFT JOIN tmp_apikey_lookup ON tmp_apikey_lookup.key_id = `key`.id
+		WHERE `key`.user_id is not null
+	"""
+	sql.execute(statement, [IntegrationKey.Service.ETHEREUM_ID.name()])
 }
 
 databaseChangeLog = {
 
-	// For each API key that is attached to a user:
-	// - create a new IntegrationKey for the user
-	// - delete the key
+	// fill a lookup table
 	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-1") {
+		createTable(tableName: "tmp_apikey_lookup") {
+			column(name: "key_id", type: "VARCHAR(255)") {
+				constraints(nullable: "false")
+			}
+			column(name: "user_id", type: "BIGINT(20)") {
+				constraints(nullable: "true")
+			}
+			column(name: "key_name", type: "VARCHAR(255)") {
+				constraints(nullable: "false")
+			}
+			column(name: "account_address", type: "VARCHAR(255)") {
+				constraints(nullable: "false")
+			}
+			column(name: "generated_integration_key_id", type: "VARCHAR(255)") {
+				constraints(nullable: "false")
+			}
+			column(name: "generated_user_password", type: "VARCHAR(255)") {
+				constraints(nullable: "true")
+			}
+		}
+		createIndex(tableName: "tmp_apikey_lookup", indexName: "tmp_apikey_lookup_index_1", unique: "true") {
+			column(name: "key_id")
+		}
+		createIndex(tableName: "tmp_apikey_lookup", indexName: "tmp_apikey_lookup_index_2", unique: "false") {
+			column(name: "user_id")
+		}
+		createIndex(tableName: "tmp_apikey_lookup", indexName: "tmp_apikey_lookup_index_3", unique: "true") {
+			column(name: "account_address")
+		}
 		grailsChange {
 			change {
-				sql.eachRow('SELECT id, name, user_id FROM `key` where user_id is not null') { row ->
+				def THREAD_COUNT = Runtime.getRuntime().availableProcessors() + 1
+				ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT)
+				def migrations = []
+				sql.eachRow('SELECT id, name, user_id FROM `key`') { row ->
 					String apiKeyId = row['id']
 					String apiKeyName = row['name']
-					int userId = row['user_id']
-					String accountAddress = getAccountAddress(apiKeyId)
-					String integrationKeyName = 'Converted from API key: ' + apiKeyName
-					createIntegrationKey(integrationKeyName, accountAddress, userId, sql)
+					Long userId = row['user_id']
+					migrations << [
+						apiKeyId: apiKeyId,
+						apiKeyName: apiKeyName,
+						userId: userId,
+						accountAddressProducer: executorService.submit(new GetAccountAddressTask(apiKeyId)),
+					]
+				}
+				sql.withBatch('INSERT INTO tmp_apikey_lookup (key_id, key_name, user_id, account_address, generated_integration_key_id, generated_user_password) VALUES (?, ?, ?, ?, ?, ?)') { statement ->
+					migrations.each { migration ->
+						statement.addBatch([
+							migration.apiKeyId,
+							migration.apiKeyName,
+							migration.userId,
+							migration.accountAddressProducer.get(),
+							IdGenerator.get(),
+							(migration.userId == null) ? AlphanumericStringGenerator.getRandomAlphanumericString(32) : null
+						])
+					}
 				}
 			}
 		}
-		sql('DELETE FROM `key` where user_id is not null')
 	}
 
-	// For each anonymous API key:
-	// - create a new Ethereum user (and inbox stream for that user)
-	// - migrate the key’s permissions to that user
-	// - delete the key
+	// create new users for anonymous keys (and update lookup table)
 	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-2") {
 		grailsChange {
 			change {
-				sql.eachRow('SELECT id, name, user_id FROM `key` where user_id is null') { row ->
-					String apiKeyId = row['id']
-					String accountAddress = getAccountAddress(apiKeyId)
-					def insertResult = sql.executeInsert("INSERT INTO user (version, account_expired, account_locked, enabled, name, password, password_expired, username, signup_method) VALUE (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+				sql.execute("""
+					INSERT INTO user (version, account_expired, account_locked, enabled, name, password, password_expired, username, signup_method)
+					SELECT
 						0,
 						false,
 						false,
 						true,
-						"Anonymous User",
-						AlphanumericStringGenerator.getRandomAlphanumericString(32),
+						'Anonymous User',
+						generated_user_password,
 						false,
-						accountAddress,
-						SignupMethod.MIGRATED.name()
-					]);
-					int userId = insertResult[0][0]
-					sql.execute("UPDATE permission SET user_id = ?, key_id = null WHERE key_id = ?", [ userId, apiKeyId])
-					createIntegrationKey(accountAddress, accountAddress, userId, sql)
-					createInboxStream(userId, accountAddress, sql)
-				}
+						account_address,
+						?
+					FROM tmp_apikey_lookup
+					WHERE user_id is null
+				""", [SignupMethod.MIGRATED.name()])
+				sql.execute("""
+					UPDATE tmp_apikey_lookup
+					LEFT JOIN user ON user.username = tmp_apikey_lookup.account_address
+					SET
+						tmp_apikey_lookup.user_id = user.id
+					WHERE user_id is null
+				""");
 			}
 		}
-		sql('DELETE FROM `key` where user_id is null')
+	}
+
+	// move the permissions of anonymous keys
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-3") {
+		grailsChange {
+			change {
+				sql.execute("""
+					UPDATE permission
+					LEFT JOIN tmp_apikey_lookup ON tmp_apikey_lookup.key_id = permission.key_id
+					SET
+						permission.user_id = tmp_apikey_lookup.user_id,
+						permission.key_id = null
+					WHERE permission.key_id is not null
+				""");
+			}
+		}
+	}
+
+	// create integration keys
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-4") {
+		grailsChange {
+			change {
+				sql.execute("""
+					INSERT INTO integration_key (id, version, name, json, user_id, service, id_in_service, date_created, last_updated)
+					SELECT
+						generated_integration_key_id,
+						0,
+						CONCAT('Converted from API key: ',key_name),
+						CONCAT(CONCAT('{\"address\":\"',account_address),'\"}'),
+						user_id,
+						?,
+						account_address,
+						CURRENT_TIMESTAMP(),
+						CURRENT_TIMESTAMP()
+					FROM tmp_apikey_lookup
+				""", [IntegrationKey.Service.ETHEREUM_ID.name()])
+			}
+		}
+	}
+
+	// create inbox streams for the integration keys
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-5") {
+		grailsChange {
+			change {
+				sql.execute("""
+					INSERT INTO stream (version, id, name, date_created, last_updated, partitions, require_signed_data, auto_configure, storage_days, inbox, inactivity_threshold_hours, example_type, require_encrypted_data)
+					SELECT
+						0,
+						account_address,
+						account_address,
+						CURRENT_TIMESTAMP(),
+						CURRENT_TIMESTAMP(),
+						1,
+						false,
+						false,
+						?,
+						true,
+						?,
+						?,
+						false
+					FROM tmp_apikey_lookup
+				""", [Stream.DEFAULT_STORAGE_DAYS, Stream.DEFAULT_INACTIVITY_THRESHOLD_HOURS, ExampleType.NOT_SET.value])
+			}
+		}
+	}
+
+	// create permissions for the inbox streams
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-6") {
+		grailsChange {
+			change {
+				List<Permission.Operation> permissionOperations = [
+					Permission.Operation.STREAM_GET,
+					Permission.Operation.STREAM_EDIT,
+					Permission.Operation.STREAM_DELETE,
+					Permission.Operation.STREAM_PUBLISH,
+					Permission.Operation.STREAM_SUBSCRIBE,
+					Permission.Operation.STREAM_SHARE,
+				];
+				sql.execute("""
+					INSERT INTO permission (version, operation, stream_id, anonymous, user_id)
+					SELECT
+						0,
+						permission_id,
+						account_address,
+						false,
+						user_id
+					FROM tmp_apikey_lookup
+					JOIN (
+						(SELECT ? as permission_id FROM DUAL) UNION ALL
+						(SELECT ? as permission_id FROM DUAL) UNION ALL
+						(SELECT ? as permission_id FROM DUAL) UNION ALL
+						(SELECT ? as permission_id FROM DUAL) UNION ALL
+						(SELECT ? as permission_id FROM DUAL) UNION ALL
+						(SELECT ? as permission_id FROM DUAL)
+					) as permission_ids
+				""", permissionOperations.collect { it.id })
+			}
+		}
+	}
+
+	// delete keys
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-7") {
+		sql('DELETE FROM `key`')
+	}
+
+	// drop lookup table
+	changeSet(author: "teogeb", id: "convert-API-keys-to-Ethereum-IDs-8") {
+		dropTable(tableName: "tmp_apikey_lookup")
 	}
 }

--- a/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
+++ b/grails-app/services/com/unifina/service/EthereumIntegrationKeyService.groovy
@@ -197,11 +197,10 @@ class EthereumIntegrationKeyService {
 	}
 
 	@CompileStatic
-	private static String getAddress(String privateKey) {
+	public static String getAddress(String privateKey) {
 		BigInteger pk = new BigInteger(privateKey, 16)
 		ECKey key = ECKey.fromPrivate(pk)
 		String publicKey = Hex.encodeHexString(key.getAddress())
-
 		return publicKey
 	}
 

--- a/grails-app/services/com/unifina/service/UserService.groovy
+++ b/grails-app/services/com/unifina/service/UserService.groovy
@@ -183,4 +183,8 @@ class UserService {
 			return null
 		}
 	}
+
+	User getUserByUsername(String username) {
+		return User.findByUsername(username);
+	}
 }

--- a/grails-app/services/com/unifina/service/UserService.groovy
+++ b/grails-app/services/com/unifina/service/UserService.groovy
@@ -183,8 +183,4 @@ class UserService {
 			return null
 		}
 	}
-
-	User getUserByUsername(String username) {
-		return User.findByUsername(username);
-	}
 }

--- a/src/java/com/unifina/controller/TokenAuthenticator.java
+++ b/src/java/com/unifina/controller/TokenAuthenticator.java
@@ -5,6 +5,8 @@ import com.unifina.domain.Key;
 import com.unifina.domain.User;
 import com.unifina.domain.Userish;
 import com.unifina.service.SessionService;
+import com.unifina.service.EthereumIntegrationKeyService;
+import com.unifina.security.ApiKeyConverter;
 import grails.util.Holders;
 import org.codehaus.groovy.runtime.InvokerHelper;
 
@@ -12,10 +14,13 @@ import javax.servlet.http.HttpServletRequest;
 
 public class TokenAuthenticator {
 	SessionService sessionService = Holders.getApplicationContext().getBean(SessionService.class);
+	EthereumIntegrationKeyService ethereumIntegrationKeyService = Holders.getApplicationContext().getBean(EthereumIntegrationKeyService.class);
+
 	private enum HeaderType {
 		TOKEN,
 		BEARER
 	}
+
 	public static class AuthorizationHeader {
 
 		private HeaderType headerType;
@@ -114,9 +119,11 @@ public class TokenAuthenticator {
 		if (apiKey == null) {
 			return new AuthenticationResult(true, false, true);
 		}
-		Key keyObject = (Key) InvokerHelper.invokeMethod(Key.class, "get", apiKey);
-		if (keyObject != null) {
-			return new AuthenticationResult(keyObject);
+		String privateKey = ApiKeyConverter.createEthereumPrivateKey(apiKey);
+		String address = "0x" + EthereumIntegrationKeyService.getAddress(privateKey);
+		User user = ethereumIntegrationKeyService.getEthereumUser(address);
+		if (user != null) {
+			return new AuthenticationResult(user);
 		}
 		return new AuthenticationResult(false, false, true);
 	}

--- a/src/java/com/unifina/security/ApiKeyConverter.java
+++ b/src/java/com/unifina/security/ApiKeyConverter.java
@@ -10,7 +10,6 @@ import java.security.GeneralSecurityException;
 
 public class ApiKeyConverter {
 
-	private static final String ETHEREUM_KEY_PREFIX = "0x";
 	private static final int HEX_DIGIT_BIT_COUNT = 4;
 	private static final byte[] SALT = new byte[] {0};
 	private static final int ETHEREUM_PRIVATE_KEY_LENGTH = 64;
@@ -21,8 +20,7 @@ public class ApiKeyConverter {
 			int keyLength = (ETHEREUM_PRIVATE_KEY_LENGTH - Hex.encode(SALT).length) * HEX_DIGIT_BIT_COUNT;
 			PBEKeySpec spec = new PBEKeySpec(apiKey.toCharArray(), SALT, ITERATION_COUNT, keyLength);
 			SecretKeyFactory skf = SecretKeyFactory.getInstance(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA1.name());
-			String encoded = String.valueOf(Hex.encode(EncodingUtils.concatenate(new byte[][]{SALT, skf.generateSecret(spec).getEncoded()})));
-			return ETHEREUM_KEY_PREFIX + encoded;
+			return String.valueOf(Hex.encode(EncodingUtils.concatenate(new byte[][]{SALT, skf.generateSecret(spec).getEncoded()})));
 		} catch (GeneralSecurityException e) {
 			throw new IllegalStateException("Could not create hash", e);
 		}

--- a/src/java/com/unifina/security/ApiKeyConverter.java
+++ b/src/java/com/unifina/security/ApiKeyConverter.java
@@ -1,0 +1,30 @@
+package com.unifina.security;
+
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.util.EncodingUtils;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.GeneralSecurityException;
+
+public class ApiKeyConverter {
+
+	private static final String ETHEREUM_KEY_PREFIX = "0x";
+	private static final int HEX_DIGIT_BIT_COUNT = 4;
+	private static final byte[] SALT = new byte[] {0};
+	private static final int ETHEREUM_PRIVATE_KEY_LENGTH = 64;
+	public static final int ITERATION_COUNT = 4096;
+
+	public static String createEthereumPrivateKey(String apiKey) {
+		try {
+			int keyLength = (ETHEREUM_PRIVATE_KEY_LENGTH - Hex.encode(SALT).length) * HEX_DIGIT_BIT_COUNT;
+			PBEKeySpec spec = new PBEKeySpec(apiKey.toCharArray(), SALT, ITERATION_COUNT, keyLength);
+			SecretKeyFactory skf = SecretKeyFactory.getInstance(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA1.name());
+			String encoded = String.valueOf(Hex.encode(EncodingUtils.concatenate(new byte[][]{SALT, skf.generateSecret(spec).getEncoded()})));
+			return ETHEREUM_KEY_PREFIX + encoded;
+		} catch (GeneralSecurityException e) {
+			throw new IllegalStateException("Could not create hash", e);
+		}
+	}
+}

--- a/src/java/com/unifina/security/ApiKeyConverter.java
+++ b/src/java/com/unifina/security/ApiKeyConverter.java
@@ -10,17 +10,15 @@ import java.security.GeneralSecurityException;
 
 public class ApiKeyConverter {
 
-	private static final int HEX_DIGIT_BIT_COUNT = 4;
 	private static final byte[] SALT = new byte[] {0};
-	private static final int ETHEREUM_PRIVATE_KEY_LENGTH = 64;
-	public static final int ITERATION_COUNT = 4096;
+	private static final int ITERATION_COUNT = 4096;
+	private static final int KEY_LENGTH = 256;
 
 	public static String createEthereumPrivateKey(String apiKey) {
 		try {
-			int keyLength = (ETHEREUM_PRIVATE_KEY_LENGTH - Hex.encode(SALT).length) * HEX_DIGIT_BIT_COUNT;
-			PBEKeySpec spec = new PBEKeySpec(apiKey.toCharArray(), SALT, ITERATION_COUNT, keyLength);
-			SecretKeyFactory skf = SecretKeyFactory.getInstance(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA1.name());
-			return String.valueOf(Hex.encode(EncodingUtils.concatenate(new byte[][]{SALT, skf.generateSecret(spec).getEncoded()})));
+			PBEKeySpec spec = new PBEKeySpec(apiKey.toCharArray(), SALT, ITERATION_COUNT, KEY_LENGTH);
+			SecretKeyFactory skf = SecretKeyFactory.getInstance(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA512.name());
+			return String.valueOf(Hex.encode(skf.generateSecret(spec).getEncoded()));
 		} catch (GeneralSecurityException e) {
 			throw new IllegalStateException("Could not create hash", e);
 		}

--- a/test/unit/com/unifina/controller/LogoutApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/LogoutApiControllerSpec.groovy
@@ -3,6 +3,7 @@ package com.unifina.controller
 import com.unifina.ControllerSpecification
 import com.unifina.domain.User
 import com.unifina.service.SessionService
+import com.unifina.service.EthereumIntegrationKeyService
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 
@@ -14,11 +15,13 @@ import grails.test.mixin.TestFor
 class LogoutApiControllerSpec extends ControllerSpecification {
 
 	SessionService sessionService
+	EthereumIntegrationKeyService ethereumIntegrationKeyService
 	User me
 
 	def setup() {
 		me = new User().save(failOnError: true, validate: false)
 		sessionService = controller.sessionService = mockBean(SessionService, Mock(SessionService))
+		ethereumIntegrationKeyService = mockBean(EthereumIntegrationKeyService, Mock(EthereumIntegrationKeyService))
 	}
 
 	def "logout invalidates session token"() {

--- a/test/unit/com/unifina/controller/RESTAPIFiltersSpec.groovy
+++ b/test/unit/com/unifina/controller/RESTAPIFiltersSpec.groovy
@@ -2,11 +2,11 @@ package com.unifina.controller
 
 import com.unifina.BeanMockingSpecification
 import com.unifina.controller.NodeApiController
-import com.unifina.domain.Key
 import com.unifina.domain.Role
 import com.unifina.domain.User
 import com.unifina.domain.UserRole
 import com.unifina.service.SessionService
+import com.unifina.service.EthereumIntegrationKeyService
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin
@@ -14,20 +14,22 @@ import grails.test.mixin.web.FiltersUnitTestMixin
 
 @TestMixin(FiltersUnitTestMixin)
 @TestFor(NodeApiController)
-@Mock([User, UserRole, RESTAPIFilters, Key, Role])
+@Mock([User, UserRole, RESTAPIFilters, Role])
 class RESTAPIFiltersSpec extends BeanMockingSpecification {
+
+	private static final String USER_API_KEY = "myApiKey"
+	private static final String USER_ACCOUNT_ADDRESS = "0xa0f7f3ff8a0965d0d46e5f1f963102fc6bed45ec"
+	private static final String USER_SESSION_TOKEN = "mytoken"
 
 	User user
 	Role adminRole, devopsRole
 	SessionService sessionService
+	EthereumIntegrationKeyService ethereumIntegrationKeyService
 
 	void setup() {
 		user = new User().save(failOnError: true, validate: false)
 		sessionService = mockBean(SessionService, Mock(SessionService))
-
-		Key key = new Key(name: "k1", user: user)
-		key.id = "myApiKey"
-		key.save(failOnError: true, validate: true)
+		ethereumIntegrationKeyService = mockBean(EthereumIntegrationKeyService, Mock(EthereumIntegrationKeyService))
 
 		adminRole = new Role(authority: "ROLE_ADMIN").save(failOnError: true)
 		devopsRole = new Role(authority: "ROLE_DEV_OPS").save(failOnError: true)
@@ -35,13 +37,14 @@ class RESTAPIFiltersSpec extends BeanMockingSpecification {
 
 	void "authenticationFilter responds with 403 and 'NOT_PERMITTED' if user don't have proper role"() {
 		when:
-		request.addHeader("Authorization", "Token myApiKey")
+		request.addHeader("Authorization", "Token " + USER_API_KEY)
 		request.requestURI = "/api/v1/nodes"
 		withFilters(action: "index") {
 			controller.index()
 		}
 
 		then:
+		1 * ethereumIntegrationKeyService.getEthereumUser(USER_ACCOUNT_ADDRESS) >> user
 		response.status == 403
 		response.json == [
 			code   : "NOT_PERMITTED",
@@ -54,28 +57,28 @@ class RESTAPIFiltersSpec extends BeanMockingSpecification {
 		new UserRole(user: user, role: adminRole).save(failOnError: true)
 
 		when:
-		request.addHeader("Authorization", "Token myApiKey")
+		request.addHeader("Authorization", "Token " + USER_API_KEY)
 		request.requestURI = "/api/v1/nodes"
 		withFilters(action: "index") {
 			controller.index()
 		}
 
 		then:
+		1 * ethereumIntegrationKeyService.getEthereumUser(USER_ACCOUNT_ADDRESS) >> user
 		response.status == 200
 	}
 
 	void "authentication passes when session token provided"() {
-		String token = "mytoken"
 		when:
 		new UserRole(user: user, role: adminRole).save(failOnError: true)
-		request.addHeader("Authorization", "Bearer " + token)
+		request.addHeader("Authorization", "Bearer " + USER_SESSION_TOKEN)
 		request.requestURI = "/api/v1/nodes"
 		withFilters(action: "index") {
 			controller.index()
 		}
 
 		then:
-		1 * sessionService.getUserishFromToken(token) >> user
+		1 * sessionService.getUserishFromToken(USER_SESSION_TOKEN) >> user
 		response.status == 200
 	}
 }

--- a/test/unit/com/unifina/controller/UserApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/UserApiControllerSpec.groovy
@@ -10,6 +10,7 @@ import com.unifina.security.PasswordEncoder
 import com.unifina.service.SessionService
 import com.unifina.service.UserAvatarImageService
 import com.unifina.service.UserService
+import com.unifina.service.EthereumIntegrationKeyService
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin
@@ -25,6 +26,7 @@ class UserApiControllerSpec extends ControllerSpecification {
 	User ethUser
 	PasswordEncoder passwordEncoder = new UnitTestPasswordEncoder()
 	SessionService sessionService
+	EthereumIntegrationKeyService ethereumIntegrationKeyService
 
 	def setup() {
 		me = new User(
@@ -47,6 +49,7 @@ class UserApiControllerSpec extends ControllerSpecification {
 		ethUser.save(validate: false)
 		controller.passwordEncoder = passwordEncoder
 		sessionService = mockBean(SessionService, Mock(SessionService))
+		ethereumIntegrationKeyService = mockBean(EthereumIntegrationKeyService, Mock(EthereumIntegrationKeyService))
 	}
 
 	void "unauthenticated user gets back 401"() {

--- a/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
+++ b/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
@@ -8,6 +8,6 @@ class ApiKeyConverterSpec extends Specification {
 		String converted = ApiKeyConverter.createEthereumPrivateKey("mock-api-key")
 		then:
 		true
-		converted == "0x003806b4ddedf17eddb217e191e02a98dd057d4f223c5e0302c5d00fb2b604c9"
+		converted == "003806b4ddedf17eddb217e191e02a98dd057d4f223c5e0302c5d00fb2b604c9"
 	}
 }

--- a/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
+++ b/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
@@ -8,6 +8,6 @@ class ApiKeyConverterSpec extends Specification {
 		String converted = ApiKeyConverter.createEthereumPrivateKey("mock-api-key")
 		then:
 		true
-		converted == "003806b4ddedf17eddb217e191e02a98dd057d4f223c5e0302c5d00fb2b604c9"
+		converted == "372da4ca3dbb6829ddbaaf81478344e89c1544d8be98705c54477de238e448b7"
 	}
 }

--- a/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
+++ b/test/unit/com/unifina/security/ApiKeyConverterSpec.groovy
@@ -1,0 +1,13 @@
+package com.unifina.security
+
+import spock.lang.Specification
+
+class ApiKeyConverterSpec extends Specification {
+	void "createEthereumPrivateKey"() {
+		when:
+		String converted = ApiKeyConverter.createEthereumPrivateKey("mock-api-key")
+		then:
+		true
+		converted == "0x003806b4ddedf17eddb217e191e02a98dd057d4f223c5e0302c5d00fb2b604c9"
+	}
+}


### PR DESCRIPTION
All API keys are converted to Ethereum integration keys. 

The database migration script converts API keys to integration keys with a deterministic function, inserts the keys to the DB and deletes the API keys. It creates new anonymous users for keys that don't belong to any user.

API key authentication is still supported: when a user authenticates with an API key, TokenAuthenticator calculates the integration key from the API key and finds the user by that integration key.

After this PR has been merged, we can most likely remove all remaining API key functionality (expect the TokenAuthenticator functionality described above) and drop the `Key` from the DB. Those changes will be done in a separate PR.

Open questions:

- There is an endpoint `/api/v1/login/apikey` where a user can create a session token by posting an API key. Is that endpoint still supported? Should we convert the API key to an integration key there similarly as we do in TokenAuthenticator? (`LoginApiController.groovy:49`)

- ApiKeyConverter uses PBKDF2WithHmacSHA512 to create an integration key. That algorithm requires a salt. Is it ok to use minimalistic 1-byte salt value that we define in the source code? Or should we define application level configuration property and read the salt from there? Currently we use just value "0" as a salt (`ApiKeyConverter.java:13`). Spring Security's [Pbkdf2PasswordEncoder](https://github.com/spring-projects/spring-security/blob/master/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java) implements PBKDF2 encoding by generating 8 random bytes as salt and prefixing the salt to the output in plain text. We don't include the salt in the output. Is that ok?

- When we migrate an API key that belongs to a user, we create a new integration key and delete all permissions that are attached to the key (`"DELETE FROM permission WHERE key_id = ?", [apiKeyId]`). Is it ok just to delete all permissions, and not migrate those? In the test DB there are no permissions for these keys, but the production environment may have some? (`2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy:87`)

- When we create an API key that doesn't belong to a user, we create a new user. Is the "UNKNOWN" signupMethod a good value to be used for these new users? Or should we e.g. create a new enum value "MIGRATED" for these? (`2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy:113`)

