### PR TITLE
BACK-126: Read ENS owner from registry contract

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/Web3jHelper.java
+++ b/src/java/com/unifina/signalpath/blockchain/Web3jHelper.java
@@ -291,15 +291,9 @@ public class Web3jHelper {
 		String ensContractAddress = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.ensRegistryContractAddress");
 		ENS ensRegistry = ENS.load(ensContractAddress, web3j, transactionManager, new DefaultGasProvider());
 		byte[] nameHash = NameHash.nameHashAsBytes(domain);
-		String resolverAddress = send(ensRegistry.resolver(nameHash));
-		if (!Objects.equals(resolverAddress, ADDRESS_NONE)) {
-			PublicResolver resolver = PublicResolver.load(resolverAddress, web3j, transactionManager, new DefaultGasProvider());
-			String contractAddress = send(resolver.addr(NameHash.nameHashAsBytes(domain)));
-			if (!Objects.equals(contractAddress, ADDRESS_NONE)) {
-				return contractAddress;
-			} else {
-				return null;
-			}
+		String contractAddress = send(ensRegistry.owner(nameHash));
+		if (!Objects.equals(contractAddress, ADDRESS_NONE)) {
+			return contractAddress;
 		} else {
 			return null;
 		}


### PR DESCRIPTION
Fetch the owner of an ENS domain directly from the registry contract.  There is no need to fetch the resolver of the ENS domain and read the attributes from the resolver.

In production environment we use 
`function owner(bytes32 node) external view returns (address)`
from
https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e#code

In dev we use the same function from contract `0x92E8435EB56fD01BF4C79B66d47AC1A94338BB03`

The earlier implementation did not read the owner information correctly. It fetched the owner information from resolver's `addr` function: https://etherscan.io/address/0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41#code  (that field contains the same information in some cases, e.g. https://app.ens.domains/name/purplemonkeydishwasher.eth)