### PR TITLE
DEVOP-51: Validate Markdown links in GitHub Actions

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,19 @@
+name: Markdown CI
+
+# https://github.com/gaurav-nelson/github-action-markdown-link-check
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+
+jobs:
+  check-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.12
+        with:
+            use-quiet-mode: 'yes'
+            use-verbose-mode: 'yes'
+            max-depth: 2


### PR DESCRIPTION
- Scheduled to run on Monday mornings (Helsinki time)