### PR TITLE
BACK-110: Reorganise Travis CI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+streamr-docker-dev
 .idea
 .settings
 .slcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,23 @@ if: (branch = master) OR (branch = "/^deployed-\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/")
 
 git:
   submodules: false
-before_install:
-- curl -s http://get.sdkman.io | bash
-- echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-- source "/home/travis/.sdkman/bin/sdkman-init.sh"
-- sdk install grails 2.5.6
-- nvm install $NODE_VERSION
 env:
   global:
-  - NODE_VERSION=$(cat rest-e2e-tests/.nvmrc)
-  - OWNER=streamr
-  - IMAGE_NAME=engine-and-editor
+    - NODE_VERSION=$(cat rest-e2e-tests/.nvmrc)
+    - OWNER=streamr
+    - IMAGE_NAME=engine-and-editor
+    - PATH=$PATH:$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev
+before_install:
+  - sudo /etc/init.d/mysql stop
+  - curl -s http://get.sdkman.io | bash
+  - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+  - source "/home/travis/.sdkman/bin/sdkman-init.sh"
+  - sdk install grails 2.5.6
+  - nvm install $NODE_VERSION
+  - git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git
+  - cp $TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh $TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/streamr-docker-dev
+  - sed -i -e "s#${OWNER}/${IMAGE_NAME}:dev#${OWNER}/${IMAGE_NAME}:local#g" "$TRAVIS_BUILD_DIR/streamr-docker-dev/docker-compose.override.yml"
+  - sudo ifconfig docker0 10.200.10.1/24
 import:
  - source: streamr-dev/travis-ci:aws-staging-secrets.yml@master
  - source: streamr-dev/travis-ci:aws-production-secrets.yml@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 os: linux
-dist: xenial
+dist: focal
 jdk:
 - openjdk8
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 os: linux
-dist: focal
+dist: xenial
 jdk:
 - openjdk8
 services:

--- a/.travis_scripts/integration_test.sh
+++ b/.travis_scripts/integration_test.sh
@@ -2,12 +2,7 @@
 
 set -e
 
-sudo /etc/init.d/mysql stop
-if [ ! -d streamr-docker-dev ]; then # Skip clone on subsequent attemps.
-	git clone https://github.com/streamr-dev/streamr-docker-dev.git
-fi
-sudo ifconfig docker0 10.200.10.1/24
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" start mysql redis --wait
+streamr-docker-dev start mysql redis --wait
 
 # Report generation phase will crash if a SecurityManager is installed. Fix: skip report generation with -no-reports
 grails test-app -no-reports -integration --stacktrace --verbose

--- a/.travis_scripts/rest_e2e_test.sh
+++ b/.travis_scripts/rest_e2e_test.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
 
-sudo /etc/init.d/mysql stop
-echo "node version: $(node --version)"
 (cd rest-e2e-tests && npm ci)
 
-git clone https://github.com/streamr-dev/streamr-docker-dev.git
-
-# same as streamr-docker-dev bind-ip
-sudo ifconfig docker0 10.200.10.1/24
-
 # Start everything except engine-and-editor
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" start mysql redis cassandra parity-node0 parity-sidechain-node0 bridge data-union-server broker-node-storage-1 nginx smtp
+streamr-docker-dev start mysql redis cassandra parity-node0 parity-sidechain-node0 bridge data-union-server broker-node-storage-1 nginx smtp
 
 # Print app output to console
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" log -f engine-and-editor &
+streamr-docker-dev log -f engine-and-editor &
 
 # Wait for services to start
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" wait
+streamr-docker-dev wait
 
 # Start engine-and-editor in the background
 nohup grails test run-app --non-interactive &

--- a/.travis_scripts/smoke_test.sh
+++ b/.travis_scripts/smoke_test.sh
@@ -2,13 +2,7 @@
 
 set -e
 
-sudo ifconfig docker0 10.200.10.1/24
-
-git clone https://github.com/streamr-dev/streamr-docker-dev.git
-
-sed -i -e "s#${OWNER}/${IMAGE_NAME}:dev#${OWNER}/${IMAGE_NAME}:local#g" "$TRAVIS_BUILD_DIR/streamr-docker-dev/docker-compose.override.yml"
-
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" start --wait
+streamr-docker-dev start --wait
 
 wait_time=10
 for ((i = 0; i < 5; i++)); do

--- a/.travis_scripts/streamr-client-test.sh
+++ b/.travis_scripts/streamr-client-test.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 set -e
 
-sudo /etc/init.d/mysql stop
-if [ ! -d streamr-docker-dev ]; then # Skip clone on subsequent attemps.
-	git clone https://github.com/streamr-dev/streamr-docker-dev.git
-fi
-## Switch EE tag to the one built locally
-sed -i "s/engine-and-editor:dev/engine-and-editor:local/g" $TRAVIS_BUILD_DIR/streamr-docker-dev/docker-compose.override.yml
-sudo ifconfig docker0 10.200.10.1/24
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" start --except hsl-demo --wait
+streamr-docker-dev start --except hsl-demo --wait
 
 ## Setup testing Tool
 git clone https://github.com/streamr-dev/streamr-client-testing.git


### PR DESCRIPTION
- Run common commands for all steps in the `before_install:` step
    - Removes a lot of duplication
- By default all steps get the following setup out-of-the-box:
    - Default Mysql provided by Travis CI is in stopped state
    - Grails 2.5.6 installed
    - `streamr-docker-dev` installed in `$PATH`
    - `streamr-docker-dev` networking
    - If built, use local Docker image for E&E `streamr-docker-dev/engine-and-editor:local`
    - Installs Node defined in `rest-e2e-tests/.nvmrc` for running REST API tests
