### PR TITLE
NET-187: Event stream for storage node assignments

### DIFF
--- a/grails-app/domain/com/unifina/domain/SignupMethod.groovy
+++ b/grails-app/domain/com/unifina/domain/SignupMethod.groovy
@@ -1,8 +1,6 @@
 package com.unifina.domain
 
-import com.unifina.utils.MapTraversal
-import grails.util.Holders
-
+import com.unifina.utils.ApplicationConfig
 import javax.servlet.http.HttpServletRequest
 
 enum SignupMethod {
@@ -14,7 +12,7 @@ enum SignupMethod {
 	private final static String SERVER_URL_CONFIG_KEY = "grails.serverURL"
 
 	static SignupMethod fromRequest(HttpServletRequest request) {
-		String serverUrl = MapTraversal.getString(Holders.getConfig(), SERVER_URL_CONFIG_KEY)
+		String serverUrl = ApplicationConfig.getString(SERVER_URL_CONFIG_KEY)
 		String origin = request.getHeader("Origin")
 		return (origin == serverUrl) ? SignupMethod.CORE : SignupMethod.API
 	}

--- a/grails-app/services/com/unifina/service/BalanceService.groovy
+++ b/grails-app/services/com/unifina/service/BalanceService.groovy
@@ -1,11 +1,9 @@
 package com.unifina.service
 
-
 import com.unifina.domain.IntegrationKey
 import com.unifina.domain.User
 import com.unifina.signalpath.blockchain.EthereumModuleOptions
-import com.unifina.utils.MapTraversal
-import grails.util.Holders
+import com.unifina.utils.ApplicationConfig
 import org.web3j.exceptions.MessageDecodingException
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.http.HttpService
@@ -26,7 +24,7 @@ class BalanceService {
 		ethereumOptions = new EthereumModuleOptions()
 		final HttpService httpService = new HttpService(ethereumOptions.getRpcUrl())
 		web3j = Web3j.build(httpService)
-		dataCoinAddress = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.datacoinAddress");
+		dataCoinAddress = ApplicationConfig.getString("streamr.ethereum.datacoinAddress");
 		if (dataCoinAddress == null) {
 			throw new RuntimeException("No datacoin address found in config");
 		}

--- a/grails-app/services/com/unifina/service/BootService.groovy
+++ b/grails-app/services/com/unifina/service/BootService.groovy
@@ -9,7 +9,7 @@ import com.unifina.domain.EthereumAddress
 import com.unifina.domain.Permission
 import com.unifina.security.MyPolicy
 import com.unifina.security.MySecurityManager
-import com.unifina.utils.MapTraversal
+import com.unifina.utils.ApplicationConfig
 import grails.util.Environment
 import grails.util.Holders
 import org.apache.log4j.Logger
@@ -99,7 +99,8 @@ class BootService {
 	}
 
 	def createStorageNodeAssignmentsStream() {
-		String streamId = getNodeAddress().toString() + "/storage-node-assignments"
+		EthereumAddress nodeAddress = EthereumAddress.fromPrivateKey(ApplicationConfig.getString("streamr.ethereum.nodePrivateKey"))
+		String streamId = nodeAddress.toString() + "/storage-node-assignments"
 		Stream stream = streamService.getStream(streamId)
 		if (stream == null) {
 			User nodeUser = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(nodeAddress.toString(), SignupMethod.UNKNOWN)
@@ -107,10 +108,5 @@ class BootService {
 			permissionService.systemGrantAnonymousAccess(stream, Permission.Operation.STREAM_GET)
 			permissionService.systemGrantAnonymousAccess(stream, Permission.Operation.STREAM_SUBSCRIBE)
 		}
-	}
-
-	def getNodeAddress() {
-		String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
-		return EthereumAddress.fromPrivateKey(nodePrivateKey)
 	}
 }

--- a/grails-app/services/com/unifina/service/BootService.groovy
+++ b/grails-app/services/com/unifina/service/BootService.groovy
@@ -99,10 +99,10 @@ class BootService {
 	}
 
 	def createStorageNodeAssignmentsStream() {
-		EthereumAddress nodeAddress = EthereumAddress.fromPrivateKey(ApplicationConfig.getString("streamr.ethereum.nodePrivateKey"))
-		String streamId = nodeAddress.toString() + "/storage-node-assignments"
+		String streamId = StorageNodeService.createAssignmentStreamId()
 		Stream stream = streamService.getStream(streamId)
 		if (stream == null) {
+			EthereumAddress nodeAddress = EthereumAddress.fromPrivateKey(ApplicationConfig.getString("streamr.ethereum.nodePrivateKey"))
 			User nodeUser = ethereumIntegrationKeyService.getOrCreateFromEthereumAddress(nodeAddress.toString(), SignupMethod.UNKNOWN)
 			stream = streamService.createStream(new CreateStreamCommand(id: streamId), nodeUser, null)
 			permissionService.systemGrantAnonymousAccess(stream, Permission.Operation.STREAM_GET)

--- a/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
+++ b/grails-app/services/com/unifina/service/DataUnionJoinRequestService.groovy
@@ -8,7 +8,7 @@ import com.unifina.domain.*
 import com.unifina.utils.ThreadUtil
 import groovy.json.JsonSlurper
 import org.apache.log4j.Logger
-import com.unifina.utils.MapTraversal
+import com.unifina.utils.ApplicationConfig
 import grails.util.Holders
 
 class DataUnionJoinRequestService {
@@ -251,7 +251,7 @@ class DataUnionJoinRequestService {
 	}
 
 	DataUnionClient getClient() {
-		String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
+		String nodePrivateKey = ApplicationConfig.getString("streamr.ethereum.nodePrivateKey")
 		return streamrClientService.getInstanceForThisEngineNode().dataUnionClient(nodePrivateKey, nodePrivateKey)
 	}
 

--- a/grails-app/services/com/unifina/service/KeyValueStoreService.groovy
+++ b/grails-app/services/com/unifina/service/KeyValueStoreService.groovy
@@ -4,6 +4,7 @@ import com.lambdaworks.redis.RedisAsyncConnection
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisURI
 import com.unifina.utils.MapTraversal
+import com.unifina.utils.ApplicationConfig
 import grails.util.Holders
 import org.springframework.util.Assert
 
@@ -31,7 +32,7 @@ class KeyValueStoreService {
 	private synchronized RedisAsyncConnection<String, String> getConnection() {
 		if (connection == null) {
 			List<String> hosts = MapTraversal.getList(Holders.getConfig(), "streamr.redis.hosts");
-			String password = MapTraversal.getString(Holders.getConfig(), "streamr.redis.password");
+			String password = ApplicationConfig.getString("streamr.redis.password");
 
 			Assert.notNull(hosts, "streamr.redis.hosts is null!")
 			Assert.notEmpty(hosts, "streamr.redis.hosts is empty!")

--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -15,6 +15,7 @@ enum AssigmentEvent {
 @GrailsCompileStatic
 class StorageNodeService {
 
+	StreamService streamService
 	StreamrClientService streamrClientService
 
 	List<Stream> findStreamsByStorageNode(EthereumAddress storageNodeAddress) {
@@ -63,15 +64,15 @@ class StorageNodeService {
 	}
 
 	private notifyStorageNode(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType) {
-		StreamrClient client = streamrClientService.getInstanceForThisEngineNode()
-		com.streamr.client.rest.Stream stream = client.getStream(StorageNodeService.createAssignmentStreamId())
 		Map<String,Object> message = new LinkedHashMap([
 			event: eventType.name(),
 			stream: [
-				id: stream.getId(),
-				partitions: stream.getPartitions()
+				id: streamId,
+				partitions: streamService.getStream(streamId).partitions
 			]
 		])
-		client.publish(stream, message)
+		StreamrClient client = streamrClientService.getInstanceForThisEngineNode()
+		com.streamr.client.rest.Stream assignmentStream = client.getStream(StorageNodeService.createAssignmentStreamId())
+		client.publish(assignmentStream, message)
 	}
 }

--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -1,12 +1,21 @@
 package com.unifina.service
 
+import com.streamr.client.StreamrClient
 import com.unifina.domain.Stream
 import com.unifina.domain.StreamStorageNode
 import com.unifina.domain.EthereumAddress
+import com.unifina.utils.ApplicationConfig
 import grails.compiler.GrailsCompileStatic
+
+enum AssigmentEvent {
+	STREAM_ADDED,
+	STREAM_REMOVED
+}
 
 @GrailsCompileStatic
 class StorageNodeService {
+
+	StreamrClientService streamrClientService
 
 	List<Stream> findStreamsByStorageNode(EthereumAddress storageNodeAddress) {
 		List<StreamStorageNode> items = StreamStorageNode.findAllByStorageNodeAddress(storageNodeAddress.toString())
@@ -30,7 +39,9 @@ class StorageNodeService {
 				streamId: streamId,
 				storageNodeAddress: storageNodeAddress.toString()
 			)
-			return instance.save(validate: true)
+			StreamStorageNode saved = instance.save(validate: true)
+			notifyStorageNode(storageNodeAddress, streamId, AssigmentEvent.STREAM_ADDED)
+			return saved;
 		} else {
 			throw new DuplicateNotAllowedException("StorageNode", storageNodeAddress.toString())
 		}
@@ -40,8 +51,27 @@ class StorageNodeService {
 		StreamStorageNode instance = StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress.toString(), streamId)
 		if (instance != null) {
 			instance.delete()
+			notifyStorageNode(storageNodeAddress, streamId, AssigmentEvent.STREAM_REMOVED)
 		} else {
 			throw new NotFoundException("StorageNode", storageNodeAddress.toString())
 		}
+	}
+
+	public static String createAssignmentStreamId() {
+		EthereumAddress nodeAddress = EthereumAddress.fromPrivateKey(ApplicationConfig.getString("streamr.ethereum.nodePrivateKey"))
+		return nodeAddress.toString() + "/storage-node-assignments"
+	}
+
+	private notifyStorageNode(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType) {
+		StreamrClient client = streamrClientService.getInstanceForThisEngineNode()
+		com.streamr.client.rest.Stream stream = client.getStream(StorageNodeService.createAssignmentStreamId())
+		Map<String,Object> message = new LinkedHashMap([
+			event: eventType.name(),
+			stream: [
+				id: stream.getId(),
+				partitions: stream.getPartitions()
+			]
+		])
+		client.publish(stream, message)
 	}
 }

--- a/grails-app/services/com/unifina/service/StreamrClientService.groovy
+++ b/grails-app/services/com/unifina/service/StreamrClientService.groovy
@@ -10,9 +10,8 @@ import com.streamr.client.options.StreamrClientOptions
 import com.unifina.domain.IntegrationKey
 import com.unifina.domain.SignupMethod
 import com.unifina.domain.User
-import com.unifina.utils.MapTraversal
 import com.unifina.utils.PrivateKeyGenerator
-import grails.util.Holders
+import com.unifina.utils.ApplicationConfig
 import org.apache.log4j.Logger
 
 import java.lang.reflect.Constructor
@@ -101,7 +100,7 @@ class StreamrClientService {
 		if (instanceForThisEngineNodeLock.tryLock(3L, TimeUnit.SECONDS)) {
 			try {
 				if (!instanceForThisEngineNode) {
-					String nodePrivateKey = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.nodePrivateKey")
+					String nodePrivateKey = ApplicationConfig.getString("streamr.ethereum.nodePrivateKey")
 					log.debug("Creating StreamrClient instance for this Engine node. Using private key ${nodePrivateKey?.substring(0, 2)}...")
 
 					// Create a custom EthereumAuthenticationMethod which doesn't call the API, but instead uses the internal services to
@@ -123,8 +122,8 @@ class StreamrClientService {
 	}
 
 	private StreamrClient createInstance(AuthenticationMethod authenticationMethod) {
-		String websocketUrl = MapTraversal.getString(Holders.getConfig(), "streamr.api.websocket.url")
-		String restUrl = MapTraversal.getString(Holders.getConfig(), "streamr.api.http.url")
+		String websocketUrl = ApplicationConfig.getString("streamr.api.websocket.url")
+		String restUrl = ApplicationConfig.getString("streamr.api.http.url")
 		log.info(String.format("Creating StreamrClient instance. Websocket: %s, REST: %s", websocketUrl, restUrl))
 
 		StreamrClientOptions options = new StreamrClientOptions(
@@ -134,10 +133,10 @@ class StreamrClientService {
 			websocketUrl,
 			restUrl
 		)
-		options.setMainnetRpcUrl(MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks.local"))
-		options.setSidechainRpcUrl(MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks.sidechain"))
-		options.setDataUnionMainnetFactoryAddress(MapTraversal.getString(Holders.getConfig(), "streamr.dataunion.mainnet.factory.address"))
-		options.setDataUnionSidechainFactoryAddress(MapTraversal.getString(Holders.getConfig(), "streamr.dataunion.sidechain.factory.address"))
+		options.setMainnetRpcUrl(ApplicationConfig.getString("streamr.ethereum.networks.local"))
+		options.setSidechainRpcUrl(ApplicationConfig.getString("streamr.ethereum.networks.sidechain"))
+		options.setDataUnionMainnetFactoryAddress(ApplicationConfig.getString("streamr.dataunion.mainnet.factory.address"))
+		options.setDataUnionSidechainFactoryAddress(ApplicationConfig.getString("streamr.dataunion.sidechain.factory.address"))
 		return clientConstructor.newInstance(options)
 	}
 }

--- a/src/groovy/com/unifina/domain/EthereumAddress.groovy
+++ b/src/groovy/com/unifina/domain/EthereumAddress.groovy
@@ -4,6 +4,8 @@ import org.web3j.crypto.Keys
 import com.unifina.service.ValidationException
 import grails.compiler.GrailsCompileStatic
 import groovy.transform.EqualsAndHashCode
+import org.apache.commons.codec.binary.Hex
+import org.ethereum.crypto.ECKey
 
 @GrailsCompileStatic
 @EqualsAndHashCode
@@ -19,5 +21,12 @@ class EthereumAddress {
 
 	public String toString() {
 		return value
+	}
+
+	static EthereumAddress fromPrivateKey(String privateKey) {
+		BigInteger pk = new BigInteger(privateKey, 16)
+		ECKey key = ECKey.fromPrivate(pk)
+		String publicKey = "0x" + Hex.encodeHexString(key.getAddress())
+		return new EthereumAddress(publicKey)
 	}
 }

--- a/src/groovy/com/unifina/domain/EthereumAddress.groovy
+++ b/src/groovy/com/unifina/domain/EthereumAddress.groovy
@@ -4,12 +4,14 @@ import org.web3j.crypto.Keys
 import com.unifina.service.ValidationException
 import grails.compiler.GrailsCompileStatic
 import groovy.transform.EqualsAndHashCode
-import org.apache.commons.codec.binary.Hex
-import org.ethereum.crypto.ECKey
+import org.web3j.crypto.Sign
+import org.web3j.utils.Numeric
 
 @GrailsCompileStatic
 @EqualsAndHashCode
 class EthereumAddress {
+	private static final String PREFIX = "0x"
+
 	private String value
 
 	EthereumAddress(String value) {
@@ -24,9 +26,12 @@ class EthereumAddress {
 	}
 
 	static EthereumAddress fromPrivateKey(String privateKey) {
+		if (privateKey.startsWith(PREFIX)) {
+			privateKey = privateKey.substring(PREFIX.length())
+		}
 		BigInteger pk = new BigInteger(privateKey, 16)
-		ECKey key = ECKey.fromPrivate(pk)
-		String publicKey = "0x" + Hex.encodeHexString(key.getAddress())
-		return new EthereumAddress(publicKey)
+		BigInteger publicKey = Sign.publicKeyFromPrivate(pk);
+		String address = Keys.getAddress(publicKey);
+		return new EthereumAddress(Numeric.prependHexPrefix(address));
 	}
 }

--- a/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumModuleOptions.java
@@ -3,6 +3,7 @@ package com.unifina.signalpath.blockchain;
 import com.unifina.signalpath.ModuleOption;
 import com.unifina.signalpath.ModuleOptions;
 import com.unifina.utils.MapTraversal;
+import com.unifina.utils.ApplicationConfig;
 import grails.util.Holders;
 import org.apache.log4j.Logger;
 import org.web3j.protocol.Web3j;
@@ -15,7 +16,7 @@ import java.util.Map;
 public class EthereumModuleOptions implements Serializable {
 	private static final Logger log = Logger.getLogger(EthereumModuleOptions.class);
 
-	private String network = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.defaultNetwork");
+	private String network = ApplicationConfig.getString("streamr.ethereum.defaultNetwork");
 	private double gasPriceWei = 20e9; // 20 Gwei
 	private int gasLimit = 6000000;
 
@@ -98,7 +99,7 @@ public class EthereumModuleOptions implements Serializable {
 	}
 
 	public String getRpcUrl() {
-		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.networks." + network);
+		String url = ApplicationConfig.getString("streamr.ethereum.networks." + network);
 		if (url == null) {
 			throw new RuntimeException("No rpcUrl found for Ethereum network " + network);
 		}
@@ -106,7 +107,7 @@ public class EthereumModuleOptions implements Serializable {
 	}
 
 	public String getWebsocketRpcUri() {
-		String url = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.wss." + network);
+		String url = ApplicationConfig.getString("streamr.ethereum.wss." + network);
 		if (url == null) {
 			log.warn("No websockets URI found for Ethereum network " + network);
 		}

--- a/src/java/com/unifina/signalpath/blockchain/Web3jHelper.java
+++ b/src/java/com/unifina/signalpath/blockchain/Web3jHelper.java
@@ -2,6 +2,7 @@ package com.unifina.signalpath.blockchain;
 
 import com.unifina.utils.MapTraversal;
 import com.unifina.utils.ThreadUtil;
+import com.unifina.utils.ApplicationConfig;
 import grails.util.Holders;
 import org.apache.log4j.Logger;
 import org.web3j.abi.EventValues;
@@ -288,7 +289,7 @@ public class Web3jHelper {
 	public static String getENSDomainOwner(String domain) throws BlockchainException {
 		Web3j web3j = Web3jHelper.getWeb3jConnectionFromConfig();
 		TransactionManager transactionManager = new ClientTransactionManager(web3j, null);
-		String ensContractAddress = MapTraversal.getString(Holders.getConfig(), "streamr.ethereum.ensRegistryContractAddress");
+		String ensContractAddress = ApplicationConfig.getString("streamr.ethereum.ensRegistryContractAddress");
 		ENS ensRegistry = ENS.load(ensContractAddress, web3j, transactionManager, new DefaultGasProvider());
 		byte[] nameHash = NameHash.nameHashAsBytes(domain);
 		String contractAddress = send(ensRegistry.owner(nameHash));

--- a/src/java/com/unifina/utils/ApplicationConfig.groovy
+++ b/src/java/com/unifina/utils/ApplicationConfig.groovy
@@ -1,0 +1,12 @@
+package com.unifina.utils
+
+import grails.util.Holders
+import grails.compiler.GrailsCompileStatic
+import groovy.transform.EqualsAndHashCode
+
+@GrailsCompileStatic
+class ApplicationConfig {
+    static String getString(String key) {
+        return MapTraversal.getString(Holders.getConfig(), key)
+    }
+}

--- a/test/integration/com/unifina/service/KeyValueStoreServiceIntegrationSpec.groovy
+++ b/test/integration/com/unifina/service/KeyValueStoreServiceIntegrationSpec.groovy
@@ -4,6 +4,7 @@ import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnection
 import com.lambdaworks.redis.RedisURI
 import com.unifina.utils.MapTraversal
+import com.unifina.utils.ApplicationConfig
 import grails.util.Holders
 import org.joda.time.DateTime
 import org.springframework.util.Assert
@@ -17,7 +18,7 @@ class KeyValueStoreServiceIntegrationSpec extends Specification {
 		service = Holders.getApplicationContext().getBean(KeyValueStoreService)
 
 		List<String> hosts = MapTraversal.getList(Holders.getConfig(), "streamr.redis.hosts");
-		String password = MapTraversal.getString(Holders.getConfig(), "streamr.redis.password");
+		String password = ApplicationConfig.getString("streamr.redis.password");
 
 		Assert.notNull(hosts, "streamr.redis.hosts is null!")
 		Assert.notEmpty(hosts, "streamr.redis.hosts is empty!")

--- a/test/unit/com/unifina/domain/EthereumAddressSpec.groovy
+++ b/test/unit/com/unifina/domain/EthereumAddressSpec.groovy
@@ -18,4 +18,13 @@ class EthereumAddressSpec extends Specification {
 		address1.equals(address2)
 		address1.hashCode() == address2.hashCode()
 	}
+
+	void "fromPrivateKey"() {
+		when:
+		EthereumAddress address1 = EthereumAddress.fromPrivateKey('0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF')
+		EthereumAddress address2 = EthereumAddress.fromPrivateKey('0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF')
+		then:
+		address1.toString() == "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c"
+		address2.toString() == "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c"
+	}
 }


### PR DESCRIPTION
Sends an event to a separate event stream when a streams is added to a storage node (or removed from a storage node).

All events are sent to the same stream (${EE_address}/storage-node-assignments`), and the stream is created when the application starts, if needed. 