### PR TITLE
BACK-76: End-to-end tests: StreamrClient API url config

### DIFF
--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const StreamrClient = require('streamr-client')
-const URL = 'http://localhost/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -3,7 +3,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const StreamrClient = require('streamr-client')
 
-const URL = 'http://localhost/api/v1/'
+const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)


### PR DESCRIPTION
The commit #00496f in streamr-docker-dev commit changed the functionality of Nginx: restUrl parameter doesn't work if it has an slash at the end of the string.