### PR TITLE
BACK-79: Remove API-key permission handling

### DIFF
--- a/grails-app/controllers/com/unifina/controller/PermissionApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/PermissionApiController.groovy
@@ -18,7 +18,7 @@ class PermissionApiController {
 			subscriptions = Boolean.parseBoolean(params.subscriptions)
 		}
 		Resource resource = new Resource(params.resourceClass, params.resourceId)
-		List<Permission> permissions = permissionService.findAllPermissions(resource, request.apiUser, request.apiKey, subscriptions)
+		List<Permission> permissions = permissionService.findAllPermissions(resource, request.apiUser, subscriptions)
 		def perms = permissions*.toMap()
 		render(perms as JSON)
 	}
@@ -26,7 +26,7 @@ class PermissionApiController {
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def getOwnPermissions() {
 		Resource resource = new Resource(params.resourceClass, params.resourceId)
-		List<Permission> permissions = permissionService.getOwnPermissions(resource, request.apiUser, request.apiKey)
+		List<Permission> permissions = permissionService.getOwnPermissions(resource, request.apiUser)
 		def perms = permissions*.toMap()
 		render(perms as JSON)
 	}
@@ -43,7 +43,7 @@ class PermissionApiController {
 		Key apiKey = request.apiKey
 		Permission newPermission
 		if (cmd.anonymous) {
-			newPermission = permissionService.saveAnonymousPermission(apiUser, apiKey, op, res)
+			newPermission = permissionService.saveAnonymousPermission(apiUser, op, res)
 		} else {
 			String subjectTemplate = grailsApplication.config.unifina.email.shareInvite.subject
 			String sharer = apiUser?.username
@@ -55,7 +55,6 @@ class PermissionApiController {
 				EmailMessage msg = new EmailMessage(sharer, recipient, subjectTemplate, res)
 				newPermission = permissionService.savePermissionAndSendShareResourceEmail(
 					apiUser,
-					apiKey,
 					op,
 					user.username,
 					msg
@@ -78,14 +77,14 @@ class PermissionApiController {
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def show(Long id) {
 		Resource resource = new Resource(params.resourceClass, params.resourceId)
-		Permission p = permissionService.findPermission(id, resource, request.apiUser, request.apiKey)
+		Permission p = permissionService.findPermission(id, resource, request.apiUser)
 		render(p.toMap() as JSON)
 	}
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def delete(Long id) {
 		Resource resource = new Resource(params.resourceClass, params.resourceId)
-		permissionService.deletePermission(id, resource, request.apiUser, request.apiKey)
+		permissionService.deletePermission(id, resource, request.apiUser)
 		render(status: 204)
 	}
 

--- a/grails-app/domain/com/unifina/domain/Permission.groovy
+++ b/grails-app/domain/com/unifina/domain/Permission.groovy
@@ -10,16 +10,15 @@ import groovy.transform.EqualsAndHashCode
  * EqualsAndHashCode are used in PermissionService to build a Set in a special case of UI Channels.
  * @see com.unifina.service.PermissionService#getPermissionsTo(Object r, Userish u)
  */
-@EqualsAndHashCode(includes="anonymous,user,key,invite,canvas,dashboard,stream,product,operation,subscription,endsAt,parent")
+@EqualsAndHashCode(includes="anonymous,user,invite,canvas,dashboard,stream,product,operation,subscription,endsAt,parent")
 @Entity
 class Permission {
 
 	/** Permission can be global, that is, let (also) anonymous users execute the operation */
 	Boolean anonymous = false
 
-	/** Permission "belongs to" either a User, Key, or (transiently) a SignupInvite. Ignored for anonymous Permissions */
+	/** Permission "belongs to" either a User or (transiently) a SignupInvite. Ignored for anonymous Permissions */
 	User user
-	Key key
 	SignupInvite invite
 
 	/**
@@ -220,7 +219,6 @@ class Permission {
 
 	static constraints = {
 		user(nullable: true)
-		key(nullable: true)
 		invite(nullable: true)
 		canvas(nullable: true)
 		dashboard(nullable: true)
@@ -256,14 +254,8 @@ class Permission {
 					user: user?.username ?: invite?.email,
 					operation: operation.id
 			]
-		} else if (key) {
-			return [
-					id: id,
-					key: key.toMap(),
-					operation: operation.id
-			]
 		} else {
-			throw new IllegalStateException("Invalid Permission! Must relate to one of: anonymous, user, invite, key")
+			throw new IllegalStateException("Invalid Permission! Must relate to one of: anonymous, user, invite")
 		}
 	}
 
@@ -277,9 +269,6 @@ class Permission {
 		}
 		if (user) {
 			map["user"] = user.id
-		}
-		if (key) {
-			map["key"] = key.id
 		}
 		if (invite) {
 			map["invite"] = invite.id

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -158,4 +158,5 @@ databaseChangeLog = {
 	include file: 'core/2020-10-01-remove-inbox-stream.groovy'
 	include file: 'core/2020-09-18-convert-API-keys-to-Ethereum-IDs.groovy'
 	include file: 'core/2020-10-12-fix-subscription-column-class.groovy'
+	include file: 'core/2020-10-23-remove-API-key-permission.groovy'
 }

--- a/grails-app/migrations/core/2020-10-23-remove-API-key-permission.groovy
+++ b/grails-app/migrations/core/2020-10-23-remove-API-key-permission.groovy
@@ -1,0 +1,12 @@
+package core
+databaseChangeLog = {
+	changeSet(author: "teogeb", id: "remove-API-key-permission-1") {
+		dropForeignKeyConstraint(baseTableName: "permission", constraintName: "FKE125C5CF8EE35041")
+	}
+	changeSet(author: "teogeb", id: "remove-API-key-permission-2") {
+		dropIndex(indexName: "FKE125C5CF8EE35041", tableName: "permission")
+	}
+	changeSet(author: "teogeb", id: "remove-API-key-permission-3") {
+		dropColumn(columnName: "key_id", tableName: "permission")
+	}
+}

--- a/grails-app/services/com/unifina/service/PermissionService.groovy
+++ b/grails-app/services/com/unifina/service/PermissionService.groovy
@@ -69,10 +69,7 @@ class PermissionService {
 		if (!check(userish, resource, op)) {
 			String name
 			Userish u = userish?.resolveToUserish()
-			if (u instanceof Key) {
-				Key k = u as Key
-				name = k.user?.username
-			} else if (u instanceof User) {
+			if (u instanceof User) {
 				User s = u as User
 				name = s.username
 			}
@@ -141,24 +138,19 @@ class PermissionService {
 		// Special case of UI channels: they inherit permissions from the associated canvas
 		if (resource instanceof Stream && resource.isUIChannel()) {
 			Set<Permission> syntheticPermissions = new HashSet<>()
-			Key key = null
 			User user = null
-			if (userish instanceof Key) {
-				key = userish as Key
-			} else if (userish instanceof User) {
+			if (userish instanceof User) {
 				user = userish as User
 			}
 			if (userish != null && isPermissionToStreamViaDashboard(userish, resource)) {
 				syntheticPermissions.add(new Permission(
 					stream: resource,
 					operation: Permission.Operation.STREAM_GET,
-					key: key,
 					user: user,
 				))
 				syntheticPermissions.add(new Permission(
 					stream: resource,
 					operation: Permission.Operation.STREAM_SUBSCRIBE,
-					key: key,
 					user: user,
 				))
 			}
@@ -171,7 +163,6 @@ class PermissionService {
 						Permission sp = new Permission(
 							stream: resource,
 							operation: op,
-							key: key,
 							user: user,
 						)
 						syntheticPermissions.add(sp)
@@ -430,7 +421,7 @@ class PermissionService {
 	List<Permission> systemRevoke(Permission permission) {
 		return performRevoke(
 			permission.anonymous,
-			permission.user ?: permission.invite ?: permission.key,
+			permission.user ?: permission.invite,
 			getResourceFromPermission(permission),
 			permission.operation)
 	}
@@ -565,28 +556,26 @@ class PermissionService {
 			return "user"
 		} else if (userish instanceof SignupInvite) {
 			return "invite"
-		} else if (userish instanceof Key) {
-			return "key"
 		} else {
 			throw new IllegalArgumentException("Unexpected Userish instance: " + userish)
 		}
 	}
 
-	Permission savePermissionAndSendShareResourceEmail(User apiUser, Key apiKey, Operation op, String targetUsername, EmailMessage msg) {
+	Permission savePermissionAndSendShareResourceEmail(User apiUser, Operation op, String targetUsername, EmailMessage msg) {
 		User userish = User.findByUsername(targetUsername)
-		Permission permission = savePermission(msg.resource, apiUser, apiKey, userish, op)
+		Permission permission = savePermission(msg.resource, apiUser, userish, op)
 		sendEmailShareResource(op, msg)
 		return permission
 	}
 
-	Permission saveAnonymousPermission(User apiUser, Key apiKey, Operation op, Resource resource) {
-		Object res = resource.load(apiUser, apiKey, true)
+	Permission saveAnonymousPermission(User apiUser, Operation op, Resource resource) {
+		Object res = resource.load(apiUser, true)
 		Permission permission = grantAnonymousAccess(apiUser, res, op)
 		return permission
 	}
 
-	private Permission savePermission(Resource resource, User apiUser, Key apiKey, Userish targetUserish, Operation op) {
-		Object res = resource.load(apiUser, apiKey, true)
+	private Permission savePermission(Resource resource, User apiUser, Userish targetUserish, Operation op) {
+		Object res = resource.load(apiUser, true)
 		Permission permission = grant(apiUser, res, targetUserish, op)
 		return permission
 	}
@@ -642,7 +631,7 @@ class PermissionService {
 			invite.sent = true
 			invite.save(failOnError: true, validate: true)
 		}
-		Permission newPermission = savePermission(msg.resource, apiUser, null, invite, op)
+		Permission newPermission = savePermission(msg.resource, apiUser, invite, op)
 		return newPermission
 	}
 
@@ -650,27 +639,27 @@ class PermissionService {
 		EthereumIntegrationKeyService ethereumIntegrationKeyService = Holders.getApplicationContext().getBean(EthereumIntegrationKeyService)
 		User user = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(username, signupMethod)
 		User userish = User.findByUsername(user.username)
-		Permission newPermission = savePermission(res, grantor, null, userish, operation)
+		Permission newPermission = savePermission(res, grantor, userish, operation)
 		return newPermission
 	}
 
 	@Transactional(readOnly = true)
-	List<Permission> getOwnPermissions(Resource resource, User apiUser, Key apiKey) {
-		Object res = resource.load(apiUser, apiKey, false)
-		List<Permission> results = getPermissionsTo(res, apiUser ?: apiKey)
+	List<Permission> getOwnPermissions(Resource resource, User apiUser) {
+		Object res = resource.load(apiUser, false)
+		List<Permission> results = getPermissionsTo(res, apiUser)
 		return results
 	}
 
 	@Transactional(readOnly = true)
-	List<Permission> findAllPermissions(Resource resource, User apiUser, Key apiKey, boolean subscriptions) {
-		Object res = resource.load(apiUser, apiKey, true)
+	List<Permission> findAllPermissions(Resource resource, User apiUser, boolean subscriptions) {
+		Object res = resource.load(apiUser, true)
 		List<Permission> permissions = getPermissionsTo(res, subscriptions, null)
 		return permissions
 	}
 
 	@Transactional(readOnly = true)
-	Permission findPermission(Long permissionId, Resource resource, User apiUser, Key apiKey) {
-		Object res = resource.load(apiUser, apiKey, true)
+	Permission findPermission(Long permissionId, Resource resource, User apiUser) {
+		Object res = resource.load(apiUser, true)
 		List<Permission> permissions = getPermissionsTo(res)
 		Permission p = permissions.find { it.id == permissionId }
 		if (!p) {
@@ -679,14 +668,14 @@ class PermissionService {
 		return p
 	}
 
-	void deletePermission(Long permissionId, Resource resource, User apiUser, Key apiKey) {
-		Object res = resource.load(apiUser, apiKey, false)
+	void deletePermission(Long permissionId, Resource resource, User apiUser) {
+		Object res = resource.load(apiUser, false)
 		List<Permission> permissions = getPermissionsTo(res)
 		Permission p = permissions.find { it.id == permissionId }
 		if (!p) {
 			throw new NotFoundException("Permission not found", resource.type(), permissionId?.toString())
 		}
-		Userish user = apiUser ?: apiKey
+		Userish user = apiUser
 		boolean canShare = check(user, res, Permission.Operation.shareOperation(res))
 		if (canShare == false && p.user == user) {
 			// user without share permission to resource can delete their own permission to resource

--- a/src/groovy/com/unifina/domain/Resource.groovy
+++ b/src/groovy/com/unifina/domain/Resource.groovy
@@ -44,7 +44,7 @@ class Resource {
 		return "Unknown"
 	}
 
-	Object load(User apiUser, Key apiKey, boolean requireShareResourcePermission) {
+	Object load(User apiUser, boolean requireShareResourcePermission) {
 		Object resource
 		if (Canvas.isAssignableFrom(clazz)) {
 			resource = Canvas.get(idToString())
@@ -63,7 +63,7 @@ class Resource {
 		}
 		Permission.Operation shareOp = Permission.Operation.shareOperation(resource)
 		PermissionService permissionService = Holders.getApplicationContext().getBean(PermissionService)
-		if (requireShareResourcePermission && !permissionService.check(apiUser ?: apiKey, resource, shareOp)) {
+		if (requireShareResourcePermission && !permissionService.check(apiUser, resource, shareOp)) {
 			throw new NotPermittedException(apiUser?.username, clazz.simpleName, idToString(), shareOp.id)
 		}
 		return resource

--- a/test/integration/com/unifina/service/PermissionServiceDeleteIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/PermissionServiceDeleteIntegrationSpec.groovy
@@ -46,7 +46,7 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		Resource res = new Resource(Canvas, resource.id)
 
 		when:
-		service.deletePermission(permission.id, res, user, null)
+		service.deletePermission(permission.id, res, user)
 
 		then:
 		Permission.get(permission.id) == null
@@ -58,7 +58,7 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		Resource res = new Resource(Canvas, resource.id)
 
 		when:
-		service.deletePermission(permission.id, res, user, null)
+		service.deletePermission(permission.id, res, user)
 
 		then:
 		def e = thrown(NotPermittedException)
@@ -71,7 +71,7 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		Resource res = new Resource(Canvas, resource.id)
 
 		when:
-		service.deletePermission(permission.id, res, user, null)
+		service.deletePermission(permission.id, res, user)
 
 		then:
 		Permission.get(permission.id) == null
@@ -84,7 +84,7 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		Resource res = new Resource(Canvas, anotherResource.id)
 
 		when:
-		service.deletePermission(anotherPermission.id, res, user, null)
+		service.deletePermission(anotherPermission.id, res, user)
 
 		then:
 		def e = thrown(NotPermittedException)
@@ -95,12 +95,11 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		setup:
 		Resource res = new Resource(Canvas, resource.id)
 		User apiUser = user
-		Key apiKey = null
 		Permission share = service.systemGrant(apiUser, resource, Permission.Operation.CANVAS_SHARE)
 		Permission share2 = service.systemGrant(apiUser, resource, Permission.Operation.CANVAS_SHARE)
 		Permission p = service.systemGrant(apiUser, resource, Permission.Operation.CANVAS_INTERACT)
 		when:
-		service.deletePermission(p.id, res, apiUser, apiKey)
+		service.deletePermission(p.id, res, apiUser)
 		then:
 		Permission.get(p.id) == null
 	}
@@ -109,11 +108,10 @@ class PermissionServiceDeleteIntegrationSpec extends IntegrationSpec {
 		setup:
 		Resource res = new Resource(Canvas, resource.id)
 		User apiUser = user
-		Key apiKey = null
 		Permission share = service.systemGrant(apiUser, resource, Permission.Operation.CANVAS_SHARE)
 		Permission p = service.systemGrant(apiUser, resource, Permission.Operation.CANVAS_INTERACT)
 		when:
-		service.deletePermission(null, res, apiUser, apiKey)
+		service.deletePermission(null, res, apiUser)
 		then:
 		def e = thrown(NotFoundException)
 		e.type == "Canvas"

--- a/test/unit/com/unifina/controller/PermissionApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/PermissionApiControllerSpec.groovy
@@ -92,7 +92,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		response.json[0].id == canvasPermission.id
 		response.json[0].user == "me@me.net"
 		response.json[0].operation == "canvas_share"
-		1 * permissionService.findAllPermissions(resource, request.apiUser, null, true) >> [canvasPermission, *ownerPermissions]
+		1 * permissionService.findAllPermissions(resource, request.apiUser, true) >> [canvasPermission, *ownerPermissions]
 		0 * permissionService._
     }
 
@@ -112,7 +112,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		response.json[0].id == streamPermission.id
 		response.json[0].user == "me@me.net"
 		response.json[0].operation == "stream_share"
-		1 * permissionService.findAllPermissions(resource, request.apiUser, null, true) >> [streamPermission, *ownerPermissions]
+		1 * permissionService.findAllPermissions(resource, request.apiUser, true) >> [streamPermission, *ownerPermissions]
 		0 * permissionService._
 	}
 
@@ -133,7 +133,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		response.json[0].id == streamPermission.id
 		response.json[0].user == "me@me.net"
 		response.json[0].operation == "stream_share"
-		1 * permissionService.findAllPermissions(resource, request.apiUser, null,false) >> [streamPermission, *ownerPermissions]
+		1 * permissionService.findAllPermissions(resource, request.apiUser, false) >> [streamPermission, *ownerPermissions]
 		0 * permissionService._
 	}
 
@@ -150,7 +150,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		response.status == 200
 		response.json.user == "me@me.net"
 		response.json.operation == "canvas_share"
-		1 * permissionService.findPermission(canvasPermission.id, resource, request.apiUser, null) >> canvasPermission
+		1 * permissionService.findPermission(canvasPermission.id, resource, request.apiUser) >> canvasPermission
 		0 * permissionService._
 	}
 
@@ -168,7 +168,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		response.json.id == 2
 		response.json.user == "me@me.net"
 		response.json.operation == "stream_share"
-		1 * permissionService.findPermission(streamPermission.id, resource, request.apiUser, null) >> streamPermission
+		1 * permissionService.findPermission(streamPermission.id, resource, request.apiUser) >> streamPermission
 		0 * permissionService._
 	}
 
@@ -204,7 +204,6 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		then:
 		1 * controller.permissionService.savePermissionAndSendShareResourceEmail(
 			_,
-			_,
 			Permission.Operation.CANVAS_GET,
 			_,
 			_
@@ -227,7 +226,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		authenticatedAs(me) { controller.delete() }
 		then:
 		response.status == 204
-		1 * permissionService.deletePermission(_, resource, request.apiUser, null)
+		1 * permissionService.deletePermission(_, resource, request.apiUser)
 		0 * permissionService._
 	}
 
@@ -255,7 +254,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		then:
 		response.status == 200
 		response.json*.operation == ownerPermissions*.toMap()*.operation
-		1 * permissionService.getOwnPermissions(resource, me, null) >> [*ownerPermissions]
+		1 * permissionService.getOwnPermissions(resource, me) >> [*ownerPermissions]
 		0 * permissionService._
 	}
 
@@ -271,7 +270,7 @@ class PermissionApiControllerSpec extends ControllerSpecification {
 		then:
 		response.status == 200
 		response.json == [[id: 1, operation: "canvas_share", user: "me@me.net"]]
-		1 * permissionService.getOwnPermissions(resource, me, null) >> [canvasPermission]
+		1 * permissionService.getOwnPermissions(resource, me) >> [canvasPermission]
 		0 * permissionService._
 	}
 

--- a/test/unit/com/unifina/controller/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/StreamApiControllerSpec.groovy
@@ -174,21 +174,6 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		ex.getUser() == me.getUsername()
 	}
 
-	void "shows a Stream of logged in Key"() {
-		Key key = new Key(name: "anonymous key")
-		key.id = "anonymousKeyKey"
-		key.save(failOnError: true)
-		permissionService.systemGrant(key, streamOne, Permission.Operation.STREAM_GET)
-
-		when:
-		params.id = streamOne.id
-		authenticatedAs(me) { controller.show() }
-
-		then:
-		response.status == 200
-		response.json.name == "stream"
-	}
-
 	void "does not show Stream if key not permitted"() {
 		Key key = new Key(name: "anonymous key")
 		key.id = "anonymousKeyKey"


### PR DESCRIPTION
API keys are deprecated and all keys have been migrated to Ethereum integration keys. There are no permissions that belong to keys anymore.

Remove the functionality that handles key permissions and remove "key_id" column from permission table.