### PR TITLE
BACK-97: Drop support for "sandbox" domain

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4487,7 +4487,7 @@
         "id": {
           "type": "string",
           "description": "ID of this stream.",
-          "example": "sandbox/foo/bar"
+          "example": "foobar.eth/foo/bar"
         },
         "name": {
           "type": "string",

--- a/rest-e2e-tests/streams-api.test.js
+++ b/rest-e2e-tests/streams-api.test.js
@@ -67,15 +67,6 @@ describe('Streams API', () => {
 			await assertStreamrClientResponseError(request, 422)
 		})
 
-		it('create with sandbox id', async function() {
-			const streamId = 'sandbox/foo/bar' + Date.now()
-			const properties = {
-				id: streamId
-			}
-			const response = await getStreamrClient(streamOwner).createStream(properties)
-			assert.equal(response.id, streamId)
-		})
-
 		it('create with owned domain id', async function() {
 			const streamId = 'testdomain1.eth/foo/bar' + Date.now()
 			const properties = {
@@ -107,7 +98,7 @@ describe('Streams API', () => {
 
     describe('GET /api/v1/streams/:id', () => {
         it('works with uri-encoded ids', async () => {
-            const id = 'sandbox/streams-api.test.js/stream-' + Date.now()
+            const id = streamOwner.address + '/streams-api.test.js/stream-' + Date.now()
             await getStreamrClient(streamOwner).createStream({
                 id
             })

--- a/src/groovy/com/unifina/domain/CustomStreamIDValidator.groovy
+++ b/src/groovy/com/unifina/domain/CustomStreamIDValidator.groovy
@@ -11,7 +11,6 @@ class CustomStreamIDValidator {
 		boolean isOwnedBy(String domain, User owner)
 	}
 
-	public static final String SANDBOX_HOST = "sandbox"
 	// path rules:
 	// - must start by slash
 	// - can contain chars a-z, A-Z, 0-9 and -_.
@@ -31,19 +30,11 @@ class CustomStreamIDValidator {
 		} else {
 			Matcher matcher = REGEX.matcher(id)
 			if (matcher.matches()) {
-				String host = matcher.group(1)
-				return isValidHost(host, creator)
+				String domain = matcher.group(1)
+				return domainValidator.isOwnedBy(domain, creator)
 			} else {
 				return false;
 			}
-		}
-	}
-
-	boolean isValidHost(String host, User creator) {
-		if (host.equals(SANDBOX_HOST)) {
-			return true
-		} else {
-			return domainValidator.isOwnedBy(host, creator)
 		}
 	}
 }

--- a/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
+++ b/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
@@ -5,33 +5,34 @@ import spock.lang.Unroll
 
 class CustomStreamIDValidatorSpec extends Specification {
 
-	private static final String MOCK_DOMAIN = "sub.my-domain.eth"
+	private static final String MOCK_ENS_DOMAIN = "sub.my-domain.eth"
 	private static final String MOCK_INTEGRATION_KEY_ADDRESS = "0xAbcdeabCDE123456789012345678901234567890"
 
 	@Unroll
 	void "validate #value"(String value, Boolean expected) {
 		def User mockUser = new User()
-		def domainValidator = {domain, creator -> ((creator == mockUser) && (domain.equals(MOCK_DOMAIN) || (domain.equals(MOCK_INTEGRATION_KEY_ADDRESS))))}
+		def domainValidator = {domain, creator -> ((creator == mockUser) && (domain.equals(MOCK_ENS_DOMAIN) || domain.equalsIgnoreCase(MOCK_INTEGRATION_KEY_ADDRESS)))}
 		def validator = new CustomStreamIDValidator(domainValidator)
 		expect:
 		validator.validate(value, mockUser) == expected
 		where:
 		value | expected
-		"sandbox/a" | true
-		"sandbox/abc/def" | true
-		"sandbox/abc/def/file.txt" | true
-		"sandbox/foo.bar/lorem.ipsum" | true
-		"sandbox/foo-bar/lorem.ipsum" | true
+		"sub.my-domain.eth/a" | true
+		"sub.my-domain.eth/abc/def" | true
+		"sub.my-domain.eth/abc/def/file.txt" | true
+		"sub.my-domain.eth/foo.bar/lorem.ipsum" | true
+		"sub.my-domain.eth/foo-bar/lorem.ipsum" | true
 		"sub.my-domain.eth/abc/def" | true
 		"0xAbcdeabCDE123456789012345678901234567890/abc/def" | true
-		"sandbox/foo-bar/lorem~ipsum" | false
-		"sandbox/abc/def/" | false
-		"sandbox/abc/def/file." | false
-		"sandbox/foo//bar" | false
+		"0xaBCDEABcde123456789012345678901234567890/abc/def" | true
+		"sub.my-domain.eth/foo-bar/lorem~ipsum" | false
+		"sub.my-domain.eth/abc/def/" | false
+		"sub.my-domain.eth/abc/def/file." | false
+		"sub.my-domain.eth/foo//bar" | false
 		"foobar.eth/abc/def" | false
+		"sub.my-domain.eth" | false
 		"0x1111111111111111111111111111111111111111/abc/def" | false
 		"foo" | false
-		"sandbox" | false
 		"" | false
 		" " | false
 	}

--- a/test/unit/com/unifina/service/StreamServiceSpec.groovy
+++ b/test/unit/com/unifina/service/StreamServiceSpec.groovy
@@ -40,19 +40,19 @@ class StreamServiceSpec extends Specification {
 
 	void "createStream replaces empty name with stream id"() {
 		when:
-		Stream s = service.createStream(new CreateStreamCommand(id: "sandbox/foobar"), me, null)
+		Stream s = service.createStream(new CreateStreamCommand(id: "foobar"), me, null)
 
 		then:
-		s.name == "sandbox/foobar"
+		s.name == "foobar"
 	}
 
 	void "createStream results in persisted Stream"() {
 		when:
-		service.createStream(new CreateStreamCommand(id: "sandbox/foobar"), me, null)
+		service.createStream(new CreateStreamCommand(id: "foobar"), me, null)
 
 		then:
 		Stream.count() == 1
-		Stream.list().first().id == "sandbox/foobar"
+		Stream.list().first().id == "foobar"
 	}
 
 	void "createStream results in all permissions for Stream"() {

--- a/test/unit/com/unifina/signalpath/streams/CreateStreamSpec.groovy
+++ b/test/unit/com/unifina/signalpath/streams/CreateStreamSpec.groovy
@@ -35,7 +35,7 @@ class CreateStreamSpec extends BeanMockingSpecification {
 	void "creates streams from valid input value specifications"() {
 		when:
 		Map inputValues = [
-			id: ["sandbox/1", "sandbox/2", "sandbox/error"],
+			id: ["id-1", "id-2", "id-error"],
 			name: ["stream-1", "stream-2", "error"],
 			description: ["my 1st stream", "", "error"],
 			fields: [[:], [a: "boolean", b: "string"], [:]]
@@ -51,7 +51,7 @@ class CreateStreamSpec extends BeanMockingSpecification {
 
 		then:
 		4 * streamService.createStream(new CreateStreamCommand(
-			id: "sandbox/1",
+			id: "id-1",
 			name: "stream-1",
 			description: "my 1st stream",
 			config: [fields: []],
@@ -61,7 +61,7 @@ class CreateStreamSpec extends BeanMockingSpecification {
 			return s
 		}
 		4 * streamService.createStream(new CreateStreamCommand(
-			id: "sandbox/2",
+			id: "id-2",
 			name: "stream-2",
 			description: "",
 			config: [fields: [[name: "a", type: "boolean"], [name: "b", type: "string"]]],
@@ -71,7 +71,7 @@ class CreateStreamSpec extends BeanMockingSpecification {
 			return s
 		}
 		4 * streamService.createStream(new CreateStreamCommand(
-			id: "sandbox/error",
+			id: "id-error",
 			name: "error",
 			description: "error",
 			config: [fields: []]

--- a/test/unit/com/unifina/signalpath/streams/GetOrCreateStreamSpec.groovy
+++ b/test/unit/com/unifina/signalpath/streams/GetOrCreateStreamSpec.groovy
@@ -54,7 +54,7 @@ class GetOrCreateStreamSpec extends ModuleTestingSpecification {
 
 	void "GetOrCreateStreamSpec works as expected"() {
 		Map inputValues = [
-			id: ["sandbox/1", "sandbox/2", "sandbox/3", "sandbox/4", "sandbox/5"],
+			id: ["id-1", "id-2", "id-3", "id-4", "id-5"],
 			name: ["doesnotexist", "exists", "doesnotexist2", "exists-with-fields", "doesnotexist"],
 			description: ["test-stream"] * 5,
 			fields: [[a: "boolean", b: "string"]] * 5
@@ -71,7 +71,7 @@ class GetOrCreateStreamSpec extends ModuleTestingSpecification {
 
 	void "found streams are cached"() {
 		Map inputValues = [
-				id: ["sandbox/foo", "sandbox/foo"],
+				id: ["id-foo", "id-foo"],
 				name: ["exists", "exists"],
 				description: ["test-stream"] * 2,
 				fields: [[a: "boolean", b: "string"]] * 2


### PR DESCRIPTION
Remove the hard-coded shared `sandbox` domain, as it is now redundant after BACK-94.