### PR TITLE
BACK-63: Remove inbox stream functionality

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4864,11 +4864,6 @@
           "description": "If true, all data in this stream must be encrypted.",
           "example": false
         },
-        "inbox": {
-          "type": "boolean",
-          "description": "If true, this stream is a user's inbox.",
-          "example": false
-        },
         "dateCreated": {
           "type": "string",
           "description": "ISO-8601 timestamp of when stream was created.",
@@ -4935,11 +4930,6 @@
 		  "requireEncryptedData": {
 			"type": "boolean",
 			"description": "If true, all data in this stream must be encrypted.",
-			"example": false
-		  },
-		  "inbox": {
-			"type": "boolean",
-			"description": "If true, this stream is a user's inbox.",
 			"example": false
 		  },
 		  "dateCreated": {

--- a/grails-app/domain/com/unifina/domain/Stream.groovy
+++ b/grails-app/domain/com/unifina/domain/Stream.groovy
@@ -26,8 +26,6 @@ class Stream implements Comparable {
 	String uiChannelPath
 	Canvas uiChannelCanvas
 
-	Boolean inbox = false
-
 	Boolean requireSignedData = false
 	// Stream requires data to be encrypted
 	Boolean requireEncryptedData = false
@@ -67,7 +65,6 @@ class Stream implements Comparable {
 		uiChannel defaultValue: "false"
 		uiChannelPath index: "ui_channel_path_idx"
 		config type: 'text'
-		inbox defaultValue: "false"
 		requireSignedData defaultValue: "false"
 		requireEncryptedData defaultValue: "false"
 		autoConfigure defaultValue: "true"
@@ -90,7 +87,6 @@ class Stream implements Comparable {
 			config: config == null || config.empty ? config : JSON.parse(config),
 			description: description,
 			uiChannel: uiChannel,
-			inbox: inbox,
 			dateCreated: dateCreated,
 			lastUpdated: lastUpdated,
 			requireSignedData: requireSignedData,
@@ -109,7 +105,6 @@ class Stream implements Comparable {
 			name: name,
 			description: description,
 			uiChannel: uiChannel,
-			inbox: inbox,
 			dateCreated: dateCreated,
 			lastUpdated: lastUpdated,
 			requireSignedData: requireSignedData,

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -154,4 +154,5 @@ databaseChangeLog = {
 	include file: 'core/2020-08-24-add-user-signup-method.groovy'
 	include file: 'core/2020-09-11-add-stream-storage-node.groovy'
 	include file: 'core/2020-09-15-add-DU-version-field-to-product.groovy'
+	include file: 'core/2020-10-01-remove-inbox-stream.groovy'
 }

--- a/grails-app/migrations/core/2020-10-01-remove-inbox-stream.groovy
+++ b/grails-app/migrations/core/2020-10-01-remove-inbox-stream.groovy
@@ -1,0 +1,12 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "teogeb", id: "remove-inbox-stream-1") {
+		sql("DELETE FROM permission WHERE stream_id IN (SELECT id FROM stream WHERE inbox = b'1')");
+	}
+	changeSet(author: "teogeb", id: "remove-inbox-stream-2") {
+		sql("DELETE FROM stream WHERE inbox = b'1'");
+	}
+	changeSet(author: "teogeb", id: "remove-inbox-stream-3") {
+		dropColumn(columnName: "inbox", tableName: "stream")
+	}
+}

--- a/grails-app/services/com/unifina/service/StreamService.groovy
+++ b/grails-app/services/com/unifina/service/StreamService.groovy
@@ -31,12 +31,6 @@ class StreamService {
 		.create()
 
 	Stream getStream(String id) {
-		if (EthereumAddressValidator.validate(id)) {
-			Stream inboxStream = Stream.get(id.toLowerCase())
-			if (inboxStream.inbox) {
-				return inboxStream
-			}
-		}
 		return Stream.get(id)
 	}
 
@@ -154,17 +148,6 @@ class StreamService {
 			return false
 		}
 		return permissionService.check(key.user, stream, Permission.Operation.STREAM_SUBSCRIBE)
-	}
-
-	List<Stream> getInboxStreams(List<User> users) {
-		if (users.isEmpty()) return new ArrayList<Stream>()
-		List<IntegrationKey> keys = IntegrationKey.createCriteria().list {
-			user {
-				'in'("id", users*.id)
-			}
-			'in'("service", [IntegrationKey.Service.ETHEREUM, IntegrationKey.Service.ETHEREUM_ID])
-		}
-		return Stream.findAllByIdInListAndInbox(keys*.idInService, true)
 	}
 
 	static class StreamStatus {

--- a/rest-e2e-tests/schemas/stream.json
+++ b/rest-e2e-tests/schemas/stream.json
@@ -14,7 +14,6 @@
     "lastUpdated",
     "requireSignedData",
     "requireEncryptedData",
-    "inbox",
     "autoConfigure",
     "storageDays",
     "inactivityThresholdHours"
@@ -66,10 +65,6 @@
     },
     "requireEncryptedData": {
       "description": "Does this stream require data to be encrypted?",
-      "type": "boolean"
-    },
-    "inbox": {
-      "description": "Is this an inbox stream?",
       "type": "boolean"
     },
     "autoConfigure": {

--- a/src/groovy/com/unifina/controller/StreamListParams.groovy
+++ b/src/groovy/com/unifina/controller/StreamListParams.groovy
@@ -9,7 +9,6 @@ import groovy.transform.CompileStatic
 class StreamListParams extends ListParams {
 	String name
 	Boolean uiChannel
-	Boolean inbox = false
 
 	StreamListParams() {
 		super()
@@ -19,7 +18,6 @@ class StreamListParams extends ListParams {
 	static constraints = {
 		name(nullable: true, blank: false)
 		uiChannel(nullable: true)
-		inbox(nullable: true)
 	}
 
 	@Override
@@ -38,10 +36,6 @@ class StreamListParams extends ListParams {
 			if (uiChannel != null) {
 				eq("uiChannel", uiChannel)
 			}
-			// Filter by inbox stream
-			if (inbox != null) {
-				eq("inbox", inbox)
-			}
 		}
 	}
 
@@ -50,7 +44,6 @@ class StreamListParams extends ListParams {
 		return super.toMap() + ([
 			name     : name,
 			uiChannel: uiChannel,
-			inbox    : inbox
 		] as Map<String, Object>)
 	}
 }

--- a/test/unit/com/unifina/service/EthereumIntegrationKeyServiceSpec.groovy
+++ b/test/unit/com/unifina/service/EthereumIntegrationKeyServiceSpec.groovy
@@ -189,30 +189,6 @@ class EthereumIntegrationKeyServiceSpec extends Specification {
 		IntegrationKey.count() == 0
 	}
 
-	void "delete() deletes corresponding inbox stream and its permissions"() {
-		service.subscriptionService = Stub(SubscriptionService)
-
-		def integrationKey = new IntegrationKey(user: me)
-		integrationKey.id = "integration-key"
-		integrationKey.idInService = "address"
-		integrationKey.save(failOnError: true, validate: false)
-		Stream inbox = new Stream()
-		inbox.id = "address"
-		inbox.inbox = true
-		inbox.save(failOnError: true, validate: false)
-		Permission perm = new Permission(operation: Permission.Operation.STREAM_SUBSCRIBE)
-		perm.stream = inbox
-		perm.user = me
-		perm.save(failOnError: true, validate: false)
-
-		when:
-		service.delete("integration-key", me)
-		then:
-		IntegrationKey.count() == 0
-		Stream.get("address") == null
-		Permission.findAllByStream(inbox) == []
-	}
-
 	void "delete() invokes subscriptionService#beforeIntegrationKeyRemoved for Ethereum IDs"() {
 		def subscriptionService = service.subscriptionService = Mock(SubscriptionService)
 
@@ -288,42 +264,6 @@ class EthereumIntegrationKeyServiceSpec extends Specification {
 		user.username == me.username
 		IntegrationKey.count == 1
 		User.count == 1
-	}
-
-	void "createEthereumUser() creates inbox stream"() {
-		User someoneElse = new User(username: "someoneElse@streamr.com").save(failOnError: true, validate: false)
-		when:
-		service.createEthereumUser("address", SignupMethod.UNKNOWN)
-		then:
-		1 * userService.createUser(_) >> someoneElse
-		1 * permissionService.systemGrantAll(_, _)
-		Stream.count == 1
-		Stream.get("address").inbox
-	}
-
-	void "createEthereumID() creates inbox stream"() {
-		service.subscriptionService = Stub(SubscriptionService)
-
-		Challenge ch = new Challenge("id", "foobar", 300)
-		final String signature = "0x50ba6f6df25ba593cb8188df29ca27ea0a7cd38fadc4d40ef9fad455117e190f2a7ec880a76b930071205fee19cf55eb415bd33b2f6cb5f7be36f79f740da6e81b"
-		final String address = "0x10705c0b408eb64860f67a81f5908b51b62a86fc"
-		final String name = "foobar"
-		when:
-		service.createEthereumID(me, name, ch.getId(), ch.getChallenge(), signature)
-		then:
-		1 * permissionService.systemGrantAll(_, _)
-		1 * challengeService.verifyChallengeAndGetAddress(ch.getId(), ch.getChallenge(), signature) >> address
-		Stream.count == 1
-		Stream.get(address).inbox
-	}
-
-	void "createEthereumAccount() creates inbox stream"() {
-		when:
-		service.createEthereumAccount(me, "ethKey", "fa7d31d2fb3ce6f18c629857b7ef5cc3c6264dc48ddf6557cc20cf7a5b361365")
-		then:
-		1 * permissionService.systemGrantAll(_, _)
-		Stream.count == 1
-		Stream.get("0xf4f683a8502b2796392bedb05dbbcc8c6e582e59").inbox
 	}
 
 	void "cannot remove only key of ethereum user"() {

--- a/test/unit/com/unifina/service/PermissionServiceSpec.groovy
+++ b/test/unit/com/unifina/service/PermissionServiceSpec.groovy
@@ -183,27 +183,27 @@ class PermissionServiceSpec extends BeanMockingSpecification {
 	void "systemRevoke() on a stream also revokes the parent permissions"() {
 		User publisher = new User()
 		publisher.id = 7L
-		Stream pubInbox = new Stream(name: "publisher", inbox: true)
-		pubInbox.id = "publisher"
-		pubInbox.save(failOnError: true, validate: false)
+		Stream pub = new Stream(name: "publisher")
+		pub.id = "publisher"
+		pub.save(failOnError: true, validate: false)
 		User subscriber = new User(username: "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)
-		Stream subInbox = new Stream(name: subscriber.username, inbox: true)
-		subInbox.id = subscriber.username
-		subInbox.save(failOnError: true, validate: false)
+		Stream sub = new Stream(name: subscriber.username)
+		sub.id = subscriber.username
+		sub.save(failOnError: true, validate: false)
 		Stream stream = new Stream()
 		stream.id = "stream"
 		setup:
 		new Permission(user: publisher, stream: stream, operation: Operation.STREAM_PUBLISH).save(failOnError: true, validate: false)
 
 		Permission parent = new Permission(user: subscriber, stream: stream, operation: Operation.STREAM_SUBSCRIBE).save(failOnError: true, validate: false)
-		new Permission(user: subscriber, stream: pubInbox, operation: Operation.STREAM_PUBLISH, parent: parent).save(failOnError: true, validate: false)
-		new Permission(user: publisher, stream: subInbox, operation: Operation.STREAM_PUBLISH, parent: parent).save(failOnError: true, validate: false)
+		new Permission(user: subscriber, stream: pub, operation: Operation.STREAM_PUBLISH, parent: parent).save(failOnError: true, validate: false)
+		new Permission(user: publisher, stream: sub, operation: Operation.STREAM_PUBLISH, parent: parent).save(failOnError: true, validate: false)
 		when:
 		service.systemRevoke(subscriber, stream, Operation.STREAM_SUBSCRIBE)
 		then:
 		!service.check(subscriber, stream, Permission.Operation.STREAM_SUBSCRIBE)
-		!service.check(subscriber, pubInbox, Permission.Operation.STREAM_PUBLISH)
-		!service.check(publisher, subInbox, Permission.Operation.STREAM_PUBLISH)
+		!service.check(subscriber, pub, Permission.Operation.STREAM_PUBLISH)
+		!service.check(publisher, sub, Permission.Operation.STREAM_PUBLISH)
 	}
 
 	void "stranger can read public resources with anonymous read access"() {

--- a/test/unit/com/unifina/service/StreamServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamServiceSpec.groovy
@@ -40,22 +40,6 @@ class StreamServiceSpec extends Specification {
 		me.save(validate: false, failOnError: true)
 	}
 
-	def "getStream for inbox stream is case-insensitive"() {
-		Stream s = new Stream()
-		s.id = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
-		s.inbox = true
-		s.name = "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6"
-		s.save(validate: false)
-
-		when:
-		Stream queried1 = service.getStream(s.id)
-		Stream queried2 = service.getStream("0x" + s.id.substring(2).toUpperCase())
-
-		then:
-		queried1.id == s.id
-		queried2.id == s.id
-	}
-
 	def "add example shared streams"() {
 		setup:
 		service.permissionService = Mock(PermissionService)
@@ -253,34 +237,6 @@ class StreamServiceSpec extends Specification {
 		result1 && result1b
 		2 * service.permissionService.check(user2, stream, Permission.Operation.STREAM_SUBSCRIBE) >> false
 		!result2 && !result2b
-	}
-
-	void "getInboxStreams() returns all inbox streams of the users"() {
-		User user1 = new User(id: 1, username: "u1").save(failOnError: true, validate: false)
-		IntegrationKey key1 = new IntegrationKey(user: user1, service: IntegrationKey.Service.ETHEREUM_ID,
-			idInService: "0x9fe1ae3f5efe2a01eca8c2e9d3c11102cf4bea57").save(failOnError: true, validate: false)
-		User user2 = new User(id: 2, username: "u2").save(failOnError: true, validate: false)
-		IntegrationKey key2 = new IntegrationKey(user: user2, service: IntegrationKey.Service.ETHEREUM,
-			idInService: "0x26e1ae3f5efe8a01eca8c2e9d3c32702cf4bead6").save(failOnError: true, validate: false)
-		IntegrationKey key3 = new IntegrationKey(user: user2, service: IntegrationKey.Service.ETHEREUM,
-			idInService: "0xfff1ae3f5efe8a01eca8c25933c32702cf4b1121").save(failOnError: true, validate: false)
-		User user3 = new User(id: 3, username: "u3").save(failOnError: true, validate: false)
-
-		Stream s1 = new Stream(name: key1.idInService, inbox: true)
-		s1.id = key1.idInService
-		s1.save(failOnError: true, validate: false)
-		Stream s2 = new Stream(name: key1.idInService, inbox: true)
-		s2.id = key2.idInService
-		s2.save(failOnError: true, validate: false)
-		Stream s3 = new Stream(name: key1.idInService, inbox: true)
-		s3.id = key3.idInService
-		s3.save(failOnError: true, validate: false)
-
-		Set<Stream> expectedResults = [s1, s2, s3]
-		when:
-		Set<Stream> results = service.getInboxStreams([user1, user2, user3])
-		then:
-		results == expectedResults
 	}
 
 	void "status ok and has recent messages"() {


### PR DESCRIPTION
Remove implementation of inbox stream functionality. Delete inbox streams from DB, permissions of those streams and inbox-column of `stream` table.

The migration scripts deletes ~22k inbox streams and ~132k permissions.