### PR TITLE
BACK-7: Storage node case sensitivity

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2890,6 +2890,9 @@
 				},
 				"500": {
 					"description": "Unexpected error"
+				},
+				"422": {
+					"description": "Validation error"
 				}
 			}
 		}
@@ -2952,14 +2955,14 @@
 				"400": {
 					"description": "Storage node already exists"
 				},
-				"422": {
-					"description": "Validation error"
-				},
 				"401": {
 					"description": "No authentication"
 				},
 				"403": {
 					"description": "Authentication failed"
+				},
+				"422": {
+					"description": "Validation error"
 				}
 			}
 		}
@@ -2995,6 +2998,9 @@
 				},
 				"403": {
 					"description": "Authentication failed"
+				},
+				"422": {
+					"description": "Validation error"
 				}
 			}
 		}

--- a/grails-app/controllers/com/unifina/controller/StorageNodeApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/StorageNodeApiController.groovy
@@ -24,12 +24,8 @@ class StorageNodeApiController {
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
 	def findStreamsByStorageNode(String storageNodeAddress) {
-		if (EthereumAddressValidator.validate(storageNodeAddress)) {
-			List<Stream> streams = storageNodeService.findStreamsByStorageNode(storageNodeAddress)
-			return render(streams*.toSummaryMap() as JSON)
-		} else {
-			throw new BadRequestException("Malformed storage node address")
-		}
+		List<Stream> streams = storageNodeService.findStreamsByStorageNode(new EthereumAddress(storageNodeAddress))
+		return render(streams*.toSummaryMap() as JSON)
 	}
 
 	@StreamrApi(authenticationLevel = AuthLevel.NONE)
@@ -43,7 +39,7 @@ class StorageNodeApiController {
 		log.info("addStorageNodeToStream: storageNodeAddress=" + command.address + ", streamId=" + streamId)
 		if (command.validate()) {
 			if (checkEditPermission(streamId, request.apiUser)) {
-				StreamStorageNode streamStorageNode = storageNodeService.addStorageNodeToStream(command.address, streamId)
+				StreamStorageNode streamStorageNode = storageNodeService.addStorageNodeToStream(new EthereumAddress(command.address), streamId)
 				return render(streamStorageNode.toMap() as JSON)
 			} else {
 				throw new NotPermittedException(request.apiUser.username, "Stream", streamId)
@@ -55,16 +51,12 @@ class StorageNodeApiController {
 
 	@StreamrApi(authenticationLevel = AuthLevel.USER)
 	def removeStorageNodeFromStream(String storageNodeAddress, String streamId) {
-		if (EthereumAddressValidator.validate(storageNodeAddress)) {
-			log.info("removeStorageNodeFromStream: storageNodeAddress=" + storageNodeAddress + ", streamId=" + streamId)
-			if (checkEditPermission(streamId, request.apiUser)) {
-				storageNodeService.removeStorageNodeFromStream(storageNodeAddress, streamId)
-				return render(status: 204)
-			} else {
-				throw new NotPermittedException(request.apiUser.username, "Stream", streamId)
-			}
+		log.info("removeStorageNodeFromStream: storageNodeAddress=" + storageNodeAddress + ", streamId=" + streamId)
+		if (checkEditPermission(streamId, request.apiUser)) {
+			storageNodeService.removeStorageNodeFromStream(new EthereumAddress(storageNodeAddress), streamId)
+			return render(status: 204)
 		} else {
-			throw new BadRequestException("Malformed storage node address")
+			throw new NotPermittedException(request.apiUser.username, "Stream", streamId)
 		}
 	}
 

--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -1,15 +1,15 @@
 package com.unifina.service
 
-
 import com.unifina.domain.Stream
 import com.unifina.domain.StreamStorageNode
+import com.unifina.domain.EthereumAddress
 import grails.compiler.GrailsCompileStatic
 
 @GrailsCompileStatic
 class StorageNodeService {
 
-	List<Stream> findStreamsByStorageNode(String storageNodeAddress) {
-		List<StreamStorageNode> items = StreamStorageNode.findAllByStorageNodeAddress(storageNodeAddress)
+	List<Stream> findStreamsByStorageNode(EthereumAddress storageNodeAddress) {
+		List<StreamStorageNode> items = StreamStorageNode.findAllByStorageNodeAddress(storageNodeAddress.toString())
 		Iterable<Serializable> streamIds = items.collect{ it.streamId } as Iterable<Serializable>
 		return Stream.getAll(streamIds)
 	}
@@ -23,25 +23,25 @@ class StorageNodeService {
 		}
 	}
 
-	StreamStorageNode addStorageNodeToStream(String storageNodeAddress, String streamId) {
-		boolean exists = (StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress, streamId) != null)
+	StreamStorageNode addStorageNodeToStream(EthereumAddress storageNodeAddress, String streamId) {
+		boolean exists = (StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress.toString(), streamId) != null)
 		if (!exists) {
 			StreamStorageNode instance = new StreamStorageNode(
 				streamId: streamId,
-				storageNodeAddress: storageNodeAddress
+				storageNodeAddress: storageNodeAddress.toString()
 			)
 			return instance.save(validate: true)
 		} else {
-			throw new DuplicateNotAllowedException("StorageNode", storageNodeAddress)
+			throw new DuplicateNotAllowedException("StorageNode", storageNodeAddress.toString())
 		}
 	}
 
-	void removeStorageNodeFromStream(String storageNodeAddress, String streamId) {
-		StreamStorageNode instance = StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress, streamId)
+	void removeStorageNodeFromStream(EthereumAddress storageNodeAddress, String streamId) {
+		StreamStorageNode instance = StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress.toString(), streamId)
 		if (instance != null) {
 			instance.delete()
 		} else {
-			throw new NotFoundException("StorageNode", storageNodeAddress)
+			throw new NotFoundException("StorageNode", storageNodeAddress.toString())
 		}
 	}
 }

--- a/rest-e2e-tests/test-utilities.js
+++ b/rest-e2e-tests/test-utilities.js
@@ -23,6 +23,11 @@ const assertStreamrClientResponseError = async (request, expectedStatusCode) => 
 		})
 }
 
+const assertEqualEthereumAddresses = (actual, expected) => {
+	const normalized = address => address ? address.toLowerCase : address
+	assert.equal(normalized(actual), normalized(expected))
+}
+
 const getStreamrClient = (user) => {
 	return new StreamrClient({
 		restUrl: REST_URL,
@@ -54,6 +59,7 @@ const testUsers = _.mapValues({
 module.exports = {
 	assertResponseIsError,
 	assertStreamrClientResponseError,
+	assertEqualEthereumAddresses,
 	getSessionToken,
 	testUsers,
 	getStreamrClient

--- a/src/groovy/com/unifina/domain/EthereumAddress.groovy
+++ b/src/groovy/com/unifina/domain/EthereumAddress.groovy
@@ -1,9 +1,12 @@
 package com.unifina.domain
 
+import org.web3j.crypto.Keys
 import com.unifina.service.ValidationException
 import grails.compiler.GrailsCompileStatic
+import groovy.transform.EqualsAndHashCode
 
 @GrailsCompileStatic
+@EqualsAndHashCode
 class EthereumAddress {
 	private String value
 
@@ -11,7 +14,7 @@ class EthereumAddress {
 		if (!EthereumAddressValidator.validate.call(value)) {
 			throw new ValidationException("Address is not a valid Ethereum address")
 		}
-		this.value = value.toLowerCase()
+		this.value = Keys.toChecksumAddress(value)
 	}
 
 	public String toString() {

--- a/src/groovy/com/unifina/domain/EthereumAddress.groovy
+++ b/src/groovy/com/unifina/domain/EthereumAddress.groovy
@@ -1,0 +1,20 @@
+package com.unifina.domain
+
+import com.unifina.service.ValidationException
+import grails.compiler.GrailsCompileStatic
+
+@GrailsCompileStatic
+class EthereumAddress {
+	private String value
+
+	EthereumAddress(String value) {
+		if (!EthereumAddressValidator.validate.call(value)) {
+			throw new ValidationException("Address is not a valid Ethereum address")
+		}
+		this.value = value.toLowerCase()
+	}
+
+	public String toString() {
+		return value
+	}
+}

--- a/src/java/com/unifina/service/ValidationException.java
+++ b/src/java/com/unifina/service/ValidationException.java
@@ -16,6 +16,10 @@ public class ValidationException extends RuntimeException {
 		super(turnToMessage(Collections.singletonList(error)));
 	}
 
+	public ValidationException(String message) {
+		super(message);
+	}
+
 	private static String turnToMessage(List<FieldError> errors) {
 		String msg = "Validation failed for fields:\n";
 		for (FieldError error : errors) {

--- a/test/unit/com/unifina/domain/EthereumAddressSpec.groovy
+++ b/test/unit/com/unifina/domain/EthereumAddressSpec.groovy
@@ -1,0 +1,21 @@
+package com.unifina.domain
+
+import spock.lang.Specification
+
+class EthereumAddressSpec extends Specification {
+	void "toString() returns checksum form"() {
+		when:
+		EthereumAddress address = new EthereumAddress('0x0089d53f703f7e0843953d48133f74ce247184c2')
+		then:
+		address.toString() == "0x0089d53F703f7E0843953D48133f74cE247184c2"
+	}
+
+	void "equals and hashCode"() {
+		when:
+		EthereumAddress address1 = new EthereumAddress('0x0089d53f703f7e0843953d48133f74ce247184c2')
+		EthereumAddress address2 = new EthereumAddress('0x0089D53F703F7E0843953D48133F74CE247184C2')
+		then:
+		address1.equals(address2)
+		address1.hashCode() == address2.hashCode()
+	}
+}


### PR DESCRIPTION
Support case-insensitive input of storage node address. Store the address to DB in Ethereum checksum form and output the JSONs in that form.

EthereumAddress object is parsed from the command JSON manually and StreamStorageNode's field type is just a plain string instead of an EthereumAddress instance. If it is possible, string<->EthereumAddress conversions should happen automatically. We can enhance the functionality in BACK-85 if we apply this logic to the whole application.

Another small functionality change: if the request path has a malformed Ethereum address, the endpoint returns HTTP 422 (previously  HTTP 400).