### PR TITLE
BACK-71: Replace Tomcat connection pool with c3p0

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -110,6 +110,7 @@ grails.project.dependency.resolution = {
 
 		compile('com.google.code.gson:gson:2.8.5')
 		runtime('mysql:mysql-connector-java:5.1.20')
+		runtime('com.mchange:c3p0:0.9.5.5')
 		runtime('commons-net:commons-net:3.3')
 		runtime('org.apache.commons:commons-math3:3.2')
 		runtime('commons-codec:commons-codec:1.15')

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -2,22 +2,6 @@ dataSource {
 	pooled = true
 	driverClassName = "com.mysql.jdbc.Driver"
 	dialect = 'org.hibernate.dialect.MySQL5InnoDBDialect'
-	properties {
-		initialSize = 2
-		maxActive = 50 // -1
-		minIdle = 2
-		maxIdle = 25
-		maxWait = 30000
-		maxAge = 10 * 60000
-		minEvictableIdleTimeMillis=60000 // 1800000
-		timeBetweenEvictionRunsMillis=60000 //1800000, default: 5000
-		validationQuery = "SELECT 1"
-		validationQueryTimeout = 3
-		validationInterval = 15000
-		testOnBorrow = true
-		testWhileIdle = true
-		testOnReturn = false
-	}
 }
 hibernate {
 	cache.use_second_level_cache = true

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -25,6 +25,7 @@ beans = {
 		password = grailsApplication.config.dataSource.password
 		driverClass = grailsApplication.config.dataSource.driverClassName
 		jdbcUrl = grailsApplication.config.dataSource.url
+		// Options below can be tweaked for performance
 		maxPoolSize = 100
 		testConnectionOnCheckin = true
 		testConnectionOnCheckout = false

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,7 +1,8 @@
+import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.streamr.api.client.StreamrClientProvider
 import com.unifina.provider.S3FileUploadProvider
-import com.unifina.utils.CustomEditorRegistrar
 import com.unifina.security.BCryptPasswordEncoder
+import com.unifina.utils.CustomEditorRegistrar
 
 // Place your Spring DSL code here
 beans = {
@@ -17,4 +18,16 @@ beans = {
 	streamrClient(StreamrClientProvider,
 		(String) grailsApplication.config.streamr.api.http.url
 	)
+
+	dataSource(ComboPooledDataSource) { args ->
+		args.destroyMethod = "close"
+		user = grailsApplication.config.dataSource.username
+		password = grailsApplication.config.dataSource.password
+		driverClass = grailsApplication.config.dataSource.driverClassName
+		jdbcUrl = grailsApplication.config.dataSource.url
+		maxPoolSize = 100
+		testConnectionOnCheckin = true
+		testConnectionOnCheckout = false
+		idleConnectionTestPeriod = 30
+	}
 }


### PR DESCRIPTION
c3p0 connection pool has had reliable track record over the years and is considered industry "standard" over Tomcat connection pool.
- Current Mysql driver is JDBC 4(.2) compatible. Don't set preferredTestQuery.
- c3p0 fixes an issue where JDBC connections were closed prematurely:
```
java.sql.SQLException: PooledConnection has already been closed.
	at com.unifina.service.SessionService$$ESH9pQjI.generateToken(SessionService.groovy:26)
	at com.unifina.controller.LoginApiController.apikey(LoginApiController.groovy:55)
	at com.brandseye.cors.CorsFilter.doFilter(CorsFilter.java:100)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
