### PR TITLE
BACK-108: Increase REST API Login test timeout

### DIFF
--- a/rest-e2e-tests/login-api.test.js
+++ b/rest-e2e-tests/login-api.test.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch')
 
 const URL = 'http://localhost/api/v1'
 const API_KEY = 'tester1-api-key'
-const TIMEOUT = 5000
+const TIMEOUT = 10000
 
 describe('Login API', () => {
 


### PR DESCRIPTION
Login REST API test POST /api/v1/login/apikey has started to timeout after BACK-12. Lets increase the timeout temporarily until BACK-92 is done.