### PR TITLE
BACK-94: Create streams under own address

### DIFF
--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -67,7 +67,7 @@ describe('Streams API', () => {
 			await assertStreamrClientResponseError(request, 422)
 		})
 
-		it('create with sandbox domain id', async function() {
+		it('create with sandbox id', async function() {
 			const streamId = 'sandbox/foo/bar' + Date.now()
 			const properties = {
 				id: streamId
@@ -85,10 +85,19 @@ describe('Streams API', () => {
 			assert.equal(response.id, streamId)
 		})
 
-		it('create with invalid domain id', async function() {
-			const sandboxDomainId = 'foobar.eth/loremipsum'
+		it('create with integration key id', async function() {
+			const streamId = streamOwner.address + '/foo/bar' + Date.now()
 			const properties = {
-				id: sandboxDomainId
+				id: streamId
+			}
+			const response = await getStreamrClient(streamOwner).createStream(properties)
+			assert.equal(response.id, streamId)
+		})
+
+		it('create with invalid id', async function() {
+			const streamId = 'foobar.eth/loremipsum'
+			const properties = {
+				id: streamId
 			}
 			const request = getStreamrClient(streamOwner).createStream(properties)
 			await assertStreamrClientResponseError(request, 422)

--- a/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
+++ b/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
@@ -4,10 +4,14 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class CustomStreamIDValidatorSpec extends Specification {
+
+	private static final String MOCK_DOMAIN = "sub.my-domain.eth"
+	private static final String MOCK_INTEGRATION_KEY_ADDRESS = "0xAbcdeabCDE123456789012345678901234567890"
+
 	@Unroll
 	void "validate #value"(String value, Boolean expected) {
 		def User mockUser = new User()
-		def domainValidator = {domain, creator -> ((creator == mockUser) && (domain.equals("sub.my-domain.eth")))}
+		def domainValidator = {domain, creator -> ((creator == mockUser) && (domain.equals(MOCK_DOMAIN) || (domain.equals(MOCK_INTEGRATION_KEY_ADDRESS))))}
 		def validator = new CustomStreamIDValidator(domainValidator)
 		expect:
 		validator.validate(value, mockUser) == expected
@@ -19,11 +23,13 @@ class CustomStreamIDValidatorSpec extends Specification {
 		"sandbox/foo.bar/lorem.ipsum" | true
 		"sandbox/foo-bar/lorem.ipsum" | true
 		"sub.my-domain.eth/abc/def" | true
+		"0xAbcdeabCDE123456789012345678901234567890/abc/def" | true
 		"sandbox/foo-bar/lorem~ipsum" | false
 		"sandbox/abc/def/" | false
 		"sandbox/abc/def/file." | false
 		"sandbox/foo//bar" | false
 		"foobar.eth/abc/def" | false
+		"0x1111111111111111111111111111111111111111/abc/def" | false
 		"foo" | false
 		"sandbox" | false
 		"" | false


### PR DESCRIPTION
Allow users to create streams with the naming pattern `<address>/<path>` where `<address>` is an Ethereum address connected to the user.