### PR TITLE
BACK-61: Anonymous keys don't need "stream_delete" and "stream_edit" permissions

### DIFF
--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -154,4 +154,5 @@ databaseChangeLog = {
 	include file: 'core/2020-08-24-add-user-signup-method.groovy'
 	include file: 'core/2020-09-11-add-stream-storage-node.groovy'
 	include file: 'core/2020-09-15-add-DU-version-field-to-product.groovy'
+	include file: 'core/2020-10-01-remove-anonymous-keys-delete-and-edit-permissions.groovy'
 }

--- a/grails-app/migrations/core/2020-10-01-remove-anonymous-keys-delete-and-edit-permissions.groovy
+++ b/grails-app/migrations/core/2020-10-01-remove-anonymous-keys-delete-and-edit-permissions.groovy
@@ -1,0 +1,6 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "teogeb", id: "remove-anonymous-keys-delete-and-edit-permissions-1") {
+		sql("DELETE FROM permission WHERE key_id is not null and (operation='stream_delete' or operation='stream_edit')");
+	}
+}


### PR DESCRIPTION
Delete all "stream_delete" and "stream_edit" permissions that are attached to anonymous keys.

An earlier migration script `2020-01-24-new-permissions.groovy` created most/all of these permissions when it migrated old "write" permissions to "stream_edit"+"stream_publish"+"stream_delete".