### PR TITLE
Bug: storageDays ignored by back-end on POST /api/v1/streams

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4626,29 +4626,59 @@
 		  }
 		}
 	  },
-	"StreamCreateRequest": {
-		"type": "object",
-		"properties": {
-			"id": {
-				"type": "string",
-				"description": "ID of this stream.",
-				"example": "sandbox/foo/bar"
-			},
-			"name": {
-				"type": "string",
-				"description": "Name of this stream.",
-				"example": "My stream"
-			},
-			"description": {
-				"type": "string",
-				"description": "Description of this stream.",
-				"example": "My stream description"
-			},
-			"config": {
-				"$ref": "#/definitions/StreamConfig"
-			}
-		}
-	},
+    "StreamCreateRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of this stream.",
+          "example": "sandbox/foo/bar"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of this stream.",
+          "example": "My stream"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of this stream.",
+          "example": "My stream description"
+        },
+        "config": {
+          "$ref": "#/definitions/StreamConfig"
+        },
+        "partitions": {
+          "type": "integer",
+          "description": "Number of partitions in this stream. Defaults to 1 (unpartitioned).",
+          "example": 1
+        },
+        "requireSignedData": {
+          "type": "boolean",
+          "description": "If true, all messages in this stream must be cryptographically signed. Client's should not accept unsigned messages.",
+          "example": false
+        },
+        "requireEncryptedData": {
+          "type": "boolean",
+          "description": "If true, all data in this stream must be encrypted.",
+          "example": false
+        },
+        "autoConfigure": {
+          "type": "boolean",
+          "description": "If true, always try to automatically configure field names and types.",
+          "example": true
+        },
+        "storageDays": {
+          "type": "integer",
+          "description": "Historical data storage period (days)",
+          "example": 365
+        },
+        "inactivityThresholdHours": {
+          "type": "integer",
+          "description": "Inactivity period for a stream in hours.",
+          "example": 48
+        }
+      }
+    },
     "StreamUpdateRequest": {
       "type": "object",
       "properties": {
@@ -4664,6 +4694,36 @@
         },
         "config": {
           "$ref": "#/definitions/StreamConfig"
+        },
+        "partitions": {
+          "type": "integer",
+          "description": "Number of partitions in this stream. Defaults to 1 (unpartitioned).",
+          "example": 1
+        },
+        "requireSignedData": {
+          "type": "boolean",
+          "description": "If true, all messages in this stream must be cryptographically signed. Client's should not accept unsigned messages.",
+          "example": false
+        },
+        "requireEncryptedData": {
+          "type": "boolean",
+          "description": "If true, all data in this stream must be encrypted.",
+          "example": false
+        },
+        "autoConfigure": {
+          "type": "boolean",
+          "description": "If true, always try to automatically configure field names and types.",
+          "example": true
+        },
+        "storageDays": {
+          "type": "integer",
+          "description": "Historical data storage period (days)",
+          "example": 365
+        },
+        "inactivityThresholdHours": {
+          "type": "integer",
+          "description": "Inactivity period for a stream in hours.",
+          "example": 48
         }
       }
     },

--- a/grails-app/services/com/unifina/service/StreamService.groovy
+++ b/grails-app/services/com/unifina/service/StreamService.groovy
@@ -30,6 +30,9 @@ class CreateStreamCommand {
 	Boolean uiChannel = false
 	Boolean requireSignedData = false
 	Boolean requireEncryptedData = false
+	Boolean autoConfigure = true
+	Integer storageDays = Stream.DEFAULT_STORAGE_DAYS
+	Integer inactivityThresholdHours = Stream.DEFAULT_INACTIVITY_THRESHOLD_HOURS
 }
 
 class StreamService {
@@ -61,6 +64,9 @@ class StreamService {
 			uiChannel: cmd.uiChannel,
 			requireSignedData: cmd.requireSignedData,
 			requireEncryptedData: cmd.requireEncryptedData,
+			autoConfigure: cmd.autoConfigure,
+			storageDays: cmd.storageDays,
+			inactivityThresholdHours: cmd.inactivityThresholdHours,
 			uiChannelPath: uiChannelPath,
 			uiChannelCanvas: uiChannelCanvas
 		)

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -36,6 +36,7 @@ describe('Streams API', () => {
 				assert.deepEqual(json.config, properties.config)
 				assert.equal(json.partitions, properties.partitions)
 				assert.equal(json.uiChannel, properties.uiChannel)
+          assert.equal(json.storageDays, properties.storageDays)
 				if (expectedId !== undefined) {
 					assert.equal(json.id, expectedId)
 				}
@@ -52,6 +53,7 @@ describe('Streams API', () => {
 				   ]
 				},
 				partitions: 12,
+          storageDays: 66,
 				uiChannel: false
 			}
 			const createResponse = await Streamr.api.v1.streams

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -36,7 +36,9 @@ describe('Streams API', () => {
 				assert.deepEqual(json.config, properties.config)
 				assert.equal(json.partitions, properties.partitions)
 				assert.equal(json.uiChannel, properties.uiChannel)
-          assert.equal(json.storageDays, properties.storageDays)
+				assert.equal(json.autoConfigure, properties.autoConfigure)
+				assert.equal(json.storageDays, properties.storageDays)
+				assert.equal(json.inactivityThresholdHours, properties.inactivityThresholdHours)
 				if (expectedId !== undefined) {
 					assert.equal(json.id, expectedId)
 				}
@@ -53,7 +55,9 @@ describe('Streams API', () => {
 				   ]
 				},
 				partitions: 12,
-          storageDays: 66,
+				autoConfigure: false,
+				storageDays: 66,
+				inactivityThresholdHours: 4,
 				uiChannel: false
 			}
 			const createResponse = await Streamr.api.v1.streams


### PR DESCRIPTION
Should be able to set autoConfigure, storageDays and inactivityThresholdHours when creating a stream by POST /api/v1/streams