### PR TITLE
BACK-129: remove empty streams array from Product list

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5155,7 +5155,6 @@
         "name",
         "description",
         "category",
-        "streams",
         "ownerAddress",
         "beneficiaryAddress",
         "pricePerSecond",

--- a/grails-app/domain/com/unifina/domain/Product.groovy
+++ b/grails-app/domain/com/unifina/domain/Product.groovy
@@ -152,7 +152,6 @@ class Product {
 			imageUrl: imageUrl,
 			thumbnailUrl: thumbnailUrl,
 			category: category?.id,
-			streams: [],
 			state: state.toString(),
 			previewStream: previewStream?.id,
 			previewConfigJson: previewConfigJson,

--- a/rest-e2e-tests/schemas/product.json
+++ b/rest-e2e-tests/schemas/product.json
@@ -10,7 +10,6 @@
     "description",
     "imageUrl",
     "category",
-    "streams",
     "state",
     "previewStream",
     "previewConfigJson",
@@ -115,15 +114,23 @@
     "ownerAddress": {
       "description": "Ethereum address of product owner",
       "oneOf": [
-        { "type": "null" },
-        { "$ref": "#/definitions/ethereumAddress" }
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/ethereumAddress"
+        }
       ]
     },
     "beneficiaryAddress": {
       "description": "Ethereum address of beneficiary",
       "oneOf": [
-        { "type": "null" },
-        { "$ref": "#/definitions/ethereumAddress" }
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/ethereumAddress"
+        }
       ]
     },
     "isFree": {
@@ -163,60 +170,90 @@
     },
     "contact": {
       "description": "Product's contact details",
-      "type": [ "object", "null" ],
+      "type": [
+        "object",
+        "null"
+      ],
       "properties": {
         "email": {
           "description": "Product's email addresss.",
           "oneOf": [
-            { "type": "null" },
-            { "$ref": "#/definitions/emailAddress" }
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/emailAddress"
+            }
           ]
         },
         "url": {
           "description": "Product's url address for contact.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         },
         "social1": {
           "description": "Product's social media link 1.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         },
         "social2": {
           "description": "Product's social media link 2.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         },
         "social3": {
           "description": "Product's social media link 3.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         },
         "social4": {
           "description": "Product's social media link 4.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         }
       }
     },
     "termsOfUse": {
       "description": "Product's legal terms of use.",
-      "type": [ "object", "null" ],
+      "type": [
+        "object",
+        "null"
+      ],
       "properties": {
         "commercialUse": {
           "description": "Terms of use for commercial use.",
@@ -242,16 +279,24 @@
           "description": "Name of the custom terms of use document's link.",
           "maxLength": 100,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         },
         "termsUrl": {
           "description": "URL address for custom terms of use document.",
           "maxLength": 2048,
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
           ]
         }
       }
@@ -259,8 +304,12 @@
     "dataUnionVersion": {
       "description": "Data Union version",
       "oneOf": [
-        { "type": "null" },
-        { "type": "number" }
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
       ]
     }
   },


### PR DESCRIPTION
In the "summary" rendering of `Product` (as output by the list endpoint), there was a `streams` array which was hard-coded to an empty array for whatever old reason.

These are just quick, minimal changes to clean it up. If someone wants to take over and improve the docs, feel free to add to this PR. I just removed it as a required field from the swagger spec.

Cc @juhah, risk of frontend starting to fail validation of `Product` objects due to the missing `streams` field.