### PR TITLE
BACK-77: Convert e2e-tests to use private key authentication

### DIFF
--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -22,32 +22,32 @@ const pollCondition = async (condition, timeout = TIMEOUT, interval = 100) => {
     return result
 }
 
-const freshUser = StreamrClient.generateEthereumAccount()
-
-async function createStreamrClient() {
+async function createStreamrClient(user) {
     const client = new StreamrClient({
         url: WS_URL,
         restUrl: REST_URL,
         auth: {
-            privateKey: freshUser.privateKey,
+            privateKey: user.privateKey,
         },
     })
     await client.connect()
     return client
 }
 
+const freshUser = StreamrClient.generateEthereumAccount()
+
 // The tests should be run sequentially
 describe('Canvas API', function() {
 
     let streamrClient
     let stream
-    let canvas
+	let canvas
 
     // sets timeout on before and all test cases in this suite
     this.timeout(TIMEOUT)
 
     before(async () => {
-        streamrClient = await createStreamrClient()
+        streamrClient = await createStreamrClient(freshUser)
 
         // Create a unique stream for this test
         stream = await streamrClient.createStream({
@@ -336,7 +336,7 @@ function TestClockTable() {
     this.timeout(80000)
 
     before(async () => {
-        streamrClient = await createStreamrClient()
+        streamrClient = await createStreamrClient(freshUser)
     })
 
     before(async () => {

--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -28,10 +28,9 @@ const pollCondition = async (condition, timeout = TIMEOUT, interval = 100) => {
     return result
 }
 
-async function CreateClientUser() {
-    // Generate a new user to isolate the test and not require any pre-existing resources
-    const freshUser = StreamrClient.generateEthereumAccount()
+const freshUser = StreamrClient.generateEthereumAccount()
 
+async function createStreamrClient() {
     const client = new StreamrClient({
         url: WS_URL,
         restUrl: REST_URL,
@@ -40,16 +39,13 @@ async function CreateClientUser() {
         },
     })
     await client.connect()
-
-    const sessionToken = await client.session.getSessionToken()
-    return { client, sessionToken }
+    return client
 }
 
 // The tests should be run sequentially
 describe('Canvas API', function() {
 
     let streamrClient
-    let sessionToken
     let stream
     let canvas
 
@@ -57,9 +53,7 @@ describe('Canvas API', function() {
     this.timeout(TIMEOUT)
 
     before(async () => {
-        const created = await CreateClientUser()
-        streamrClient = created.client
-        sessionToken = created.sessionToken
+        streamrClient = await createStreamrClient()
 
         // Create a unique stream for this test
         stream = await streamrClient.createStream({
@@ -87,7 +81,7 @@ describe('Canvas API', function() {
 
         const canvasResponse = await Streamr.api.v1.canvases
             .create(canvasTemplate)
-            .withSessionToken(sessionToken)
+            .withAuthenticatedUser(freshUser)
             .call()
 
         canvas = await canvasResponse.json()
@@ -105,7 +99,7 @@ describe('Canvas API', function() {
         it('starts the canvas', async () => {
             const response = await Streamr.api.v1.canvases
                 .start(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
 
             const json = await response.json()
@@ -162,7 +156,7 @@ describe('Canvas API', function() {
                 await pollCondition(async () => {
                     response = await Streamr.api.v1.canvases
                         .getRuntimeState(canvas.id, 'modules/0')
-                        .withSessionToken(sessionToken)
+                        .withAuthenticatedUser(freshUser)
                         .call()
 
                     json = await response.json()
@@ -182,7 +176,7 @@ describe('Canvas API', function() {
                 await pollCondition(async () => {
                     response = await Streamr.api.v1.canvases
                         .getRuntimeState(canvas.id, 'modules/1')
-                        .withSessionToken(sessionToken)
+                        .withAuthenticatedUser(freshUser)
                         .call()
 
                     json = await response.json()
@@ -205,7 +199,7 @@ describe('Canvas API', function() {
         it('stops the canvas', async () => {
             const response = await Streamr.api.v1.canvases
                 .stop(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
 
             const json = await response.json()
@@ -225,12 +219,12 @@ describe('Canvas API', function() {
             const p = new Promise((resolve, reject) => done = (err) => err ? reject(err) : resolve())
             const r1 = await Streamr.api.v1.canvases
                 .start(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
             assert.equal(r1.status, 200)
             const r2 = await Streamr.api.v1.canvases
                 .stop(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
             assert.equal(r2.status, 200)
 
@@ -262,7 +256,7 @@ describe('Canvas API', function() {
                 // restart for second time
                 const r3 = await Streamr.api.v1.canvases
                     .start(canvas.id)
-                    .withSessionToken(sessionToken)
+                    .withAuthenticatedUser(freshUser)
                     .call()
                 assert.equal(r3.status, 200)
 
@@ -285,7 +279,7 @@ describe('Canvas API', function() {
         after(async () => {
             await Streamr.api.v1.canvases
                 .stop(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
         })
 
@@ -341,7 +335,6 @@ describe('Canvas API', function() {
 
 function TestClockTable() {
     let streamrClient
-    let sessionToken
     let canvas
     let subscription
 
@@ -349,9 +342,7 @@ function TestClockTable() {
     this.timeout(80000)
 
     before(async () => {
-        const created = await CreateClientUser()
-        streamrClient = created.client
-        sessionToken = created.sessionToken
+        streamrClient = await createStreamrClient()
     })
 
     before(async () => {
@@ -360,7 +351,7 @@ function TestClockTable() {
 
         const canvasResponse = await Streamr.api.v1.canvases
             .create(canvasTemplate)
-            .withSessionToken(sessionToken)
+            .withAuthenticatedUser(freshUser)
             .call()
 
         canvas = await canvasResponse.json()
@@ -391,7 +382,7 @@ function TestClockTable() {
 
         Streamr.api.v1.canvases
             .start(canvas.id)
-            .withSessionToken(sessionToken)
+            .withAuthenticatedUser(freshUser)
             .call()
             .then((r1) => {
                 assert.equal(r1.status, 200)
@@ -399,10 +390,10 @@ function TestClockTable() {
     })
 
     after(async () => {
-        if (canvas && sessionToken) {
+        if (canvas) {
             await Streamr.api.v1.canvases
                 .stop(canvas.id)
-                .withSessionToken(sessionToken)
+                .withAuthenticatedUser(freshUser)
                 .call()
                 .catch(console.warn) // ignore
         }

--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -7,11 +7,8 @@ const Streamr = require('./streamr-api-clients')
 
 const REST_URL = 'http://localhost/api/v1'
 const WS_URL = 'ws://localhost/api/v1/ws'
-
 const TIMEOUT = 130 * 1000
-
 const NUM_MESSAGES = 50
-
 const WAIT_TIME = 15000
 
 const pollCondition = async (condition, timeout = TIMEOUT, interval = 100) => {

--- a/rest-e2e-tests/canvas-api.stress-test.js
+++ b/rest-e2e-tests/canvas-api.stress-test.js
@@ -3,13 +3,10 @@ const StreamrClient = require('streamr-client')
 const assert = require('chai').assert
 const fs = require('fs')
 const Emitter = require('events')
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 
 const REST_URL = 'http://localhost/api/v1'
 const WS_URL = 'ws://localhost/api/v1/ws'
-const LOGGING_ENABLED = false
-
-const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
 
 const TIMEOUT = 130 * 1000
 

--- a/rest-e2e-tests/categories-api.test.js
+++ b/rest-e2e-tests/categories-api.test.js
@@ -1,12 +1,7 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
 
 describe('Categories API', () => {

--- a/rest-e2e-tests/cors.test.js
+++ b/rest-e2e-tests/cors.test.js
@@ -2,7 +2,6 @@ const assert = require('chai').assert
 const fetch = require('node-fetch')
 
 const URL = 'http://localhost/api/v1'
-
 const TIMEOUT = 5000
 
 describe('CORS Requests', () => {

--- a/rest-e2e-tests/dataunions-api.test.js
+++ b/rest-e2e-tests/dataunions-api.test.js
@@ -1,8 +1,5 @@
 const assert = require('chai').assert
 const Streamr = require('./streamr-api-clients')
-const SchemaValidator = require('./schema-validator')
-
-const schemaValidator = new SchemaValidator()
 
 describe('DataUnions API', () => {
     describe('GET /api/v1/dataunions', () => {

--- a/rest-e2e-tests/dataunions-api.test.js
+++ b/rest-e2e-tests/dataunions-api.test.js
@@ -1,12 +1,7 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
 
 describe('DataUnions API', () => {

--- a/rest-e2e-tests/login-api.test.js
+++ b/rest-e2e-tests/login-api.test.js
@@ -1,11 +1,8 @@
 const assert = require('chai').assert
 const fetch = require('node-fetch')
-const StreamrClient = require('streamr-client')
 
 const URL = 'http://localhost/api/v1'
-
 const API_KEY = 'tester1-api-key'
-
 const TIMEOUT = 5000
 
 describe('Login API', () => {

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -1,10 +1,6 @@
 const assert = require('chai').assert
 const StreamrClient = require('streamr-client')
-const initStreamrApi = require('./streamr-api-clients')
-
-const REST_URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
+const Streamr = require('./streamr-api-clients')
 
 const testUser = StreamrClient.generateEthereumAccount()
 

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -1,7 +1,6 @@
 const assert = require('chai').assert
 const StreamrClient = require('streamr-client')
 const initStreamrApi = require('./streamr-api-clients')
-const newSessionToken = require('./test-utilities.js').newSessionToken
 
 const REST_URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
@@ -24,15 +23,14 @@ describe('REST API', function() {
             await assertContentLengthIsZero(response)
         })
         it('with auth token responds with 404', async () => {
-            const response = await Streamr.api.v1.not_found.withApiKey(API_KEY).notFound().call()
+            const response = await Streamr.api.v1.not_found.notFound().withApiKey(API_KEY).call()
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)
         })
         it('with session token responds with 404', async () => {
 			// Generate a new user to isolate the test and not require any pre-existing resources
 			const freshUser = StreamrClient.generateEthereumAccount()
-            const sessionToken = await newSessionToken(freshUser.privateKey)
-            const response = await Streamr.api.v1.not_found.withSessionToken(sessionToken).notFound().call()
+            const response = await Streamr.api.v1.not_found.notFound().withAuthenticatedUser(freshUser).call()
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)
         })

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -31,7 +31,7 @@ describe('REST API', function() {
         it('with session token responds with 404', async () => {
 			// Generate a new user to isolate the test and not require any pre-existing resources
 			const freshUser = StreamrClient.generateEthereumAccount()
-            const sessionToken = await newSessionToken(REST_URL, freshUser.privateKey)
+            const sessionToken = await newSessionToken(freshUser.privateKey)
             const response = await Streamr.api.v1.not_found.withSessionToken(sessionToken).notFound().call()
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -5,7 +5,8 @@ const initStreamrApi = require('./streamr-api-clients')
 const REST_URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 const Streamr = initStreamrApi(REST_URL, LOGGING_ENABLED)
-const API_KEY = 'product-api-tester-key'
+
+const testUser = StreamrClient.generateEthereumAccount()
 
 describe('REST API', function() {
     describe('GET /api/v1/page-not-found', function() {
@@ -22,14 +23,16 @@ describe('REST API', function() {
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)
         })
-        it('with auth token responds with 404', async () => {
-            const response = await Streamr.api.v1.not_found.notFound().withApiKey(API_KEY).call()
+        it('with session token responds with 404', async () => {
+            const response = await Streamr.api.v1.not_found.notFound()
+                .withAuthenticatedUser(testUser)
+                .call()
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)
         })
         it('with session token responds with 404', async () => {
-			// Generate a new user to isolate the test and not require any pre-existing resources
-			const freshUser = StreamrClient.generateEthereumAccount()
+            // Generate a new user to isolate the test and not require any pre-existing resources
+            const freshUser = StreamrClient.generateEthereumAccount()
             const response = await Streamr.api.v1.not_found.notFound().withAuthenticatedUser(freshUser).call()
             assert.equal(response.status, 404)
             await assertContentLengthIsZero(response)

--- a/rest-e2e-tests/notfound-api.test.js
+++ b/rest-e2e-tests/notfound-api.test.js
@@ -2,9 +2,10 @@ const assert = require('chai').assert
 const StreamrClient = require('streamr-client')
 const Streamr = require('./streamr-api-clients')
 
-const testUser = StreamrClient.generateEthereumAccount()
-
 describe('REST API', function() {
+
+    const testUser = StreamrClient.generateEthereumAccount()
+
     describe('GET /api/v1/page-not-found', function() {
         const assertContentLengthIsZero = async function (response) {
             const body = await response.text()

--- a/rest-e2e-tests/package-lock.json
+++ b/rest-e2e-tests/package-lock.json
@@ -192,19 +192,6 @@
         }
       }
     },
-    "@ethersproject/address": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
-      "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/rlp": "^5.0.3",
-        "bn.js": "^4.4.0"
-      }
-    },
     "@ethersproject/base64": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.4.tgz",
@@ -222,30 +209,12 @@
         "@ethersproject/properties": "^5.0.3"
       }
     },
-    "@ethersproject/bignumber": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
-      "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "bn.js": "^4.4.0"
-      }
-    },
     "@ethersproject/bytes": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
       "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
-      }
-    },
-    "@ethersproject/constants": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
-      "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.0.6"
       }
     },
     "@ethersproject/contracts": {
@@ -295,17 +264,6 @@
             "@ethersproject/bignumber": "^5.0.7"
           }
         }
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.3.tgz",
-      "integrity": "sha512-KSnJyL0G9lxbOK0UPrUcaYTc/RidrX8c+kn7xnEpTmSGxqlndw4BzvQcRgYt31bOIwuFtwlWvOo6AN2tJgdQtA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/strings": "^5.0.3"
       }
     },
     "@ethersproject/hdnode": {
@@ -727,32 +685,6 @@
         }
       }
     },
-    "@ethersproject/strings": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
-      "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5"
-      }
-    },
-    "@ethersproject/transactions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.4.tgz",
-      "integrity": "sha512-QvS5CzxmL46D9Y3OlddurYgEIi5mb0eAgrKm5pM074Uz/1qxCYr+Ah12I4hpaciZtCq4Fe12YWZqUFb1vGcH6Q==",
-      "requires": {
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4"
-      }
-    },
     "@ethersproject/units": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.6.tgz",
@@ -1030,19 +962,6 @@
         "tslib": "^2.0.0"
       }
     },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
-    },
     "@types/asn1js": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.2.tgz",
@@ -1051,53 +970,15 @@
         "@types/pvutils": "*"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
-    "@types/node": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.0.tgz",
-      "integrity": "sha512-SOIyrdADB4cq6eY1F+9iU48iIomFAPltu11LCvA9PKcyEwHadjCFzNVPotAR+oEJA0bCP4Xvvgy+vwu1ZjVh8g=="
-    },
-    "@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/pvutils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
       "integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
-    },
-    "@types/secp256k1": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      }
     },
     "aes-js": {
       "version": "3.0.0",
@@ -1151,11 +1032,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
     "array-uniq": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
@@ -1172,24 +1048,6 @@
         "is-string": "^1.0.4"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "asn1js": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
@@ -1198,20 +1056,10 @@
         "pvutils": "^1.0.17"
       }
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-wait-until": {
       "version": "1.2.6",
@@ -1223,124 +1071,30 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-      "requires": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1369,81 +1123,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
     },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
-      }
-    },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -1453,74 +1132,10 @@
         "ieee754": "^1.1.4"
       }
     },
-    "buffer-to-arraybuffer": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
-    },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "bufferutil": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
-      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
-      "requires": {
-        "node-gyp-build": "~3.7.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
-        }
-      }
-    },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-        }
-      }
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -1564,48 +1179,6 @@
         "readdirp": "~3.4.0"
       }
     },
-    "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-    },
-    "cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "dependencies": {
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "class-is": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1641,14 +1214,6 @@
         }
       }
     },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1680,51 +1245,6 @@
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
       "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
     },
-    "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
-    "content-hash": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
-      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
-      "requires": {
-        "cids": "^0.7.1",
-        "multicodec": "^0.5.5",
-        "multihashes": "^0.4.15"
-      }
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -1734,89 +1254,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
-      }
-    },
-    "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
-      }
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "debug": {
       "version": "4.1.1",
@@ -1831,19 +1268,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -1851,11 +1275,6 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
-    },
-    "defer-to-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1870,73 +1289,10 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "des.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
-    "diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -1956,19 +1312,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "es-abstract": {
       "version": "1.17.6",
@@ -2017,40 +1360,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2060,137 +1369,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eth-ens-namehash": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
-      "requires": {
-        "idna-uts46-hx": "^2.3.1",
-        "js-sha3": "^0.5.7"
-      }
-    },
-    "eth-lib": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
-      "requires": {
-        "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
-        "nano-json-stream-parser": "^0.1.2",
-        "servify": "^0.1.12",
-        "ws": "^3.0.0",
-        "xhr-request-promise": "^0.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
-      }
-    },
-    "ethereum-bloom-filters": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
-      "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
-      "requires": {
-        "js-sha3": "^0.8.0"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-        }
-      }
-    },
-    "ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "requires": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "ethereumjs-common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
-    },
-    "ethereumjs-tx": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "requires": {
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "ethereumjs-util": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.5.tgz",
-      "integrity": "sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==",
-      "requires": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
-        }
-      }
     },
     "ethers": {
       "version": "5.0.19",
@@ -2367,131 +1545,10 @@
         }
       }
     },
-    "ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-      "requires": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-        }
-      }
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -2503,46 +1560,12 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
-      }
-    },
-    "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "find-up": {
@@ -2562,11 +1585,6 @@
         "is-buffer": "~2.0.3"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
     "form-data": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -2575,34 +1593,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "requires": {
-        "minipass": "^2.6.0"
       }
     },
     "fs.realpath": {
@@ -2631,22 +1621,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
-    "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -2668,56 +1642,10 @@
         "is-glob": "^4.0.1"
       }
     },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      }
-    },
-    "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -2732,32 +1660,10 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "^1.4.1"
-      }
-    },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "hash.js": {
       "version": "1.1.7",
@@ -2797,68 +1703,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
-      }
-    },
-    "http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "idna-uts46-hx": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        }
-      }
-    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -2877,11 +1721,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -2921,11 +1760,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
-    "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2933,11 +1767,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-map": {
       "version": "2.0.1",
@@ -2948,11 +1777,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -2967,20 +1791,10 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
-    },
     "is-set": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
       "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.5",
@@ -2995,11 +1809,6 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -3009,20 +1818,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
-      }
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -3052,107 +1847,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
-    },
-    "keythereum": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-1.0.4.tgz",
-      "integrity": "sha512-c3gWM0nQ6x5TKAzTOA1yIqn73S8sP9+lR7mc7QS6t509g7C0/CukykxGA6+B+aXI6BIrlSwVh5muPv/I1lD9LA==",
-      "requires": {
-        "crypto-browserify": "3.12.0",
-        "keccak": "1.4.0",
-        "scrypt": "6.0.3",
-        "secp256k1": "3.5.0",
-        "sjcl": "1.0.6",
-        "uuid": "3.0.0"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "secp256k1": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-          "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "bip66": "^1.1.3",
-            "bn.js": "^4.11.3",
-            "create-hash": "^1.1.2",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.2.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        }
-      }
-    },
-    "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
     },
     "locate-path": {
       "version": "6.0.0",
@@ -3180,50 +1878,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      }
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
@@ -3235,19 +1889,6 @@
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
         "mime-db": "1.43.0"
-      }
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -3268,40 +1909,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "requires": {
-        "minipass": "^2.9.0"
-      }
-    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-    },
-    "mkdirp-promise": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-      "requires": {
-        "mkdirp": "*"
-      }
     },
     "mocha": {
       "version": "8.1.3",
@@ -3335,73 +1946,10 @@
         "yargs-unparser": "1.6.1"
       }
     },
-    "mock-fs": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
-      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-      "requires": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      }
-    },
-    "multicodec": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "requires": {
-        "varint": "^5.0.0"
-      }
-    },
-    "multihashes": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
-      }
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
-    "nano-json-stream-parser": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -3442,37 +1990,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
-    "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
-    },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -3494,22 +2011,6 @@
         "object-keys": "^1.0.11"
       }
     },
-    "oboe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
-      "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
-      "requires": {
-        "http-https": "^1.0.0"
-      }
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3517,16 +2018,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "3.0.2",
@@ -3544,41 +2035,10 @@
         "p-limit": "^3.0.2"
       }
     },
-    "p-timeout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
-    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
-    "parse-asn1": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
-      "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
-    "parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -3590,47 +2050,15 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
-    "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
-    },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-    },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "promise-memoize": {
       "version": "1.2.1",
@@ -3647,42 +2075,6 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "iterate-value": "^1.0.0"
-      }
-    },
-    "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-      "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.1"
-      }
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -3708,30 +2100,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "requires": {
-        "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
     },
@@ -3741,22 +2114,6 @@
       "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
       "requires": {
         "array-uniq": "1.0.2"
-      }
-    },
-    "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-      "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
       }
     },
     "readdirp": {
@@ -3780,55 +2137,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3839,48 +2147,10 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
-    "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-      "requires": {
-        "bn.js": "^4.11.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "requires": {
-        "nan": "^2.0.8"
-      }
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -3897,48 +2167,6 @@
         "node-gyp-build": "^4.2.0"
       }
     },
-    "send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
-        "mime": "1.6.0",
-        "ms": "2.1.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
     "serialize-javascript": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -3947,52 +2175,10 @@
         "randombytes": "^2.1.0"
       }
     },
-    "serve-static": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-      "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.1"
-      }
-    },
-    "servify": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
-      "requires": {
-        "body-parser": "^1.16.0",
-        "cors": "^2.8.1",
-        "express": "^4.14.0",
-        "request": "^2.79.0",
-        "xhr": "^2.3.3"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "sha3": {
       "version": "2.1.3",
@@ -4002,30 +2188,10 @@
         "buffer": "5.6.0"
       }
     },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "simple-lru-cache": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
       "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
-    },
-    "sjcl": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.6.tgz",
-      "integrity": "sha1-ZBVGKmPMDUIVxJuuydP6DBtTUg8="
     },
     "sleep-promise": {
       "version": "8.0.1",
@@ -4036,27 +2202,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamr-client": {
       "version": "4.1.3",
@@ -4115,11 +2260,6 @@
         }
       }
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4155,14 +2295,6 @@
         "ansi-regex": "^3.0.0"
       }
     },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -4176,104 +2308,6 @@
         "has-flag": "^4.0.0"
       }
     },
-    "swarm-js": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
-      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "buffer": "^5.0.5",
-        "eth-lib": "^0.1.26",
-        "fs-extra": "^4.0.2",
-        "got": "^7.1.0",
-        "mime-types": "^2.1.16",
-        "mkdirp-promise": "^5.0.1",
-        "mock-fs": "^4.1.0",
-        "setimmediate": "^1.0.5",
-        "tar": "^4.0.2",
-        "xhr-request": "^1.0.1"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        }
-      }
-    },
-    "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
-      }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4282,84 +2316,15 @@
         "is-number": "^7.0.0"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tslib": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
       "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-    },
-    "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      }
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uri-js": {
       "version": "4.4.0",
@@ -4367,435 +2332,6 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "requires": {
-        "prepend-http": "^2.0.0"
-      }
-    },
-    "url-set-query": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-    },
-    "utf-8-validate": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
-      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
-      "requires": {
-        "node-gyp-build": "~3.7.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
-        }
-      }
-    },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-    },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
-    },
-    "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "web3": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
-      "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
-      "requires": {
-        "web3-bzz": "1.2.11",
-        "web3-core": "1.2.11",
-        "web3-eth": "1.2.11",
-        "web3-eth-personal": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-shh": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-bzz": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
-      "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
-      "requires": {
-        "@types/node": "^12.12.6",
-        "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.9.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.12.57",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.57.tgz",
-          "integrity": "sha512-Dg4fab0IP6ZtdJOkwTaMaOJA3PWw7bR6cUYh+nxkYe4+ZogiLBKhaEr9sHqVkCtREVLw92g3Fl1bt8++dHKavw=="
-        }
-      }
-    },
-    "web3-core": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
-      "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
-      "requires": {
-        "@types/bn.js": "^4.11.5",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-requestmanager": "1.2.11",
-        "web3-utils": "1.2.11"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.12.57",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.57.tgz",
-          "integrity": "sha512-Dg4fab0IP6ZtdJOkwTaMaOJA3PWw7bR6cUYh+nxkYe4+ZogiLBKhaEr9sHqVkCtREVLw92g3Fl1bt8++dHKavw=="
-        }
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
-      "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
-      "requires": {
-        "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-core-method": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
-      "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
-      "requires": {
-        "@ethersproject/transactions": "^5.0.0-beta.135",
-        "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
-      "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
-      "requires": {
-        "eventemitter3": "4.0.4"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
-      "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
-      "requires": {
-        "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-providers-http": "1.2.11",
-        "web3-providers-ipc": "1.2.11",
-        "web3-providers-ws": "1.2.11"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
-      "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
-      "requires": {
-        "eventemitter3": "4.0.4",
-        "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-eth": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
-      "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
-      "requires": {
-        "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-accounts": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-eth-ens": "1.2.11",
-        "web3-eth-iban": "1.2.11",
-        "web3-eth-personal": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
-      "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
-      "requires": {
-        "@ethersproject/abi": "5.0.0-beta.153",
-        "underscore": "1.9.1",
-        "web3-utils": "1.2.11"
-      },
-      "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.0.0-beta.153",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
-          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
-          "requires": {
-            "@ethersproject/address": ">=5.0.0-beta.128",
-            "@ethersproject/bignumber": ">=5.0.0-beta.130",
-            "@ethersproject/bytes": ">=5.0.0-beta.129",
-            "@ethersproject/constants": ">=5.0.0-beta.128",
-            "@ethersproject/hash": ">=5.0.0-beta.128",
-            "@ethersproject/keccak256": ">=5.0.0-beta.127",
-            "@ethersproject/logger": ">=5.0.0-beta.129",
-            "@ethersproject/properties": ">=5.0.0-beta.131",
-            "@ethersproject/strings": ">=5.0.0-beta.130"
-          }
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
-      "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
-      "requires": {
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-common": "^1.3.2",
-        "ethereumjs-tx": "^2.1.1",
-        "scrypt-js": "^3.0.1",
-        "underscore": "1.9.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
-      },
-      "dependencies": {
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
-      "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
-      "requires": {
-        "@types/bn.js": "^4.11.5",
-        "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-eth-ens": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
-      "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
-      "requires": {
-        "content-hash": "^2.5.2",
-        "eth-ens-namehash": "2.0.8",
-        "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
-      "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "web3-utils": "1.2.11"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
-      "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
-      "requires": {
-        "@types/node": "^12.12.6",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.12.57",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.57.tgz",
-          "integrity": "sha512-Dg4fab0IP6ZtdJOkwTaMaOJA3PWw7bR6cUYh+nxkYe4+ZogiLBKhaEr9sHqVkCtREVLw92g3Fl1bt8++dHKavw=="
-        }
-      }
-    },
-    "web3-net": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
-      "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
-      "requires": {
-        "web3-core": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
-      "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
-      "requires": {
-        "web3-core-helpers": "1.2.11",
-        "xhr2-cookies": "1.1.0"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
-      "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
-      "requires": {
-        "oboe": "2.1.4",
-        "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
-      "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
-      "requires": {
-        "eventemitter3": "4.0.4",
-        "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "websocket": "^1.0.31"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-shh": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
-      "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
-      "requires": {
-        "web3-core": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-net": "1.2.11"
-      }
-    },
-    "web3-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
-      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "eth-lib": "0.2.8",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "underscore": "1.9.1",
-        "utf8": "3.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        }
       }
     },
     "webcrypto-core": {
@@ -4814,34 +2350,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz",
       "integrity": "sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w=="
-    },
-    "websocket": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
-      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
-      "requires": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
     },
     "which": {
       "version": "2.0.2",
@@ -4935,66 +2443,10 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
       "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
-    "xhr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
-      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
-      "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "xhr-request": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
-      "requires": {
-        "buffer-to-arraybuffer": "^0.0.5",
-        "object-assign": "^4.1.1",
-        "query-string": "^5.0.1",
-        "simple-get": "^2.7.0",
-        "timed-out": "^4.0.1",
-        "url-set-query": "^1.0.0",
-        "xhr": "^2.0.4"
-      }
-    },
-    "xhr-request-promise": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
-      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
-      "requires": {
-        "xhr-request": "^1.1.0"
-      }
-    },
-    "xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "requires": {
-        "cookiejar": "^2.1.1"
-      }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/rest-e2e-tests/package-lock.json
+++ b/rest-e2e-tests/package-lock.json
@@ -505,9 +505,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.13.tgz",
-      "integrity": "sha512-5jsuk1FwXxmoQApGs8LSQyS43KP01pHA+6cQ1OPov5pT5Pcqe6ffh6UD1//BZ9Vjf+5e9AQqIk8w7FkGyROuCA==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.14.tgz",
+      "integrity": "sha512-K9QRRkkHWyprm3g4L8U9aPx5uyivznL4RYemkN2shCQumyGqFJ5SO+OtQrgebVm0JpGwFAUGugnhRUh49sjErw==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.4",
         "@ethersproject/abstract-signer": "^5.0.4",
@@ -784,9 +784,9 @@
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.6.tgz",
-      "integrity": "sha512-dRqx3+Degc5pvjaeeTHuk2EuTRM3b6ce/TiV0HRZhRXYnKyyjg0iYXEZo/b6p3rnV+Xhwxkc0+I/ISPkNpictA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.7.tgz",
+      "integrity": "sha512-n2GX1+2Tc0qV8dguUcLkjNugINKvZY7u/5fEsn0skW9rz5+jHTR5IKMV6jSfXA+WjQT8UCNMvkI3CNcdhaPbTQ==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.4",
         "@ethersproject/abstract-signer": "^5.0.4",
@@ -2193,9 +2193,9 @@
       }
     },
     "ethers": {
-      "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.18.tgz",
-      "integrity": "sha512-WCiKGfAt09hBS1HZspu+JTgeunFcUCVRhCXO8X+VadBJGTRlG722XXib79Vz2oyBperz90CcjkBPdNly61Ah4A==",
+      "version": "5.0.19",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.19.tgz",
+      "integrity": "sha512-0AZnUgZh98q888WAd1oI3aLeI+iyDtrupjANVtPPS7O63lVopkR/No8A1NqSkgl/rU+b2iuu2mUZor6GD4RG2w==",
       "requires": {
         "@ethersproject/abi": "5.0.7",
         "@ethersproject/abstract-provider": "5.0.5",
@@ -2215,7 +2215,7 @@
         "@ethersproject/networks": "5.0.4",
         "@ethersproject/pbkdf2": "5.0.4",
         "@ethersproject/properties": "5.0.4",
-        "@ethersproject/providers": "5.0.13",
+        "@ethersproject/providers": "5.0.14",
         "@ethersproject/random": "5.0.4",
         "@ethersproject/rlp": "5.0.4",
         "@ethersproject/sha2": "5.0.4",
@@ -2224,7 +2224,7 @@
         "@ethersproject/strings": "5.0.5",
         "@ethersproject/transactions": "5.0.6",
         "@ethersproject/units": "5.0.6",
-        "@ethersproject/wallet": "5.0.6",
+        "@ethersproject/wallet": "5.0.7",
         "@ethersproject/web": "5.0.9",
         "@ethersproject/wordlists": "5.0.5"
       },
@@ -4059,9 +4059,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamr-client": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.1.2.tgz",
-      "integrity": "sha512-hNo0bcKjwQK4WPKY/JWcOndvI7W3gk+kGqvIQ9URRJADdSyYAPuvdOHYIiuyyyrNfNwkyQ4OMGm5SSAMTBSp6w==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.1.3.tgz",
+      "integrity": "sha512-7+SjZzAN9o0i7vuXTUDf2i7btNW467FoHs082ZTnmYeWaXgF+WybRmMzyu0BBWJpYL4X4UUh32k9nmjEo2RMFA==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "debug": "^4.1.1",

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -15,15 +15,12 @@
     "ajv": "6.12.4",
     "async-wait-until": "1.2.6",
     "chai": "4.2.0",
-    "ethereumjs-util": "7.0.5",
     "form-data": "3.0.0",
-    "keythereum": "1.0.4",
     "lodash": "4.17.20",
     "mocha": "8.1.3",
     "node-fetch": "2.6.1",
     "sleep-promise": "8.0.1",
-    "streamr-client": "^4.1.3",
-    "web3": "1.2.11"
+    "streamr-client": "^4.1.3"
   },
   "devDependencies": {}
 }

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -22,7 +22,7 @@
     "mocha": "8.1.3",
     "node-fetch": "2.6.1",
     "sleep-promise": "8.0.1",
-    "streamr-client": "^4.1.2",
+    "streamr-client": "^4.1.3",
     "web3": "1.2.11"
   },
   "devDependencies": {}

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -1,6 +1,8 @@
 const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const StreamrClient = require('streamr-client')
+const getStreamrClient = require('./test-utilities.js').getStreamrClient
+
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
@@ -13,12 +15,9 @@ describe('POST /api/v1/streams/{id}/permissions', function() {
 	const me = StreamrClient.generateEthereumAccount()
 
 	before(async () => {
-		stream = await Streamr.api.v1.streams
-			.create({
-				name: `permissions-api.test.js-${Date.now()}`
-			})
-			.withAuthenticatedUser(me)
-			.execute()
+		stream = await getStreamrClient(me).createStream({
+			name: `permissions-api.test.js-${Date.now()}`
+		})
 	})
 
 	describe('race conditions', () => {

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -10,21 +10,14 @@ describe('POST /api/v1/streams/{id}/permissions', function() {
 	this.timeout(200 * 1000)
 
 	let stream
-	let mySessionToken
+	const me = StreamrClient.generateEthereumAccount()
 
 	before(async () => {
-		const me = StreamrClient.generateEthereumAccount()
-		mySessionToken = await new StreamrClient({
-			restUrl: URL,
-			auth: {
-				privateKey: me.privateKey,
-			}
-		}).session.getSessionToken()
 		stream = await Streamr.api.v1.streams
 			.create({
 				name: `permissions-api.test.js-${Date.now()}`
 			})
-			.withSessionToken(mySessionToken)
+			.withAuthenticatedUser(me)
 			.execute()
 	})
 
@@ -49,7 +42,7 @@ describe('POST /api/v1/streams/{id}/permissions', function() {
 				const responses = await Promise.all(operations.map((operation) => {
 					return Streamr.api.v1.streams
 						.grant(stream.id, StreamrClient.generateEthereumAccount().address, operation)
-						.withSessionToken(mySessionToken)
+						.withAuthenticatedUser(me)
 						.call()
 				}))
 				// All response statuses must be 200
@@ -63,7 +56,7 @@ describe('POST /api/v1/streams/{id}/permissions', function() {
 				const responses = await Promise.all(operations.map((operation) => {
 					return Streamr.api.v1.streams
 						.grant(stream.id, `race-condition-${i}@foobar.invalid`, 'stream_get')
-						.withSessionToken(mySessionToken)
+						.withAuthenticatedUser(me)
 						.call()
 				}))
 				// All response statuses must be 200

--- a/rest-e2e-tests/permissions-api.stress-test.js
+++ b/rest-e2e-tests/permissions-api.stress-test.js
@@ -1,11 +1,7 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const StreamrClient = require('streamr-client')
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
 describe('POST /api/v1/streams/{id}/permissions', function() {
 

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -1,14 +1,10 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const StreamrClient = require('streamr-client')
 const getSessionToken = require('./test-utilities.js').getSessionToken
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
 
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
 
 const API_KEY = 'tester1-api-key'

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -1,17 +1,11 @@
 const assert = require('chai').assert
 const Streamr = require('./streamr-api-clients')
-const SchemaValidator = require('./schema-validator')
 const StreamrClient = require('streamr-client')
 const getSessionToken = require('./test-utilities.js').getSessionToken
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
 
-const schemaValidator = new SchemaValidator()
-
-const API_KEY = 'tester1-api-key'
-
 describe('Permissions API', () => {
     const me = StreamrClient.generateEthereumAccount()
-    const nonExistingUser = StreamrClient.generateEthereumAccount()
     const existingUser = StreamrClient.generateEthereumAccount()
 
     before(async () => {

--- a/rest-e2e-tests/permissions-api.test.js
+++ b/rest-e2e-tests/permissions-api.test.js
@@ -3,6 +3,7 @@ const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const StreamrClient = require('streamr-client')
 const getSessionToken = require('./test-utilities.js').getSessionToken
+const getStreamrClient = require('./test-utilities.js').getStreamrClient
 
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
@@ -19,19 +20,16 @@ describe('Permissions API', () => {
 
     before(async () => {
         // Make sure the "existingUser" exists by logging them in
-        await getSessionToken(existingUser.privateKey)
+        await getSessionToken(existingUser)
     })
 
     describe('POST /api/v1/streams/{id}/permissions', () => {
         let stream
 
         before(async () => {
-            stream = await Streamr.api.v1.streams
-                .create({
-                    name: `permissions-api.test.js-${Date.now()}`
-                })
-                .withAuthenticatedUser(me)
-                .execute()
+            stream = await getStreamrClient(me).createStream({
+                name: `permissions-api.test.js-${Date.now()}`
+            })
         })
 
         it('can grant a permission to an existing user using email address', async () => {
@@ -71,12 +69,9 @@ describe('Permissions API', () => {
         let stream
 
         before(async function() {
-            stream = await Streamr.api.v1.streams
-                .create({
-                    name: `permissions-api.test.js-delete-${Date.now()}`
-                })
-                .withAuthenticatedUser(me)
-                .execute()
+            stream = await getStreamrClient(me).createStream({
+                name: `permissions-api.test.js-delete-${Date.now()}`
+            })
         })
 
         it('delete a permission', async function() {

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -5,11 +5,8 @@ const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
+const testUsers = require('./test-utilities.js').testUsers
 const StreamrClient = require('streamr-client')
-
-const productOwner = StreamrClient.generateEthereumAccount()
-const otherUser = StreamrClient.generateEthereumAccount()
-const devOpsUser = require('./test-utilities.js').testUsers.devOpsUser
 
 const schemaValidator = new SchemaValidator()
 
@@ -28,10 +25,10 @@ function assertIsStream(data) {
     assert(errors.length === 0, schemaValidator.toMessages(errors))
 }
 
-async function createProductAndReturnId(productBody) {
+async function createProductAndReturnId(productBody, user) {
     const json = await Streamr.api.v1.products
         .create(productBody)
-        .withAuthenticatedUser(productOwner)
+        .withAuthenticatedUser(user)
         .execute()
     return json.id
 }
@@ -46,7 +43,10 @@ describe('Products API', function() {
 
     let streamId1
     let streamId2
-    let streamId3
+	let streamId3
+	const productOwner = StreamrClient.generateEthereumAccount()
+	const otherUser = StreamrClient.generateEthereumAccount()
+	const devOpsUser = testUsers.devOpsUser
 
     this.timeout(1000 * 25)
 
@@ -99,7 +99,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -248,7 +248,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires existing Product', async () => {
@@ -324,7 +324,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -433,7 +433,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -503,7 +503,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -538,7 +538,7 @@ describe('Products API', function() {
         })
 
         it('verifies legality of state transition', async () => {
-            const productId = await createProductAndReturnId(genericProductBody)
+            const productId = await createProductAndReturnId(genericProductBody, productOwner)
 
             await Streamr.api.v1.products
                 .setDeployed(productId, deployedBody)
@@ -639,7 +639,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -726,7 +726,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -745,7 +745,7 @@ describe('Products API', function() {
         })
 
         it('requires DevOps role', async () => {
-            const productId = await createProductAndReturnId(genericProductBody)
+            const productId = await createProductAndReturnId(genericProductBody, productOwner)
             await Streamr.api.v1.products
                 .setDeployed(productId, {
                     ownerAddress: '0xAAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDDDDDDD',
@@ -873,7 +873,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires existing Product', async () => {
@@ -931,7 +931,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -1063,7 +1063,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires existing Product', async () => {
@@ -1139,7 +1139,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         it('requires existing Product', async () => {
@@ -1207,7 +1207,7 @@ describe('Products API', function() {
         let createdProductId
 
         before(async () => {
-            createdProductId = await createProductAndReturnId(genericProductBody)
+            createdProductId = await createProductAndReturnId(genericProductBody, productOwner)
         })
 
         context('when called with valid params, body, and headers', () => {
@@ -1251,7 +1251,7 @@ describe('Products API', function() {
                 priceCurrency: 'USD',
                 minimumSubscriptionInSeconds: 60,
             }
-            freeProductId = await createProductAndReturnId(freeProductBody)
+            freeProductId = await createProductAndReturnId(freeProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -1282,7 +1282,7 @@ describe('Products API', function() {
         })
 
         it('verifies that Product is free', async () => {
-            const paidProductId = await createProductAndReturnId(genericProductBody)
+            const paidProductId = await createProductAndReturnId(genericProductBody, productOwner)
 
             const response = await Streamr.api.v1.products
                 .deployFree(paidProductId)
@@ -1342,7 +1342,7 @@ describe('Products API', function() {
                 priceCurrency: 'USD',
                 minimumSubscriptionInSeconds: 60,
             }
-            freeProductId = await createProductAndReturnId(freeProductBody)
+            freeProductId = await createProductAndReturnId(freeProductBody, productOwner)
         })
 
         it('requires authentication', async () => {
@@ -1373,7 +1373,7 @@ describe('Products API', function() {
         })
 
         it('verifies that Product is free', async () => {
-            const paidProductId = await createProductAndReturnId(genericProductBody)
+            const paidProductId = await createProductAndReturnId(genericProductBody, productOwner)
 
             const response = await Streamr.api.v1.products
                 .undeployFree(paidProductId)

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch')
 const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
+const getStreamrClient = require('./test-utilities.js').getStreamrClient
 const StreamrClient = require('streamr-client')
 
 const URL = 'http://localhost/api/v1'
@@ -42,11 +43,8 @@ async function createProductAndReturnId(productBody) {
 }
 
 async function createStreamAndReturnId(streamBody, user) {
-    const json = await Streamr.api.v1.streams
-        .create(streamBody)
-        .withAuthenticatedUser(user)
-        .execute()
-    return json.id
+    const stream = await getStreamrClient(user).createStream(streamBody)
+    return stream.id
 }
 
 describe('Products API', function() {

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -3,20 +3,16 @@ const fs = require('fs')
 const zlib = require('zlib')
 const fetch = require('node-fetch')
 
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
 const StreamrClient = require('streamr-client')
 
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = process.env.LOGGING_ENABLED || false
-
 const productOwner = StreamrClient.generateEthereumAccount()
 const otherUser = StreamrClient.generateEthereumAccount()
 const devOpsUser = require('./test-utilities.js').testUsers.devOpsUser
 
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
 
 function assertIsPermission(data) {

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -1,8 +1,6 @@
 const assert = require('chai').assert
 const fs = require('fs')
 const zlib = require('zlib')
-const fetch = require('node-fetch')
-
 const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError

--- a/rest-e2e-tests/products-api.test.js
+++ b/rest-e2e-tests/products-api.test.js
@@ -13,7 +13,7 @@ const LOGGING_ENABLED = process.env.LOGGING_ENABLED || false
 
 const productOwner = StreamrClient.generateEthereumAccount()
 const otherUser = StreamrClient.generateEthereumAccount()
-const DEVOPS_USER_TOKEN = 'devops-user-key'
+const devOpsUser = require('./test-utilities.js').testUsers.devOpsUser
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
@@ -550,7 +550,7 @@ describe('Products API', function() {
 
             await Streamr.api.v1.products
                 .setDeployed(productId, deployedBody)
-                .withApiKey(DEVOPS_USER_TOKEN)
+                .withAuthenticatedUser(devOpsUser)
                 .execute()
 
             await Streamr.api.v1.products
@@ -563,7 +563,7 @@ describe('Products API', function() {
                     ...deployedBody,
                     blockNumber: 35005
                 })
-                .withApiKey(DEVOPS_USER_TOKEN)
+                .withAuthenticatedUser(devOpsUser)
                 .call()
 
             await assertResponseIsError(response, 409, 'INVALID_STATE_TRANSITION')
@@ -576,7 +576,7 @@ describe('Products API', function() {
             before(async () => {
                 response = await Streamr.api.v1.products
                     .setDeployed(createdProductId, deployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 json = await response.json()
             })
@@ -616,19 +616,19 @@ describe('Products API', function() {
             it('is an idempotent operation', async () => {
                 const response1 = await Streamr.api.v1.products
                     .setDeployed(createdProductId, deployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json1 = await response1.json()
 
                 const response2 = await Streamr.api.v1.products
                     .setDeployed(createdProductId, deployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json2 = await response2.json()
 
                 const response3 = await Streamr.api.v1.products
                     .setDeployed(createdProductId, deployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json3 = await response3.json()
 
@@ -700,7 +700,7 @@ describe('Products API', function() {
                         blockNumber: 35000,
                         blockIndex: 80
                     })
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
 
                 response = await Streamr.api.v1.products
@@ -764,7 +764,7 @@ describe('Products API', function() {
                     blockNumber: 35000,
                     blockIndex: 80
                 })
-                .withApiKey(DEVOPS_USER_TOKEN)
+                .withAuthenticatedUser(devOpsUser)
                 .call()
 
             const response = await Streamr.api.v1.products
@@ -777,7 +777,7 @@ describe('Products API', function() {
         it('verifies legality of state transition', async () => {
             const response = await Streamr.api.v1.products
                 .setUndeployed(createdProductId, undeployedBody)
-                .withApiKey(DEVOPS_USER_TOKEN)
+                .withAuthenticatedUser(devOpsUser)
                 .call()
             await assertResponseIsError(response, 409, 'INVALID_STATE_TRANSITION')
         })
@@ -797,12 +797,12 @@ describe('Products API', function() {
                         blockNumber: 35000,
                         blockIndex: 80
                     })
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
 
                 response = await Streamr.api.v1.products
                     .setUndeployed(createdProductId, undeployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
 
                 json = await response.json()
@@ -831,24 +831,24 @@ describe('Products API', function() {
                         blockNumber: 35000,
                         blockIndex: 80
                     })
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
 
                 const response1 = await Streamr.api.v1.products
                     .setUndeployed(createdProductId, undeployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json1 = await response1.json()
 
                 const response2 = await Streamr.api.v1.products
                     .setUndeployed(createdProductId, undeployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json2 = await response2.json()
 
                 const response3 = await Streamr.api.v1.products
                     .setUndeployed(createdProductId, undeployedBody)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 const json3 = await response3.json()
 

--- a/rest-e2e-tests/schema-validator.js
+++ b/rest-e2e-tests/schema-validator.js
@@ -1,5 +1,4 @@
 const Ajv = require('ajv')
-
 const categorySchema = require('./schemas/category.json')
 const permissionSchema = require('./schemas/permission.json')
 const productSchema = require('./schemas/product.json')

--- a/rest-e2e-tests/storagenode-api.test.js
+++ b/rest-e2e-tests/storagenode-api.test.js
@@ -2,7 +2,6 @@ const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const _ = require('lodash');
 const StreamrClient = require('streamr-client')
-const newSessionToken = require('./test-utilities.js').newSessionToken
 
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false;
@@ -15,7 +14,7 @@ const createMockEthereumAddress = () => {
 const createStream = async (user) => {
 	return Streamr.api.v1.streams
 		.create()
-		.withSessionToken(await newSessionToken(user.privateKey))
+		.withAuthenticatedUser(user)
 		.execute()
 		.then((json) => json.id);
 };
@@ -32,13 +31,13 @@ const findStorageNodesByStream = (streamId) => {
 const addStorageNodeToStream = async (storageNodeAddress, streamId, user) => {
 	return Streamr.api.v1.storagenodes
 		.addStorageNodeToStream(storageNodeAddress, streamId)
-		.withSessionToken((user !== undefined) ? await newSessionToken(user.privateKey) : undefined)
+		.withAuthenticatedUser(user)
 		.call();
 };
 const removeStorageNodeFromStream = async (storageNodeAddress, streamId, user) => {
 	return Streamr.api.v1.storagenodes
 		.removeStorageNodeFromStream(storageNodeAddress, streamId)
-		.withSessionToken((user !== undefined) ? await newSessionToken(user.privateKey) : undefined)
+		.withAuthenticatedUser(user)
 		.call();
 };
 const getStorageNodeCount = async (streamId) => {

--- a/rest-e2e-tests/storagenode-api.test.js
+++ b/rest-e2e-tests/storagenode-api.test.js
@@ -1,12 +1,8 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const _ = require('lodash');
 const StreamrClient = require('streamr-client')
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false;
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
 const createMockEthereumAddress = () => {
 	const LENGTH = 40;

--- a/rest-e2e-tests/storagenode-api.test.js
+++ b/rest-e2e-tests/storagenode-api.test.js
@@ -2,6 +2,7 @@ const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const _ = require('lodash');
 const StreamrClient = require('streamr-client')
+const getStreamrClient = require('./test-utilities.js').getStreamrClient
 
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false;
@@ -12,11 +13,8 @@ const createMockEthereumAddress = () => {
 	return '0x' + _.padStart(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),LENGTH, '0');
 };
 const createStream = async (user) => {
-	return Streamr.api.v1.streams
-		.create()
-		.withAuthenticatedUser(user)
-		.execute()
-		.then((json) => json.id);
+	const stream = await getStreamrClient(user).createStream();
+	return stream.id;
 };
 const findStreamsByStorageNode = (storageNodeAddress) => {
 	return Streamr.api.v1.storagenodes

--- a/rest-e2e-tests/storagenode-api.test.js
+++ b/rest-e2e-tests/storagenode-api.test.js
@@ -1,10 +1,10 @@
 const assert = require('chai').assert
 const initStreamrApi = require('./streamr-api-clients')
 const _ = require('lodash');
+const StreamrClient = require('streamr-client')
+const newSessionToken = require('./test-utilities.js').newSessionToken
 
 const URL = 'http://localhost/api/v1'
-const API_KEY = 'product-api-tester-key';
-const API_KEY_OTHER_USER = 'product-api-tester2-key'
 const LOGGING_ENABLED = false;
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
@@ -12,10 +12,10 @@ const createMockEthereumAddress = () => {
 	const LENGTH = 40;
 	return '0x' + _.padStart(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),LENGTH, '0');
 };
-const createStream = () => {
+const createStream = async (user) => {
 	return Streamr.api.v1.streams
 		.create()
-		.withApiKey(API_KEY)
+		.withSessionToken(await newSessionToken(user.privateKey))
 		.execute()
 		.then((json) => json.id);
 };
@@ -29,16 +29,16 @@ const findStorageNodesByStream = (streamId) => {
 		.findStorageNodesByStream(streamId)
 		.call();
 };
-const addStorageNodeToStream = (storageNodeAddress, streamId, apiKey = API_KEY) => {
+const addStorageNodeToStream = async (storageNodeAddress, streamId, user) => {
 	return Streamr.api.v1.storagenodes
 		.addStorageNodeToStream(storageNodeAddress, streamId)
-		.withApiKey(apiKey)
+		.withSessionToken((user !== undefined) ? await newSessionToken(user.privateKey) : undefined)
 		.call();
 };
-const removeStorageNodeFromStream = (storageNodeAddress, streamId, apiKey = API_KEY) => {
+const removeStorageNodeFromStream = async (storageNodeAddress, streamId, user) => {
 	return Streamr.api.v1.storagenodes
 		.removeStorageNodeFromStream(storageNodeAddress, streamId)
-		.withApiKey(apiKey)
+		.withSessionToken((user !== undefined) ? await newSessionToken(user.privateKey) : undefined)
 		.call();
 };
 const getStorageNodeCount = async (streamId) => {
@@ -48,14 +48,18 @@ const getStorageNodeCount = async (streamId) => {
 };
 
 describe('Storage Node API', () => {
+
+	const streamOwner = StreamrClient.generateEthereumAccount()
+	const otherUser = StreamrClient.generateEthereumAccount()
+
 	describe('GET /storageNodes/:address/stream', () => {
 		let storageNodeAddress;
 		let streamId;
 
 		before(async () => {
 			storageNodeAddress = createMockEthereumAddress();
-			streamId = await createStream();
-			await addStorageNodeToStream(storageNodeAddress, streamId);
+			streamId = await createStream(streamOwner);
+			await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
 		});
 
 		it('happy path', async () => {
@@ -84,8 +88,8 @@ describe('Storage Node API', () => {
 
 		before(async () => {
 			storageNodeAddress = createMockEthereumAddress();
-			streamId = await createStream();
-			await addStorageNodeToStream(storageNodeAddress, streamId);
+			streamId = await createStream(streamOwner);
+			await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
 		});
 
 		it('happy path', async () => {
@@ -107,11 +111,11 @@ describe('Storage Node API', () => {
 
 		before(async () => {
 			storageNodeAddress = createMockEthereumAddress();
-			streamId = await createStream();
+			streamId = await createStream(streamOwner);
 		});
 
 		it('happy path', async () => {
-			const response = await addStorageNodeToStream(storageNodeAddress, streamId);
+			const response = await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
 			assert.equal(response.status, 200)
 			const json = await response.json()
 			assert.equal(json.storageNodeAddress, storageNodeAddress);
@@ -120,22 +124,22 @@ describe('Storage Node API', () => {
 		});
 
 		it('duplicate', async () => {
-			const response = await addStorageNodeToStream(storageNodeAddress, streamId);
+			const response = await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
 			assert.equal(response.status, 400)
 		});
 
 		it('validation error', async() => {
-			const response = await addStorageNodeToStream('foobar', streamId);
+			const response = await addStorageNodeToStream('foobar', streamId, streamOwner);
 			assert.equal(response.status, 422)
 		});
 
 		it('unauthorized', async() => {
-			const response = await addStorageNodeToStream(storageNodeAddress, streamId, null);
+			const response = await addStorageNodeToStream(storageNodeAddress, streamId, undefined);
 			assert.equal(response.status, 401)
 		});
 
 		it('forbidden', async() => {
-			const response = await addStorageNodeToStream(storageNodeAddress, streamId, API_KEY_OTHER_USER);
+			const response = await addStorageNodeToStream(storageNodeAddress, streamId, otherUser);
 			assert.equal(response.status, 403)
 		});
 	});
@@ -146,12 +150,12 @@ describe('Storage Node API', () => {
 
 		before(async () => {
 			storageNodeAddress = createMockEthereumAddress();
-			streamId = await createStream();
-			await addStorageNodeToStream(storageNodeAddress, streamId);
+			streamId = await createStream(streamOwner);
+			await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
 		});
 
 		it('happy path', async () => {
-			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId);
+			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId, streamOwner);
 			assert.equal(response.status, 204);
 			const storageNodeCount = await getStorageNodeCount(streamId);
 			assert.equal(storageNodeCount, 0);
@@ -159,22 +163,22 @@ describe('Storage Node API', () => {
 
 		it('not found', async () => {
 			const nonExistingStorageNodeAddress = createMockEthereumAddress();
-			const response = await removeStorageNodeFromStream(nonExistingStorageNodeAddress, streamId);
+			const response = await removeStorageNodeFromStream(nonExistingStorageNodeAddress, streamId, streamOwner);
 			assert.equal(response.status, 404);
 		});
 
 		it('unauthorized', async() => {
-			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId, null);
+			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId, undefined);
 			assert.equal(response.status, 401)
 		});
 
 		it('forbidden', async() => {
-			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId, API_KEY_OTHER_USER);
+			const response = await removeStorageNodeFromStream(storageNodeAddress, streamId, otherUser);
 			assert.equal(response.status, 403)
 		});
 
 		it('malformed storage node address', async () => {
-			const response = await removeStorageNodeFromStream('foobar', streamId);
+			const response = await removeStorageNodeFromStream('foobar', streamId, streamOwner);
 			assert.equal(response.status, 400);
 		});
 	});

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -432,27 +432,24 @@ class NotFound {
     }
 }
 
-module.exports = (baseUrl, logging) => {
-    const options = {
-        // Append a trailing "/" if not present
-        baseUrl: baseUrl.slice(-1) === "/" ? baseUrl : baseUrl + '/',
-        logging
-    }
-
-    return {
-        api: {
-            v1: {
-                canvases: new Canvases(options),
-                categories: new Categories(options),
-                integration_keys: new IntegrationKeys(options),
-                login: new Login(options),
-                products: new Products(options),
-                streams: new Streams(options),
-                subscriptions: new Subscriptions(options),
-                dataunions: new DataUnions(options),
-                storagenodes: new StorageNodes(options),
-                not_found: new NotFound(options),
-            }
+const LOGGING_ENABLED = process.env.LOGGING_ENABLED || false
+const options = {
+	baseUrl: 'http://localhost/api/v1/',
+	logging: LOGGING_ENABLED
+}
+module.exports = {
+    api: {
+        v1: {
+            canvases: new Canvases(options),
+            categories: new Categories(options),
+            integration_keys: new IntegrationKeys(options),
+            login: new Login(options),
+            products: new Products(options),
+            streams: new Streams(options),
+            subscriptions: new Subscriptions(options),
+            dataunions: new DataUnions(options),
+            storagenodes: new StorageNodes(options),
+            not_found: new NotFound(options),
         }
     }
 }

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -83,7 +83,7 @@ class StreamrApiRequest {
             headers['Content-type'] = this.contentType
         }
         if (this.authenticatedUser) {
-            const sessionToken = await getSessionToken(this.authenticatedUser.privateKey)
+            const sessionToken = await getSessionToken(this.authenticatedUser)
             headers['Authorization'] = `Bearer ${sessionToken}`
         }
 
@@ -237,13 +237,6 @@ class Streams {
     constructor(options) {
         this.options = options
         this.permissions = new Permissions('streams', options)
-    }
-
-    create(body) {
-        return new StreamrApiRequest(this.options)
-            .method('POST')
-            .endpoint('streams')
-            .withBody(body)
     }
 
     get(id) {

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -272,18 +272,6 @@ class Streams {
             .endpoint('streams', id, 'permissions', 'me')
     }
 
-    isPublisher(streamId, address) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', streamId, 'publisher', address)
-    }
-
-    isSubscriber(streamId, address) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', streamId, 'subscriber', address)
-    }
-
     delete(streamId, permissionId) {
         return new StreamrApiRequest(this.options)
             .method('DELETE')

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -6,12 +6,8 @@ const getSessionToken = require('./test-utilities.js').getSessionToken
 
 class StreamrApiRequest {
     constructor(options) {
-        this.baseUrl = options.baseUrl || 'https://www.streamr.com/api/v1/'
-        if (!this.baseUrl.endsWith('/')) {
-            this.baseUrl += '/'
-        }
-
-        this.logging = options.logging || false
+        this.baseUrl = options.baseUrl
+        this.logging = options.logging
         this.authenticatedUser = null
         this.contentType = null
         this.queryParams = ''

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -2,7 +2,6 @@ const fetch = require('node-fetch')
 const url = require('url')
 const querystring = require('querystring')
 const FormData = require('form-data')
-const StreamrClient = require('streamr-client')
 const getSessionToken = require('./test-utilities.js').getSessionToken
 
 class StreamrApiRequest {
@@ -338,19 +337,6 @@ class Subscriptions {
     }
 }
 
-class Login {
-    constructor(options) {
-        this.options = options
-    }
-
-    challenge(address) {
-        return new StreamrApiRequest(this.options)
-            .method('POST')
-            .endpoint('login', 'challenge', address)
-            .withBody()
-    }
-}
-
 class IntegrationKeys {
     constructor(options) {
         this.options = options
@@ -443,7 +429,6 @@ module.exports = {
             canvases: new Canvases(options),
             categories: new Categories(options),
             integration_keys: new IntegrationKeys(options),
-            login: new Login(options),
             products: new Products(options),
             streams: new Streams(options),
             subscriptions: new Subscriptions(options),

--- a/rest-e2e-tests/streamr-api-clients.js
+++ b/rest-e2e-tests/streamr-api-clients.js
@@ -239,12 +239,6 @@ class Streams {
         this.permissions = new Permissions('streams', options)
     }
 
-    get(id) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', id)
-    }
-
     setFields(id, body) {
         return new StreamrApiRequest(this.options)
             .method('POST')
@@ -276,24 +270,6 @@ class Streams {
         return new StreamrApiRequest(this.options)
             .method('GET')
             .endpoint('streams', id, 'permissions', 'me')
-    }
-
-    getValidationInfo(id) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', id, 'validation')
-    }
-
-    getPublishers(id) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', id, 'publishers')
-    }
-
-    getSubscribers(id) {
-        return new StreamrApiRequest(this.options)
-            .method('GET')
-            .endpoint('streams', id, 'subscribers')
     }
 
     isPublisher(streamId, address) {

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -12,7 +12,7 @@ const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
 const streamOwner = StreamrClient.generateEthereumAccount()
 const otherUser = StreamrClient.generateEthereumAccount()
-const ensTestUser = { privateKey: '0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb' }
+const ensDomainOwner = require('./test-utilities.js').testUsers.ensDomainOwner
 
 describe('Streams API', () => {
     let streamId
@@ -101,7 +101,7 @@ describe('Streams API', () => {
 			}
 			const response = await Streamr.api.v1.streams
 				.create(properties)
-				.withAuthenticatedUser(ensTestUser)
+				.withAuthenticatedUser(ensDomainOwner)
 				.call()
 
 			assert.equal(response.status, 200)

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -3,7 +3,6 @@ const fs = require('fs')
 const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
-const newSessionToken = require('./test-utilities.js').newSessionToken
 
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
@@ -98,10 +97,9 @@ describe('Streams API', () => {
 			const properties = {
 				id: streamId
 			}
-			const sessionToken = await newSessionToken(ENS_TEST_USER_PRIVATE_KEY)
 			const response = await Streamr.api.v1.streams
 				.create(properties)
-				.withSessionToken(sessionToken)
+				.withAuthenticatedUser({ privateKey: ENS_TEST_USER_PRIVATE_KEY })
 				.call()
 
 			assert.equal(response.status, 200)

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -1,7 +1,6 @@
 const assert = require('chai').assert
 const fs = require('fs')
 const Streamr = require('./streamr-api-clients')
-const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const assertStreamrClientResponseError = require('./test-utilities.js').assertStreamrClientResponseError
 const getStreamrClient = require('./test-utilities.js').getStreamrClient

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -98,7 +98,7 @@ describe('Streams API', () => {
 			const properties = {
 				id: streamId
 			}
-			const sessionToken = await newSessionToken(URL, ENS_TEST_USER_PRIVATE_KEY)
+			const sessionToken = await newSessionToken(ENS_TEST_USER_PRIVATE_KEY)
 			const response = await Streamr.api.v1.streams
 				.create(properties)
 				.withSessionToken(sessionToken)

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -1,16 +1,11 @@
 const assert = require('chai').assert
 const fs = require('fs')
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const assertStreamrClientResponseError = require('./test-utilities.js').assertStreamrClientResponseError
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
 const StreamrClient = require('streamr-client')
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
-
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 
 const streamOwner = StreamrClient.generateEthereumAccount()
 const anonymousUser = StreamrClient.generateEthereumAccount()

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -1,17 +1,17 @@
 const assert = require('chai').assert
-const fs = require('fs')
 const Streamr = require('./streamr-api-clients')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const assertStreamrClientResponseError = require('./test-utilities.js').assertStreamrClientResponseError
 const getStreamrClient = require('./test-utilities.js').getStreamrClient
+const testUsers = require('./test-utilities.js').testUsers
 const StreamrClient = require('streamr-client')
 
-const streamOwner = StreamrClient.generateEthereumAccount()
-const anonymousUser = StreamrClient.generateEthereumAccount()
-const ensDomainOwner = require('./test-utilities.js').testUsers.ensDomainOwner
-
 describe('Streams API', () => {
-    let streamId
+
+	let streamId
+	const streamOwner = StreamrClient.generateEthereumAccount()
+	const anonymousUser = StreamrClient.generateEthereumAccount()
+	const ensDomainOwner = testUsers.ensDomainOwner
 
     before(async () => {
         const response = await getStreamrClient(streamOwner).createStream({

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -166,16 +166,18 @@ describe('Streams API', () => {
             assert.equal(response.status, 200)
         })
         it('responds with status 401 when wrong token even if endpoint does not require authentication', async () => {
+            const sessionToken = 'wrong-token';
             const response = await Streamr.api.v1.streams.permissions
                 .getOwnPermissions(streamId)
-                .withSessionToken('wrong-token')
+                .withHeader('Authorization', `Bearer ${sessionToken}`)
                 .call()
             assert.equal(response.status, 401)
         })
         it('responds with status 401 when wrong API key even if endpoint does not require authentication', async () => {
+            const apiKey = 'wrong-api-key'
             const response = await Streamr.api.v1.streams.permissions
                 .getOwnPermissions(streamId)
-                .withApiKey('wrong-api-key')
+                .withHeader('Authorization', `Token ${apiKey}`)
                 .call()
             assert.equal(response.status, 401)
         })

--- a/rest-e2e-tests/subscriptions-api.test.js
+++ b/rest-e2e-tests/subscriptions-api.test.js
@@ -12,7 +12,7 @@ const LOGGING_ENABLED = false
 
 const productOwner = StreamrClient.generateEthereumAccount()
 const otherUser = StreamrClient.generateEthereumAccount()
-const DEVOPS_USER_TOKEN = 'devops-user-key'
+const devOpsUser = require('./test-utilities.js').testUsers.devOpsUser
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
@@ -33,7 +33,7 @@ async function createProductAndReturnId(productBody) {
 async function createSubscription(subscriptionBody) {
     await Streamr.api.v1.subscriptions
         .create(subscriptionBody)
-        .withApiKey(DEVOPS_USER_TOKEN)
+        .withAuthenticatedUser(devOpsUser)
         .execute()
 }
 
@@ -143,7 +143,7 @@ describe('Subscriptions API', () => {
                 }
                 const response = await Streamr.api.v1.subscriptions
                     .create(body)
-                    .withApiKey(DEVOPS_USER_TOKEN)
+                    .withAuthenticatedUser(devOpsUser)
                     .call()
                 assert.equal(response.status, 204)
             })

--- a/rest-e2e-tests/subscriptions-api.test.js
+++ b/rest-e2e-tests/subscriptions-api.test.js
@@ -5,12 +5,13 @@ const ethereumJsUtil = require('ethereumjs-util')
 const initStreamrApi = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
+const StreamrClient = require('streamr-client')
 
 const URL = 'http://localhost/api/v1'
 const LOGGING_ENABLED = false
 
-const AUTH_TOKEN = 'product-api-tester-key'
-const AUTH_TOKEN_2 = 'product-api-tester2-key'
+const productOwner = StreamrClient.generateEthereumAccount()
+const otherUser = StreamrClient.generateEthereumAccount()
 const DEVOPS_USER_TOKEN = 'devops-user-key'
 
 const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
@@ -24,7 +25,7 @@ function assertIsSubscription(data) {
 async function createProductAndReturnId(productBody) {
     const json = await Streamr.api.v1.products
         .create(productBody)
-        .withApiKey(AUTH_TOKEN)
+        .withAuthenticatedUser(productOwner)
         .execute()
     return json.id
 }
@@ -51,7 +52,7 @@ async function submitChallenge(challenge, signature) {
             challenge: challenge,
             signature: signature
         })
-        .withApiKey(AUTH_TOKEN_2)
+        .withAuthenticatedUser(otherUser)
         .execute()
     return json
 }
@@ -103,7 +104,7 @@ describe('Subscriptions API', () => {
             const body = {}
             const response = await Streamr.api.v1.subscriptions
                 .create(body)
-                .withApiKey(AUTH_TOKEN)
+                .withAuthenticatedUser(productOwner)
                 .call()
             await assertResponseIsError(response, 422, 'VALIDATION_ERROR')
         })
@@ -115,7 +116,7 @@ describe('Subscriptions API', () => {
             }
             const response = await Streamr.api.v1.subscriptions
                 .create(body)
-                .withApiKey(AUTH_TOKEN)
+                .withAuthenticatedUser(productOwner)
                 .call()
             await assertResponseIsError(response, 422, 'VALIDATION_ERROR', 'product')
         })
@@ -129,7 +130,7 @@ describe('Subscriptions API', () => {
                 }
                 const response = await Streamr.api.v1.subscriptions
                     .create(body)
-                    .withApiKey(AUTH_TOKEN)
+                    .withAuthenticatedUser(productOwner)
                     .call()
                 await assertResponseIsError(response, 403, 'FORBIDDEN', 'DevOps role required')
             })
@@ -156,7 +157,7 @@ describe('Subscriptions API', () => {
                 }
                 const response = await Streamr.api.v1.subscriptions
                     .create(body)
-                    .withApiKey(AUTH_TOKEN)
+                    .withAuthenticatedUser(productOwner)
                     .call()
                 await assertResponseIsError(response, 400, 'PRODUCT_IS_NOT_FREE')
             })
@@ -168,7 +169,7 @@ describe('Subscriptions API', () => {
                 }
                 const response = await Streamr.api.v1.subscriptions
                     .create(body)
-                    .withApiKey(AUTH_TOKEN)
+                    .withAuthenticatedUser(productOwner)
                     .call()
                 assert.equal(response.status, 204)
             })
@@ -236,7 +237,7 @@ describe('Subscriptions API', () => {
             before(async () => {
                 response = await Streamr.api.v1.subscriptions
                     .list()
-                    .withApiKey(AUTH_TOKEN_2)
+                    .withAuthenticatedUser(otherUser)
                     .call()
                 json = await response.json()
             })

--- a/rest-e2e-tests/subscriptions-api.test.js
+++ b/rest-e2e-tests/subscriptions-api.test.js
@@ -1,17 +1,13 @@
 const assert = require('chai').assert
-const initStreamrApi = require('./streamr-api-clients')
+const Streamr = require('./streamr-api-clients')
 const SchemaValidator = require('./schema-validator')
 const assertResponseIsError = require('./test-utilities.js').assertResponseIsError
 const StreamrClient = require('streamr-client')
-
-const URL = 'http://localhost/api/v1'
-const LOGGING_ENABLED = false
 
 const productOwner = StreamrClient.generateEthereumAccount()
 const subscriber = StreamrClient.generateEthereumAccount()
 const devOpsUser = require('./test-utilities.js').testUsers.devOpsUser
 
-const Streamr = initStreamrApi(URL, LOGGING_ENABLED)
 const schemaValidator = new SchemaValidator()
 
 function assertIsSubscription(data) {

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -1,6 +1,8 @@
 const assert = require('chai').assert
 const StreamrClient = require('streamr-client')
 
+const REST_URL = 'http://localhost/api/v1'
+
 async function assertResponseIsError(response, statusCode, programmaticCode, includeInMessage) {
     const json = await response.json()
     assert.equal(response.status, statusCode)
@@ -10,21 +12,14 @@ async function assertResponseIsError(response, statusCode, programmaticCode, inc
     }
 }
 
-async function newSessionToken(restURL, privateKey) {
+async function newSessionToken(privateKey) {
 	const client = new StreamrClient({
-		restUrl: restURL,
+		restUrl: REST_URL,
 		auth: {
 			privateKey
 		},
 	})
-	await client.connect()
-
-	const sessionToken = await client.session.getSessionToken()
-	if (client.isConnected()) {
-		await client.disconnect()
-	}
-
-	return sessionToken
+	return await client.session.getSessionToken()
 }
 
 module.exports = {

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -32,12 +32,12 @@ async function getSessionToken(privateKey) {
 }
 
 const testUsers = _.mapValues({
-	// user_id=6 in the test DB, has ROLE_DEV_OPS authority
-	devOpsUser: '0x628acb12df34bb30a0b2f95ec2e6a743b386c5d4f63aa9f338bec6f613160e78'
+	devOpsUser: '0x628acb12df34bb30a0b2f95ec2e6a743b386c5d4f63aa9f338bec6f613160e78',     // user_id=6 in the test DB, has ROLE_DEV_OPS authority
+	ensDomainOwner: '0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb'  // owns testdomain1.eth ENS domain in dev mainchain
 }, privateKey => ( { privateKey } ))
 
 module.exports = {
-	assertResponseIsError: assertResponseIsError,
-	getSessionToken: getSessionToken,
-	testUsers: testUsers
+	assertResponseIsError,
+	getSessionToken,
+	testUsers
 }

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -12,17 +12,25 @@ async function assertResponseIsError(response, statusCode, programmaticCode, inc
     }
 }
 
-async function newSessionToken(privateKey) {
-	const client = new StreamrClient({
-		restUrl: REST_URL,
-		auth: {
-			privateKey
-		},
-	})
-	return await client.session.getSessionToken()
+const cachedSessionTokens = {}
+
+async function getSessionToken(privateKey) {
+	if (cachedSessionTokens[privateKey] === undefined) {
+		const client = new StreamrClient({
+			restUrl: REST_URL,
+			auth: {
+				privateKey
+			},
+		})
+		const sessionToken = await client.session.getSessionToken()
+		cachedSessionTokens[privateKey] = sessionToken
+		return sessionToken
+	} else {
+		return cachedSessionTokens[privateKey]
+	}
 }
 
 module.exports = {
 	assertResponseIsError: assertResponseIsError,
-	newSessionToken: newSessionToken
+	getSessionToken: getSessionToken
 }

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -1,4 +1,5 @@
 const assert = require('chai').assert
+const _ = require('lodash');
 const StreamrClient = require('streamr-client')
 
 const REST_URL = 'http://localhost/api/v1'
@@ -30,7 +31,13 @@ async function getSessionToken(privateKey) {
 	}
 }
 
+const testUsers = _.mapValues({
+	// user_id=6 in the test DB, has ROLE_DEV_OPS authority
+	devOpsUser: '0x628acb12df34bb30a0b2f95ec2e6a743b386c5d4f63aa9f338bec6f613160e78'
+}, privateKey => ( { privateKey } ))
+
 module.exports = {
 	assertResponseIsError: assertResponseIsError,
-	getSessionToken: getSessionToken
+	getSessionToken: getSessionToken,
+	testUsers: testUsers
 }

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -13,16 +13,31 @@ async function assertResponseIsError(response, statusCode, programmaticCode, inc
     }
 }
 
+const assertStreamrClientResponseError = async (request, expectedStatusCode) => {
+	return request
+		.then(() => {
+			assert.fail('Should response with an error code')
+		})
+		.catch(e => {
+			assert.equal(e.response.status, expectedStatusCode)
+		})
+}
+
+const getStreamrClient = (user) => {
+	return new StreamrClient({
+		restUrl: REST_URL,
+		auth: {
+			privateKey: user.privateKey
+		}
+	})
+}
+
 const cachedSessionTokens = {}
 
-async function getSessionToken(privateKey) {
+async function getSessionToken(user) {
+	const privateKey = user.privateKey
 	if (cachedSessionTokens[privateKey] === undefined) {
-		const client = new StreamrClient({
-			restUrl: REST_URL,
-			auth: {
-				privateKey
-			},
-		})
+		const client = getStreamrClient(user)
 		const sessionToken = await client.session.getSessionToken()
 		cachedSessionTokens[privateKey] = sessionToken
 		return sessionToken
@@ -38,6 +53,8 @@ const testUsers = _.mapValues({
 
 module.exports = {
 	assertResponseIsError,
+	assertStreamrClientResponseError,
 	getSessionToken,
-	testUsers
+	testUsers,
+	getStreamrClient
 }


### PR DESCRIPTION
Converted most of the endpoints to use private key authentication. API authentication is used only in login endpoints (for testing API key related functionality). 

The tests create new users when possible so that there is no dependency to the DB state. 

Also converted the tests to use the official JS client where it supports the required endpoint.

Most of the tests users in the DB could be removed if not used outside of E&E. The only user that the tests need is "devOpsUser" (id=6). 
