### PR TITLE
Developer Tools Update 2020/11 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ ps: ## Run streamr-docker-dev ps
 update: ## Run streamr-docker-dev update
 	streamr-docker-dev update
 
-.PHONY: shell
 shell-%: ## Run docker shell. Example: 'make shell-redis'
 	streamr-docker-dev  shell $*
 

--- a/Makefile
+++ b/Makefile
@@ -176,13 +176,16 @@ docker-login: ## Login with Docker
 
 .PHONY: clean
 clean: ## Remove all files created by this Makefile
-	$(MAKE) -C rest-e2e-tests clean
 	rm -rf tomcat.8081/work
 	rm -rf target
 	rm -rf .slcache
 	rm -rf "$$HOME/.grails"
 	rm -rf $(rest_srv_test_log)
 	$(grails) clean-all
+
+.PHONY: clean-all
+clean-all: clean
+	$(MAKE) -C rest-e2e-tests clean
 
 .PHONY: help
 help: ## Show Help

--- a/Makefile
+++ b/Makefile
@@ -186,4 +186,4 @@ clean: ## Remove all files created by this Makefile
 
 .PHONY: help
 help: ## Show Help
-	@grep -E '^[a-zA-Z_-]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'|sort

--- a/rest-e2e-tests/Makefile
+++ b/rest-e2e-tests/Makefile
@@ -74,5 +74,5 @@ clean: ## Remove generated files
 
 .PHONY: help
 help: ## Show Help
-	@grep -E '^[a-zA-Z0-9_\-\/]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_\-\/]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'|sort
 

--- a/rest-e2e-tests/Makefile
+++ b/rest-e2e-tests/Makefile
@@ -61,11 +61,11 @@ test/server/wait: ## Wait for server to come online
 test: vendor test/e2e test/stress ## Run tests
 
 .PHONY: test/e2e
-test/e2e: ## Run tests
+test/e2e: ## Run end to end tests
 	$(call npm, run test:e2e)
 
 .PHONY: test/stress
-test/stress: ## Run tests
+test/stress: ## Run stress tests
 	$(call npm, run test:stress)
 
 .PHONY: clean

--- a/rest-e2e-tests/Makefile
+++ b/rest-e2e-tests/Makefile
@@ -74,5 +74,5 @@ clean: ## Remove generated files
 
 .PHONY: help
 help: ## Show Help
-	@grep -E '^[a-zA-Z_-]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_\-\/]+%?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
 


### PR DESCRIPTION
- Recipe clean doesn't call '$(MAKE) -C rest-e2e-tests clean'
- Recipe clean-all calls clean and '$(MAKE) -C rest-e2e-tests clean'
- Improvements