### PR TITLE
Configure tomcat to allow encoded slash in uri

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -15,7 +15,10 @@ grails.project.fork = [
 		minMemory: 256,
 		debug: false,
 		maxPerm: 512,
-		forkReserve:false
+		forkReserve:false,
+		jvmArgs: [
+			"-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
+		]
 	],
 	test: [
 		maxMemory: System.getProperty("maxMemory") ? Integer.parseInt(System.getProperty("maxMemory")) : 4196,
@@ -25,7 +28,8 @@ grails.project.fork = [
 		forkReserve:false,
 		daemon:true,
 		jvmArgs: [
-			"-Djava.awt.headless=true"
+			"-Djava.awt.headless=true",
+			"-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
 		]
 	]
 ]

--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -20,7 +20,11 @@ class UrlMappings {
 		"/api/v1/canvases/$canvasId/modules/$moduleId"(controller: "canvasApi", action: "module") // for internal use
 		"/api/v1/canvases/downloadCsv"(method: "GET", controller: "canvasApi", action: "downloadCsv")
 
-		"/api/v1/streams"(resources: "streamApi", excludes: ["create", "edit"])
+		"/api/v1/streams"(method: "GET", controller: "streamApi", action: "index")
+		"/api/v1/streams"(method: "POST", controller: "streamApi", action: "save")
+		"/api/v1/streams/$id"(method: "GET", controller: "streamApi", action: "show")
+		"/api/v1/streams/$id"(method: "PUT", controller: "streamApi", action: "update")
+		"/api/v1/streams/$id"(method: "DELETE", controller: "streamApi", action: "delete")
 		"/api/v1/streams/$resourceId/permissions"(resources: "permissionApi", excludes: ["create", "edit", "update"]) { resourceClass = Stream }
 		"/api/v1/streams/$resourceId/permissions/me"(controller: "permissionApi", action: "getOwnPermissions") { resourceClass = Stream }
 		"/api/v1/streams/$id/fields"(method: "POST", controller: "streamApi", action: "setFields")

--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -5,8 +5,8 @@ const fs = require('fs')
 const Emitter = require('events')
 const initStreamrApi = require('./streamr-api-clients')
 
-const REST_URL = 'http://localhost:8081/streamr-core/api/v1'
-const WS_URL = 'ws://localhost:8890/api/v1/ws'
+const REST_URL = 'http://localhost/api/v1'
+const WS_URL = 'ws://localhost/api/v1/ws'
 const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)

--- a/rest-e2e-tests/categories-api.test.js
+++ b/rest-e2e-tests/categories-api.test.js
@@ -3,7 +3,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)

--- a/rest-e2e-tests/cors.test.js
+++ b/rest-e2e-tests/cors.test.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const fetch = require('node-fetch')
 
-const URL = 'http://localhost:8081/streamr-core/api/v1'
+const URL = 'http://localhost/api/v1'
 
 const TIMEOUT = 5000
 

--- a/rest-e2e-tests/dataunions-api.test.js
+++ b/rest-e2e-tests/dataunions-api.test.js
@@ -3,7 +3,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const StreamrClient = require('streamr-client')
 const initStreamrApi = require('./streamr-api-clients')
-const REST_URL = 'http://localhost:8081/streamr-core/api/v1'
+const REST_URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
 const API_KEY = 'product-api-tester-key'

--- a/rest-e2e-tests/package-lock.json
+++ b/rest-e2e-tests/package-lock.json
@@ -5,62 +5,191 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+      "integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.4.tgz",
-      "integrity": "sha512-T8woaIQHCJMZDAQim1vSp8ycsP2h1/TlnBHzQqR9atKknoqLiT26Wxr9AkhW1aufexkWrZTHbf2837469uS6Eg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+      "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
       "requires": {
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+          "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          },
+          "dependencies": {
+            "@ethersproject/properties": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
+              "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+              "requires": {
+                "@ethersproject/logger": "^5.0.5"
+              }
+            }
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.3.tgz",
-      "integrity": "sha512-0dVq0IcJd6/qTjT+bhJw6ooJuCJDNWTL8SKRFBnqr4OgDW7p1AXX2l7lQd7vX9RpbnDzurSM+fTBKCVWjdm3Vw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
+      "integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/networks": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/web": "^5.0.4"
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        }
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.3.tgz",
-      "integrity": "sha512-uhHXqmcJcxWYD+hcvsp/pu8iSgqQzgSXHJtFGUYBBkWGpCp5kF95nSRlFnyVu9uAqZxwynBtOrPZBd1ACGBQBQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
+      "integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        }
       }
     },
     "@ethersproject/address": {
@@ -77,17 +206,17 @@
       }
     },
     "@ethersproject/base64": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
-      "integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.4.tgz",
+      "integrity": "sha512-4KRykQ7BQMeOXfvio1YITwHjxwBzh92UoXIdzxDE1p53CK28bbHPdsPNYo0wl0El7lJAMpT2SOdL0hhbWRnyIA==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
-      "integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.4.tgz",
+      "integrity": "sha512-ixIr/kKiAoSzOnSc777AGIOAhKai5Ivqr4HO/Gz+YG+xkfv6kqD6AW4ga9vM20Wwb0QBhh3LoRWTu4V1K+x9Ew==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/properties": "^5.0.3"
@@ -120,19 +249,52 @@
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.3.tgz",
-      "integrity": "sha512-60H7UJx6qsp3JP5q3jFjzVNGUygRfz+XzfRwx/VeCKjHBUpFxPEIO2S30SMjYKPqw6JsgxbOjxFFZgOfQiNesw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.5.tgz",
+      "integrity": "sha512-tFI255lFbmbqMkgnuyhDWHl3yWqttPlReplYuVvDCT/SuvBjLR4ad2uipBlh1fh5X1ipK9ettAoV4S0HKim4Kw==",
       "requires": {
-        "@ethersproject/abi": "^5.0.3",
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        }
       }
     },
     "@ethersproject/hash": {
@@ -147,42 +309,160 @@
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.3.tgz",
-      "integrity": "sha512-+VQj0gRxfwRPHH7J32fTU8Ouk9CBFBIqvl937I0swO5PghNXBy/1U+o8gZMOitLIId1P3Wr6QcaDHkusi7OQXw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.5.tgz",
+      "integrity": "sha512-Ho4HZaK+KijE5adayvjAGusWMnT0mgwGa5hGMBofBOgX9nqiKf6Wxx68SXBGI1/L3rmKo6mlAjxUd8gefs0teQ==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.4",
         "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/pbkdf2": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        }
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.5.tgz",
-      "integrity": "sha512-g2kdOY5l+TDE5rIE9BLK+S7fiQMIIsM+KTxxVu4H2COROFwCSMeEb5uMCkccXc3iDX1sOBF653h8kTXCaFY03Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.7.tgz",
+      "integrity": "sha512-dgOn9JtGgjT28mDXs4LYY2rT4CzS6bG/rxoYuPq3TLHIf6nmvBcr33Fee6RrM/y8UAx4gyIkf6wb2cXsOctvQQ==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.3",
+        "@ethersproject/hdnode": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/pbkdf2": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        }
       }
     },
     "@ethersproject/keccak256": {
@@ -200,17 +480,17 @@
       "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
     },
     "@ethersproject/networks": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
-      "integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
+      "integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
-      "integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.4.tgz",
+      "integrity": "sha512-9jVBjHXQKfr9+3bkCg01a8Cd1H9e+7Kw3ZMIvAxD0lZtuzrXsJxm1hVwY9KA+PRUvgS/9tTP4viXQYwLAax7zg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/sha2": "^5.0.3"
@@ -225,31 +505,113 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.7.tgz",
-      "integrity": "sha512-lT+w/w2PKX9oyddX0DTBYl2CVHJTJONZP5HLJ3MzVvSA5dTOdiJ9Sx5rpqR7Tw+mxVA9xPjanoNCaPPIT7cykQ==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.13.tgz",
+      "integrity": "sha512-5jsuk1FwXxmoQApGs8LSQyS43KP01pHA+6cQ1OPov5pT5Pcqe6ffh6UD1//BZ9Vjf+5e9AQqIk8w7FkGyROuCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
         "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/networks": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
         "@ethersproject/rlp": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/web": "^5.0.4",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6",
         "bech32": "1.1.4",
         "ws": "7.2.3"
       },
       "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+          "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          },
+          "dependencies": {
+            "@ethersproject/properties": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
+              "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+              "requires": {
+                "@ethersproject/logger": "^5.0.5"
+              }
+            }
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        },
         "ws": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -258,9 +620,9 @@
       }
     },
     "@ethersproject/random": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
-      "integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.4.tgz",
+      "integrity": "sha512-AIZJhqs6Ba4/+U3lOjt3QZbP6b/kuuGLJUYFUonAgWmkTHwqsCwYnFvnHKQSUuHbXHvErp7WFXFlztx+yMn3kQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
@@ -276,9 +638,9 @@
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
-      "integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
+      "integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -324,15 +686,45 @@
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.3.tgz",
-      "integrity": "sha512-a6ni4OIj1e+JrvDiuLVqygYmAh53Ljk5iErkjzPgFBY8dz9xQfDxhpASjOZY0lzCf+N125yeK9N7Vm3HI7OLzQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.5.tgz",
+      "integrity": "sha512-DMFQ0ouXmNVoKWbGEUFGi8Urli4SJip9jXafQyFHWPRr5oJUqDVkNfwcyC37k+mhBG93k7qrYXCH2xJnGEOxHg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ethersproject/strings": {
@@ -362,70 +754,272 @@
       }
     },
     "@ethersproject/units": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.3.tgz",
-      "integrity": "sha512-PyQ066mFczUy0CSJJrc/VK+1ATh1bsI8EkzAVT7GQ0IPJlNDcXnGNtlH5EQGHzuXA3GDQNV23poB0Cy/WDb2zg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.6.tgz",
+      "integrity": "sha512-tsJuy4mipppdmooukRfhXt8fGx9nxvfvG6Xdy0RDm7LzHsjghjwQ69m2bCpId6SDSR1Uq1cQ9irPiUBSyWolUA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        }
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.3.tgz",
-      "integrity": "sha512-Nouwfh1HlpxaeRRi4+UDVsfrd9fitBHUvw35bTMSwJLFsZTb9xPd0LGWdX4llwVlAP/CXb6qDc0zwYy6uLp7Lw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.6.tgz",
+      "integrity": "sha512-dRqx3+Degc5pvjaeeTHuk2EuTRM3b6ce/TiV0HRZhRXYnKyyjg0iYXEZo/b6p3rnV+Xhwxkc0+I/ISPkNpictA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.3",
-        "@ethersproject/hdnode": "^5.0.3",
-        "@ethersproject/json-wallets": "^5.0.5",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/json-wallets": "^5.0.6",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+          "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          },
+          "dependencies": {
+            "@ethersproject/properties": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
+              "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+              "requires": {
+                "@ethersproject/logger": "^5.0.5"
+              }
+            }
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        }
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.5.tgz",
-      "integrity": "sha512-3lffVNOKv/ypW42eY0xhc+UXF+lFUgP1QfIZhWDTJ4xSY6tuNayXKXYq+AqjLXwxwIHzD0TOpe4j46IXJx2NXA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
+      "integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
       "requires": {
         "@ethersproject/base64": "^5.0.3",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.3.tgz",
-      "integrity": "sha512-Asro9CcBJqxtMnmKrsg79GMmH02p0JmdOwhEdRHRbr51UMRqAfV5RjiidYk21aMsTflv4VY3HgFs6q6FtRJs+w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.5.tgz",
+      "integrity": "sha512-XA3ycFltVrCTQt04w5nHu3Xq5Z6HjqWsXaAYQHFdqtugyUsIumaO9S5MOwFFuUYTNkZUoT3jCRa/OBS+K4tLfA==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+          "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          },
+          "dependencies": {
+            "@ethersproject/properties": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
+              "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+              "requires": {
+                "@ethersproject/logger": "^5.0.5"
+              }
+            }
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@peculiar/asn1-schema": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.17.tgz",
-      "integrity": "sha512-7rJD8bR1r6NFE4skDxXsLsFEO3zM2TfjX9wdq5SERoBNEuxGkAJ3uIH84sIMxvDgJtb3cMfLsv8iNpGN0nAWdw==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.23.tgz",
+      "integrity": "sha512-dV1xQJiWTzwyjfAbvwTT+RTrS4UN9kPJuy92B6oGv572wPZxaoA8R+nxLX92jLz23L43CnLvxiBo+Rip59SWfw==",
       "requires": {
-        "@types/asn1js": "^0.0.1",
+        "@types/asn1js": "^0.0.2",
         "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.11",
-        "tslib": "^2.0.1"
+        "pvtsutils": "^1.0.14",
+        "tslib": "^2.0.2"
       }
     },
     "@peculiar/json-schema": {
@@ -450,9 +1044,9 @@
       }
     },
     "@types/asn1js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.1.tgz",
-      "integrity": "sha1-74uflwjLFjKhw6nNJ3F8qr55O8I=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.2.tgz",
+      "integrity": "sha512-xtLPq140WhPqvDZDpY70rTx4qTezHs+8htbhWQGuevBRQko8FRjFSO5WVTwXOwd3W5tQRxJ7eni30fDUP2q4wQ==",
       "requires": {
         "@types/pvutils": "*"
       }
@@ -1081,6 +1675,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -1594,40 +2193,178 @@
       }
     },
     "ethers": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.12.tgz",
-      "integrity": "sha512-mgF1ZLd1y5r+hS1IPATKwKx5k/PCSqz4PEQjMR+er+Hhu6IefVVcoYATUMjmK4FG+3PAkorRMA9rJ4Y/fdW0UA==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.18.tgz",
+      "integrity": "sha512-WCiKGfAt09hBS1HZspu+JTgeunFcUCVRhCXO8X+VadBJGTRlG722XXib79Vz2oyBperz90CcjkBPdNly61Ah4A==",
       "requires": {
-        "@ethersproject/abi": "^5.0.3",
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/base64": "^5.0.3",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/contracts": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
-        "@ethersproject/hdnode": "^5.0.3",
-        "@ethersproject/json-wallets": "^5.0.5",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/providers": "^5.0.6",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/solidity": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/units": "^5.0.3",
-        "@ethersproject/wallet": "^5.0.3",
-        "@ethersproject/web": "^5.0.4",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/abi": "5.0.7",
+        "@ethersproject/abstract-provider": "5.0.5",
+        "@ethersproject/abstract-signer": "5.0.7",
+        "@ethersproject/address": "5.0.5",
+        "@ethersproject/base64": "5.0.4",
+        "@ethersproject/basex": "5.0.4",
+        "@ethersproject/bignumber": "5.0.8",
+        "@ethersproject/bytes": "5.0.5",
+        "@ethersproject/constants": "5.0.5",
+        "@ethersproject/contracts": "5.0.5",
+        "@ethersproject/hash": "5.0.6",
+        "@ethersproject/hdnode": "5.0.5",
+        "@ethersproject/json-wallets": "5.0.7",
+        "@ethersproject/keccak256": "5.0.4",
+        "@ethersproject/logger": "5.0.6",
+        "@ethersproject/networks": "5.0.4",
+        "@ethersproject/pbkdf2": "5.0.4",
+        "@ethersproject/properties": "5.0.4",
+        "@ethersproject/providers": "5.0.13",
+        "@ethersproject/random": "5.0.4",
+        "@ethersproject/rlp": "5.0.4",
+        "@ethersproject/sha2": "5.0.4",
+        "@ethersproject/signing-key": "5.0.5",
+        "@ethersproject/solidity": "5.0.5",
+        "@ethersproject/strings": "5.0.5",
+        "@ethersproject/transactions": "5.0.6",
+        "@ethersproject/units": "5.0.6",
+        "@ethersproject/wallet": "5.0.6",
+        "@ethersproject/web": "5.0.9",
+        "@ethersproject/wordlists": "5.0.5"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
+          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
+          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
+          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
+          "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
+          "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
+          "integrity": "sha512-GNpiOUm9PGUxFNqOxYKDQBM0u68bG9XC9iOulEQ8I0tOx/4qUpgVzvgXL6ugxr0RY554Gz/NQsVqknqPzUcxpQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
+          "integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
+          "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.4.tgz",
+          "integrity": "sha512-5qrrZad7VTjofxSsm7Zg/7Dr4ZOln4S2CqiDdOuTv6MBKnXj0CiBojXyuDy52M8O3wxH0CyE924hXWTDV1PQWQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.5.tgz",
+          "integrity": "sha512-Z1wY7JC1HVO4CvQWY2TyTTuAr8xK3bJijZw1a9G92JEmKdv1j255R/0YLBBcFTl2J65LUjtXynNJ2GbArPGi5g==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "elliptic": "6.5.3"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
+          "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
+          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
       }
     },
     "ethjs-unit": {
@@ -2029,6 +2766,15 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
+      "requires": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
       }
     },
     "he": {
@@ -2685,9 +3431,9 @@
       },
       "dependencies": {
         "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         }
       }
     },
@@ -2945,9 +3691,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pvtsutils": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.12.tgz",
-      "integrity": "sha512-fudCcWFUE7WPHMRVdlEDdeaeLf+8hvZFvfJJ+p8GZlwrrdoiVfv7WZaPt6k7k/NZjMxR8yUbbH51hpwlSmLHiQ==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.14.tgz",
+      "integrity": "sha512-X9SBWQ9ceNAEEgLweoE7m7P6LDnZ3pZADBq7utQQV4pQ1vj7uQIAXaAQRCz/4nKLKQRT9ZrHOuxailKqBiztrg==",
       "requires": {
         "tslib": "^2.0.1"
       }
@@ -3271,6 +4017,11 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+    },
     "sjcl": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.6.tgz",
@@ -3308,9 +4059,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamr-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.1.1.tgz",
-      "integrity": "sha512-qZ9XDPRPehz50jh+1J/o7+qyIknaV90xM+yOBOrCUUtyUiTVpAvZC9ogrkGOAhGLrVIyfE3QGBh2DIov3NhIcQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.1.2.tgz",
+      "integrity": "sha512-hNo0bcKjwQK4WPKY/JWcOndvI7W3gk+kGqvIQ9URRJADdSyYAPuvdOHYIiuyyyrNfNwkyQ4OMGm5SSAMTBSp6w==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "debug": "^4.1.1",
@@ -3331,25 +4082,37 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         }
       }
     },
     "streamr-client-protocol": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-5.0.0.tgz",
-      "integrity": "sha512-lvcODgdK3uHQHRtZPBTGyRxctWANLBaQW8oyP4IyM/J6ZRbzgvJ6hVITEsKS3hOf2+BRrvO48N6mEqCZjq/1yQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-5.3.1.tgz",
+      "integrity": "sha512-wEUlP/OCcmWv1A6e9xcd62Kyi8DkdLySuiHZlvETNsRzfQy6+c0C4C3avT04/dLdcvyD4B7zkvpMQCIKPrXRDQ==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.9.6",
+        "@babel/runtime-corejs3": "^7.11.2",
         "core-js": "^3.6.5",
-        "debug": "^4.1.1",
-        "eventemitter3": "^4.0.0",
+        "debug": "^4.2.0",
+        "ethers": "^5.0.14",
+        "eventemitter3": "^4.0.7",
+        "hashring": "^3.2.0",
         "heap": "^0.2.6",
         "promise-memoize": "^1.2.1",
-        "secp256k1": "^4.0.1",
-        "sha3": "^2.1.2"
+        "secp256k1": "^4.0.2",
+        "sha3": "^2.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "strict-uri-encode": {
@@ -3534,9 +4297,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/streamr-dev/engine-and-editor",
   "scripts": {
-	"test": "npm run test:e2e && npm run test:stress",
+    "test": "npm run test:e2e && npm run test:stress",
     "test:e2e": "mocha *.test.js --exclude '*.stress-test.js' --recursive --color false --exit --timeout 5000",
     "test:stress": "mocha *.stress-test.js --recursive --color false --exit"
   },
@@ -22,7 +22,7 @@
     "mocha": "8.1.3",
     "node-fetch": "2.6.1",
     "sleep-promise": "8.0.1",
-    "streamr-client": "4.1.1",
+    "streamr-client": "^4.1.2",
     "web3": "1.2.11"
   },
   "devDependencies": {}

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const StreamrClient = require('streamr-client')
-const URL = 'http://localhost/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -3,7 +3,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const StreamrClient = require('streamr-client')
 
-const URL = 'http://localhost/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -7,7 +7,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED || false
 
 const AUTH_TOKEN = 'product-api-tester-key'

--- a/rest-e2e-tests/storagenode-api.test.js
+++ b/rest-e2e-tests/storagenode-api.test.js
@@ -2,7 +2,7 @@ const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const _ = require('lodash');
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const API_KEY = 'product-api-tester-key';
 const API_KEY_OTHER_USER = 'product-api-tester2-key'
 const LOGGING_ENABLED = false;

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -439,7 +439,8 @@ class NotFound {
 
 module.exports = (baseUrl, logging) => {
     const options = {
-        baseUrl,
+        // Append a trailing "/" if not present
+        baseUrl: baseUrl.slice(-1) === "/" ? baseUrl : baseUrl + '/',
         logging
     }
 

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -106,6 +106,27 @@ describe('Streams API', () => {
 
 	})
 
+    describe('GET /api/v1/streams/:id', () => {
+        it('works with uri-encoded ids', async () => {
+            const id = 'sandbox/streams-api.test.js/stream-' + Date.now()
+            let response = await Streamr.api.v1.streams
+                .create({
+                    id,
+                })
+                .withApiKey(API_KEY)
+                .call()
+            assert.equal(response.status, 200)
+
+            response = await Streamr.api.v1.streams
+                .get(encodeURIComponent(id))
+                .withApiKey(API_KEY)
+                .call()
+            const json = await response.json()
+            assert.equal(response.status, 200, `Error getting stream ${id}: ${JSON.stringify(json)}`)
+            assert.equal(json.id, id)
+        })
+    })
+
     describe('GET /api/v1/streams/:id/permissions/me', () => {
         it('responds with status 404 when authenticated but stream does not exist', async () => {
             const response = await Streamr.api.v1.streams.permissions

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -4,7 +4,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const API_KEY = 'stream-api-tester-key'

--- a/rest-e2e-tests/subscriptions-api.test.js
+++ b/rest-e2e-tests/subscriptions-api.test.js
@@ -6,7 +6,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 
-const URL = 'http://localhost:8081/streamr-core/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const AUTH_TOKEN = 'product-api-tester-key'


### PR DESCRIPTION
- Configure the Grails embedded tomcat plugin to allow encoded slash in URI when using `grails run-app` and `grails run-war`.
- To verify that the change works, added e2e test for `GET`ting streams with slashes and dots in the stream id
- Some e2e tests communicated with the API via nginx, some directly to port 8081. Updated all e2e tests to use the nginx routing to really make them end-to-end.