### PR TITLE
Update end-to-end tests to use JS-client v5.x

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4858,7 +4858,7 @@
         "id": {
           "type": "integer",
           "description": "Unique identifier for this permission object",
-          "example": "3"
+          "example": 3
         },
         "user": {
           "type": "string",

--- a/rest-e2e-tests/categories-api.test.ts
+++ b/rest-e2e-tests/categories-api.test.ts
@@ -1,12 +1,13 @@
 import { assert } from 'chai'
 import Streamr from './streamr-api-clients'
 import { SchemaValidator } from './schema-validator'
+import { Response } from 'node-fetch'
 
 const schemaValidator = new SchemaValidator()
 
 describe('Categories API', () => {
     describe('GET /api/v1/categories', () => {
-        let response: any
+        let response: Response
         let json: any
 
         before(async () => {

--- a/rest-e2e-tests/notfound-api.test.ts
+++ b/rest-e2e-tests/notfound-api.test.ts
@@ -1,19 +1,20 @@
 import { assert } from 'chai'
-const StreamrClient = require('streamr-client')
+import { StreamrClient } from 'streamr-client'
 import Streamr from './streamr-api-clients'
+import { Response } from 'node-fetch'
 
 describe('REST API', function() {
 
     const testUser = StreamrClient.generateEthereumAccount()
 
     describe('GET /api/v1/page-not-found', function() {
-        const assertContentLengthIsZero = async function (response: any) {
+        const assertContentLengthIsZero = async function (response: Response) {
             const body = await response.text()
             const bodyLenBytes = body.length
             assert.equal(bodyLenBytes, 0)
 
             const cl = response.headers.get('Content-Length')
-            assert.equal(cl, 0)
+            assert.equal(cl, '0')
         }
         it('anonymous access responds with 404', async () => {
             const response = await Streamr.api.v1.not_found.notFound().call()

--- a/rest-e2e-tests/package-lock.json
+++ b/rest-e2e-tests/package-lock.json
@@ -5,164 +5,62 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+      "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-      "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.13.tgz",
+      "integrity": "sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==",
       "requires": {
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
-      "integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz",
+      "integrity": "sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/web": "^5.0.6"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/rlp": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4"
-          }
-        }
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/networks": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/web": "^5.0.12"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
-      "integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz",
+      "integrity": "sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7"
       }
     },
     "@ethersproject/address": {
@@ -221,441 +119,183 @@
       }
     },
     "@ethersproject/base64": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.4.tgz",
-      "integrity": "sha512-4KRykQ7BQMeOXfvio1YITwHjxwBzh92UoXIdzxDE1p53CK28bbHPdsPNYo0wl0El7lJAMpT2SOdL0hhbWRnyIA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.9.tgz",
+      "integrity": "sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.4.tgz",
-      "integrity": "sha512-ixIr/kKiAoSzOnSc777AGIOAhKai5Ivqr4HO/Gz+YG+xkfv6kqD6AW4ga9vM20Wwb0QBhh3LoRWTu4V1K+x9Ew==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.9.tgz",
+      "integrity": "sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/properties": "^5.0.3"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/properties": "^5.0.7"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
-      "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+      "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
         "bn.js": "^4.4.0"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
-      "integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+      "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
       "requires": {
-        "@ethersproject/logger": "^5.0.0"
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
-      "integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+      "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bignumber": "^5.0.13"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.3.tgz",
-      "integrity": "sha512-60H7UJx6qsp3JP5q3jFjzVNGUygRfz+XzfRwx/VeCKjHBUpFxPEIO2S30SMjYKPqw6JsgxbOjxFFZgOfQiNesw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.12.tgz",
+      "integrity": "sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==",
       "requires": {
-        "@ethersproject/abi": "^5.0.3",
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/abi": "^5.0.10",
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
-      "integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.12.tgz",
+      "integrity": "sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.6",
-        "@ethersproject/address": "^5.0.5",
-        "@ethersproject/bignumber": "^5.0.8",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.4",
-        "@ethersproject/strings": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.5.tgz",
-      "integrity": "sha512-Ho4HZaK+KijE5adayvjAGusWMnT0mgwGa5hGMBofBOgX9nqiKf6Wxx68SXBGI1/L3rmKo6mlAjxUd8gefs0teQ==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.10.tgz",
+      "integrity": "sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/wordlists": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/rlp": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4"
-          }
-        }
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/basex": "^5.0.7",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/pbkdf2": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8",
+        "@ethersproject/strings": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/wordlists": "^5.0.8"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.7.tgz",
-      "integrity": "sha512-dgOn9JtGgjT28mDXs4LYY2rT4CzS6bG/rxoYuPq3TLHIf6nmvBcr33Fee6RrM/y8UAx4gyIkf6wb2cXsOctvQQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz",
+      "integrity": "sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hdnode": "^5.0.8",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/pbkdf2": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/random": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/rlp": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4"
-          }
-        }
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
-      "integrity": "sha512-GNpiOUm9PGUxFNqOxYKDQBM0u68bG9XC9iOulEQ8I0tOx/4qUpgVzvgXL6ugxr0RY554Gz/NQsVqknqPzUcxpQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+      "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/bytes": "^5.0.9",
         "js-sha3": "0.5.7"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
-      "integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+      "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
     },
     "@ethersproject/networks": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
-      "integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.9.tgz",
+      "integrity": "sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==",
       "requires": {
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.4.tgz",
-      "integrity": "sha512-9jVBjHXQKfr9+3bkCg01a8Cd1H9e+7Kw3ZMIvAxD0lZtuzrXsJxm1hVwY9KA+PRUvgS/9tTP4viXQYwLAax7zg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz",
+      "integrity": "sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/sha2": "^5.0.3"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/sha2": "^5.0.7"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
-      "integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+      "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
       "requires": {
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.14.tgz",
-      "integrity": "sha512-K9QRRkkHWyprm3g4L8U9aPx5uyivznL4RYemkN2shCQumyGqFJ5SO+OtQrgebVm0JpGwFAUGugnhRUh49sjErw==",
+      "version": "5.0.24",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.24.tgz",
+      "integrity": "sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/web": "^5.0.6",
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/basex": "^5.0.7",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/networks": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/random": "^5.0.7",
+        "@ethersproject/rlp": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/web": "^5.0.12",
         "bech32": "1.1.4",
         "ws": "7.2.3"
       },
       "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/rlp": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4"
-          }
-        },
         "ws": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -664,61 +304,33 @@
       }
     },
     "@ethersproject/random": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.4.tgz",
-      "integrity": "sha512-AIZJhqs6Ba4/+U3lOjt3QZbP6b/kuuGLJUYFUonAgWmkTHwqsCwYnFvnHKQSUuHbXHvErp7WFXFlztx+yMn3kQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.9.tgz",
+      "integrity": "sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.4.tgz",
-      "integrity": "sha512-5qrrZad7VTjofxSsm7Zg/7Dr4ZOln4S2CqiDdOuTv6MBKnXj0CiBojXyuDy52M8O3wxH0CyE924hXWTDV1PQWQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+      "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
-      "integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.9.tgz",
+      "integrity": "sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
         "hash.js": "1.1.3"
       },
       "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -731,132 +343,62 @@
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.5.tgz",
-      "integrity": "sha512-Z1wY7JC1HVO4CvQWY2TyTTuAr8xK3bJijZw1a9G92JEmKdv1j255R/0YLBBcFTl2J65LUjtXynNJ2GbArPGi5g==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.11.tgz",
+      "integrity": "sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "elliptic": "6.5.3"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "elliptic": "6.5.4"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.5.tgz",
-      "integrity": "sha512-DMFQ0ouXmNVoKWbGEUFGi8Urli4SJip9jXafQyFHWPRr5oJUqDVkNfwcyC37k+mhBG93k7qrYXCH2xJnGEOxHg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.10.tgz",
+      "integrity": "sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
-      "integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+      "integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.4.tgz",
-      "integrity": "sha512-QvS5CzxmL46D9Y3OlddurYgEIi5mb0eAgrKm5pM074Uz/1qxCYr+Ah12I4hpaciZtCq4Fe12YWZqUFb1vGcH6Q==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.11.tgz",
+      "integrity": "sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==",
       "requires": {
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/rlp": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8"
       }
     },
     "@ethersproject/units": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.6.tgz",
-      "integrity": "sha512-tsJuy4mipppdmooukRfhXt8fGx9nxvfvG6Xdy0RDm7LzHsjghjwQ69m2bCpId6SDSR1Uq1cQ9irPiUBSyWolUA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.11.tgz",
+      "integrity": "sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8"
       }
     },
     "@ethersproject/wallet": {
@@ -1160,57 +702,37 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
-      "integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.14.tgz",
+      "integrity": "sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==",
       "requires": {
-        "@ethersproject/base64": "^5.0.3",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/base64": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.5.tgz",
-      "integrity": "sha512-XA3ycFltVrCTQt04w5nHu3Xq5Z6HjqWsXaAYQHFdqtugyUsIumaO9S5MOwFFuUYTNkZUoT3jCRa/OBS+K4tLfA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.10.tgz",
+      "integrity": "sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        }
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
       }
     },
     "@peculiar/asn1-schema": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.25.tgz",
-      "integrity": "sha512-Tl+pYpcfj8awiRS6J8NRnLMNz67Z3Qq2vEXMDT+CgYcMoUcrnKnDjK+qM4/mq1sHOPrZX+NLwJ4IVq2i4YLKkQ==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
+      "integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
       "requires": {
-        "@types/asn1js": "^0.0.2",
+        "@types/asn1js": "^2.0.0",
         "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.15",
+        "pvtsutils": "^1.1.1",
         "tslib": "^2.0.3"
       }
     },
@@ -1223,12 +745,9 @@
       }
     },
     "@types/asn1js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.2.tgz",
-      "integrity": "sha512-xtLPq140WhPqvDZDpY70rTx4qTezHs+8htbhWQGuevBRQko8FRjFSO5WVTwXOwd3W5tQRxJ7eni30fDUP2q4wQ==",
-      "requires": {
-        "@types/pvutils": "*"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
+      "integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
     },
     "@types/chai": {
       "version": "4.2.15",
@@ -1269,11 +788,6 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
-    },
-    "@types/pvutils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
-      "integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1330,11 +844,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "array-uniq": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
     },
     "arrify": {
       "version": "1.0.1",
@@ -1417,18 +926,27 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "bufferutil": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1538,27 +1056,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "connection-parse": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-      "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
-    },
-    "core-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-      "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA=="
-    },
     "core-js-pure": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.7.0.tgz",
-      "integrity": "sha512-EZD2ckZysv8MMt4J6HSvS9K2GdtlZtdBncKAmF9lr2n0c9dJUaUN88PSTjvgwCgQPWKTkERXITgS6JJRAnljtg=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
+      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A=="
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1585,17 +1093,17 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -1614,144 +1122,74 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "ethers": {
-      "version": "5.0.19",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.19.tgz",
-      "integrity": "sha512-0AZnUgZh98q888WAd1oI3aLeI+iyDtrupjANVtPPS7O63lVopkR/No8A1NqSkgl/rU+b2iuu2mUZor6GD4RG2w==",
+      "version": "5.0.32",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
+      "integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
       "requires": {
-        "@ethersproject/abi": "5.0.7",
-        "@ethersproject/abstract-provider": "5.0.5",
-        "@ethersproject/abstract-signer": "5.0.7",
-        "@ethersproject/address": "5.0.5",
-        "@ethersproject/base64": "5.0.4",
-        "@ethersproject/basex": "5.0.4",
-        "@ethersproject/bignumber": "5.0.8",
-        "@ethersproject/bytes": "5.0.5",
-        "@ethersproject/constants": "5.0.5",
-        "@ethersproject/contracts": "5.0.5",
-        "@ethersproject/hash": "5.0.6",
-        "@ethersproject/hdnode": "5.0.5",
-        "@ethersproject/json-wallets": "5.0.7",
-        "@ethersproject/keccak256": "5.0.4",
-        "@ethersproject/logger": "5.0.6",
-        "@ethersproject/networks": "5.0.4",
-        "@ethersproject/pbkdf2": "5.0.4",
-        "@ethersproject/properties": "5.0.4",
-        "@ethersproject/providers": "5.0.14",
-        "@ethersproject/random": "5.0.4",
-        "@ethersproject/rlp": "5.0.4",
-        "@ethersproject/sha2": "5.0.4",
-        "@ethersproject/signing-key": "5.0.5",
-        "@ethersproject/solidity": "5.0.5",
-        "@ethersproject/strings": "5.0.5",
-        "@ethersproject/transactions": "5.0.6",
-        "@ethersproject/units": "5.0.6",
-        "@ethersproject/wallet": "5.0.7",
-        "@ethersproject/web": "5.0.9",
-        "@ethersproject/wordlists": "5.0.5"
+        "@ethersproject/abi": "5.0.13",
+        "@ethersproject/abstract-provider": "5.0.10",
+        "@ethersproject/abstract-signer": "5.0.14",
+        "@ethersproject/address": "5.0.11",
+        "@ethersproject/base64": "5.0.9",
+        "@ethersproject/basex": "5.0.9",
+        "@ethersproject/bignumber": "5.0.15",
+        "@ethersproject/bytes": "5.0.11",
+        "@ethersproject/constants": "5.0.10",
+        "@ethersproject/contracts": "5.0.12",
+        "@ethersproject/hash": "5.0.12",
+        "@ethersproject/hdnode": "5.0.10",
+        "@ethersproject/json-wallets": "5.0.12",
+        "@ethersproject/keccak256": "5.0.9",
+        "@ethersproject/logger": "5.0.10",
+        "@ethersproject/networks": "5.0.9",
+        "@ethersproject/pbkdf2": "5.0.9",
+        "@ethersproject/properties": "5.0.9",
+        "@ethersproject/providers": "5.0.24",
+        "@ethersproject/random": "5.0.9",
+        "@ethersproject/rlp": "5.0.9",
+        "@ethersproject/sha2": "5.0.9",
+        "@ethersproject/signing-key": "5.0.11",
+        "@ethersproject/solidity": "5.0.10",
+        "@ethersproject/strings": "5.0.10",
+        "@ethersproject/transactions": "5.0.11",
+        "@ethersproject/units": "5.0.11",
+        "@ethersproject/wallet": "5.0.12",
+        "@ethersproject/web": "5.0.14",
+        "@ethersproject/wordlists": "5.0.10"
       },
       "dependencies": {
         "@ethersproject/address": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-          "integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
           "requires": {
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-          "integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-          "integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.0.5"
-          }
-        },
-        "@ethersproject/contracts": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.5.tgz",
-          "integrity": "sha512-tFI255lFbmbqMkgnuyhDWHl3yWqttPlReplYuVvDCT/SuvBjLR4ad2uipBlh1fh5X1ipK9ettAoV4S0HKim4Kw==",
-          "requires": {
-            "@ethersproject/abi": "^5.0.5",
-            "@ethersproject/abstract-provider": "^5.0.4",
-            "@ethersproject/abstract-signer": "^5.0.4",
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3"
-          }
-        },
-        "@ethersproject/sha2": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
-          "integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
-          "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "hash.js": "1.1.3"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-          "integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/rlp": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4"
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
           }
         },
         "@ethersproject/wallet": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.7.tgz",
-          "integrity": "sha512-n2GX1+2Tc0qV8dguUcLkjNugINKvZY7u/5fEsn0skW9rz5+jHTR5IKMV6jSfXA+WjQT8UCNMvkI3CNcdhaPbTQ==",
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.12.tgz",
+          "integrity": "sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.0.4",
-            "@ethersproject/abstract-signer": "^5.0.4",
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/hash": "^5.0.4",
-            "@ethersproject/hdnode": "^5.0.4",
-            "@ethersproject/json-wallets": "^5.0.6",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/random": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4",
-            "@ethersproject/transactions": "^5.0.5",
-            "@ethersproject/wordlists": "^5.0.4"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
+            "@ethersproject/abstract-provider": "^5.0.8",
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/hash": "^5.0.10",
+            "@ethersproject/hdnode": "^5.0.8",
+            "@ethersproject/json-wallets": "^5.0.10",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/random": "^5.0.7",
+            "@ethersproject/signing-key": "^5.0.8",
+            "@ethersproject/transactions": "^5.0.9",
+            "@ethersproject/wordlists": "^5.0.8"
           }
         }
       }
@@ -1862,15 +1300,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
-      "requires": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "he": {
@@ -1994,11 +1423,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
-    "lodash.uniqueid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
-      "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
-    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -2012,6 +1436,23 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+      "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
+      "requires": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      }
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
@@ -2024,6 +1465,11 @@
       "requires": {
         "mime-db": "1.44.0"
       }
+    },
+    "mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -2110,6 +1556,11 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
       "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
+    "node-abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.1.0.tgz",
+      "integrity": "sha512-dEYmUqjtbivotqjraOe8UvhT/poFfog1BQRNsZm/MSEDDESk2cQ1tvD8kGyuN07TM/zoW+n42odL8zTeJupYdQ=="
+    },
     "node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -2150,6 +1601,16 @@
         "wrappy": "1"
       }
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2164,6 +1625,43 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "requires": {
         "p-limit": "^3.0.2"
+      }
+    },
+    "p-memoize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.1.tgz",
+      "integrity": "sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==",
+      "requires": {
+        "mem": "^6.0.1",
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mem": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
+          "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
+          "requires": {
+            "map-age-cleaner": "^0.1.3",
+            "mimic-fn": "^3.0.0"
+          }
+        }
+      }
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -2202,11 +1700,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pvtsutils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.1.tgz",
-      "integrity": "sha512-Evbhe6L4Sxwu4SPLQ4LQZhgfWDQO3qa1lju9jM5cxsQp8vE10VipcSmo7hiJW48TmiHgVLgDtC2TL6/+ND+IVg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
+      "integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
       "requires": {
-        "tslib": "^2.0.3"
+        "tslib": "^2.1.0"
       }
     },
     "pvutils": {
@@ -2215,9 +1713,14 @@
       "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
+    "quick-lru": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.0.0.tgz",
+      "integrity": "sha512-kQ3ACYYIALMi7x8xvMU+qSF6N6baMZms8/q3dn2XFiORhFrLbpR6vTRNGR80HwlakWSoY4RnGoCJWUgnyH6zZQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -2227,12 +1730,14 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "randomstring": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz",
-      "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "array-uniq": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -2241,14 +1746,6 @@
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
       }
     },
     "regenerator-runtime": {
@@ -2300,17 +1797,12 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "sha3": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.3.tgz",
-      "integrity": "sha512-Io53D4o9qOmf3Ow9p/DoGLQiQHhtuR0ulbyambvRSG+OX5yXExk2yYfvjHtb7AtOyk6K6+sPeK/qaowWc/E/GA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
       "requires": {
-        "buffer": "5.6.0"
+        "buffer": "6.0.3"
       }
-    },
-    "simple-lru-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
     },
     "sleep-promise": {
       "version": "8.0.1",
@@ -2337,292 +1829,74 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "streamr-client": {
-      "version": "4.2.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.2.0-alpha.9.tgz",
-      "integrity": "sha512-YC09G45kF/W9hcvg+Dmk9dL83SLVnLhjc5CQCwvp5cYGpeoBgtw8bQgO23asw5x0nufqzHw4p18GpqVnD5eC/A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-5.1.0.tgz",
+      "integrity": "sha512-+RltKvWFF702V+gxzoS+MklAANBcGcURiR9DzHefBBy6H6++EBD8tSAML2qrGr2vBiLYIsYGRSQrlaNefNL33g==",
       "requires": {
-        "@babel/runtime": "^7.11.2",
-        "@ethersproject/address": "5.0.3",
-        "@ethersproject/bignumber": "5.0.6",
-        "@ethersproject/bytes": "5.0.3",
-        "@ethersproject/contracts": "5.0.3",
-        "@ethersproject/providers": "5.0.14",
-        "@ethersproject/sha2": "5.0.3",
-        "@ethersproject/transactions": "5.0.4",
-        "@ethersproject/wallet": "5.0.6",
-        "debug": "^4.1.1",
-        "ethers": "5.0.19",
+        "@babel/runtime": "^7.12.18",
+        "@babel/runtime-corejs3": "^7.12.18",
+        "@ethersproject/abi": "^5.0.12",
+        "@ethersproject/address": "^5.0.10",
+        "@ethersproject/bignumber": "^5.0.14",
+        "@ethersproject/bytes": "^5.0.10",
+        "@ethersproject/contracts": "^5.0.11",
+        "@ethersproject/keccak256": "^5.0.8",
+        "@ethersproject/providers": "^5.0.23",
+        "@ethersproject/sha2": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.10",
+        "@ethersproject/wallet": "^5.0.11",
+        "@ethersproject/web": "^5.0.13",
+        "bufferutil": "^4.0.3",
+        "debug": "^4.3.2",
         "eventemitter3": "^4.0.7",
-        "lodash.uniqueid": "^4.0.1",
+        "lodash": "^4.17.21",
+        "mem": "^8.0.0",
+        "node-abort-controller": "^1.1.0",
         "node-fetch": "^2.6.1",
-        "node-webcrypto-ossl": "^2.1.1",
+        "node-webcrypto-ossl": "^2.1.2",
         "once": "^1.4.0",
+        "p-limit": "^3.1.0",
+        "p-memoize": "^4.0.1",
+        "p-queue": "^6.6.2",
         "promise-memoize": "^1.2.1",
-        "qs": "^6.9.4",
-        "randomstring": "^1.1.5",
-        "receptacle": "^1.3.2",
-        "streamr-client-protocol": "^5.0.0",
-        "uuid": "^8.3.0",
+        "qs": "^6.9.6",
+        "quick-lru": "^6.0.0",
+        "readable-stream": "^3.6.0",
+        "streamr-client-protocol": "^8.0.0-beta.2",
+        "ts-toolbelt": "^9.3.12",
+        "utf-8-validate": "^5.0.4",
+        "uuid": "^8.3.2",
         "webpack-node-externals": "^2.5.2",
-        "ws": "^7.3.1"
+        "ws": "^7.4.3"
       },
       "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
-          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.6",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
-          },
-          "dependencies": {
-            "@ethersproject/bytes": {
-              "version": "5.0.10",
-              "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.10.tgz",
-              "integrity": "sha512-vpu0v1LZ1j1s9kERQIMnVU69MyHEzUff7nqK9XuCU4vx+AM8n9lU2gj7jtJIvGSt9HzatK/6I6bWusI5nyuaTA==",
-              "requires": {
-                "@ethersproject/logger": "^5.0.8"
-              },
-              "dependencies": {
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                }
-              }
-            }
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.0.9",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.9.tgz",
-          "integrity": "sha512-2uAKH89UcaJP/Sc+54u92BtJtZ4cPgcS1p0YbB1L3tlkavwNvth+kNCUplIB1Becqs7BOZr0B/3dMNjhJDy4Dg==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.0.13"
-          },
-          "dependencies": {
-            "@ethersproject/bignumber": {
-              "version": "5.0.14",
-              "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.14.tgz",
-              "integrity": "sha512-Q4TjMq9Gg3Xzj0aeJWqJgI3tdEiPiET7Y5OtNtjTAODZ2kp4y9jMNg97zVcvPedFvGROdpGDyCI77JDFodUzOw==",
-              "requires": {
-                "@ethersproject/bytes": "^5.0.9",
-                "@ethersproject/logger": "^5.0.8",
-                "bn.js": "^4.4.0"
-              }
-            },
-            "@ethersproject/bytes": {
-              "version": "5.0.10",
-              "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.10.tgz",
-              "integrity": "sha512-vpu0v1LZ1j1s9kERQIMnVU69MyHEzUff7nqK9XuCU4vx+AM8n9lU2gj7jtJIvGSt9HzatK/6I6bWusI5nyuaTA==",
-              "requires": {
-                "@ethersproject/logger": "^5.0.8"
-              }
-            },
-            "@ethersproject/logger": {
-              "version": "5.0.9",
-              "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-              "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-            }
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.6.tgz",
-          "integrity": "sha512-dRqx3+Degc5pvjaeeTHuk2EuTRM3b6ce/TiV0HRZhRXYnKyyjg0iYXEZo/b6p3rnV+Xhwxkc0+I/ISPkNpictA==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.0.4",
-            "@ethersproject/abstract-signer": "^5.0.4",
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/hash": "^5.0.4",
-            "@ethersproject/hdnode": "^5.0.4",
-            "@ethersproject/json-wallets": "^5.0.6",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/random": "^5.0.3",
-            "@ethersproject/signing-key": "^5.0.4",
-            "@ethersproject/transactions": "^5.0.5",
-            "@ethersproject/wordlists": "^5.0.4"
-          },
-          "dependencies": {
-            "@ethersproject/address": {
-              "version": "5.0.10",
-              "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.10.tgz",
-              "integrity": "sha512-70vqESmW5Srua1kMDIN6uVfdneZMaMyRYH4qPvkAXGkbicrCOsA9m01vIloA4wYiiF+HLEfL1ENKdn5jb9xiAw==",
-              "requires": {
-                "@ethersproject/bignumber": "^5.0.13",
-                "@ethersproject/bytes": "^5.0.9",
-                "@ethersproject/keccak256": "^5.0.7",
-                "@ethersproject/logger": "^5.0.8",
-                "@ethersproject/rlp": "^5.0.7"
-              },
-              "dependencies": {
-                "@ethersproject/keccak256": {
-                  "version": "5.0.8",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.8.tgz",
-                  "integrity": "sha512-zoGbwXcWWs9MX4NOAZ7N0hhgIRl4Q/IO/u9c/RHRY4WqDy3Ywm0OLamEV53QDwhjwn3YiiVwU1Ve5j7yJ0a/KQ==",
-                  "requires": {
-                    "@ethersproject/bytes": "^5.0.9",
-                    "js-sha3": "0.5.7"
-                  }
-                },
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                }
-              }
-            },
-            "@ethersproject/bignumber": {
-              "version": "5.0.14",
-              "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.14.tgz",
-              "integrity": "sha512-Q4TjMq9Gg3Xzj0aeJWqJgI3tdEiPiET7Y5OtNtjTAODZ2kp4y9jMNg97zVcvPedFvGROdpGDyCI77JDFodUzOw==",
-              "requires": {
-                "@ethersproject/bytes": "^5.0.9",
-                "@ethersproject/logger": "^5.0.8",
-                "bn.js": "^4.4.0"
-              },
-              "dependencies": {
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                }
-              }
-            },
-            "@ethersproject/bytes": {
-              "version": "5.0.10",
-              "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.10.tgz",
-              "integrity": "sha512-vpu0v1LZ1j1s9kERQIMnVU69MyHEzUff7nqK9XuCU4vx+AM8n9lU2gj7jtJIvGSt9HzatK/6I6bWusI5nyuaTA==",
-              "requires": {
-                "@ethersproject/logger": "^5.0.8"
-              },
-              "dependencies": {
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                }
-              }
-            },
-            "@ethersproject/rlp": {
-              "version": "5.0.8",
-              "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.8.tgz",
-              "integrity": "sha512-E4wdFs8xRNJfzNHmnkC8w5fPeT4Wd1U2cust3YeT16/46iSkLT8nn8ilidC6KhR7hfuSZE4UqSPzyk76p7cdZg==",
-              "requires": {
-                "@ethersproject/bytes": "^5.0.9",
-                "@ethersproject/logger": "^5.0.8"
-              },
-              "dependencies": {
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                }
-              }
-            },
-            "@ethersproject/transactions": {
-              "version": "5.0.10",
-              "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.10.tgz",
-              "integrity": "sha512-Tqpp+vKYQyQdJQQk4M73tDzO7ODf2D42/sJOcKlDAAbdSni13v6a+31hUdo02qYXhVYwIs+ZjHnO4zKv5BNk8w==",
-              "requires": {
-                "@ethersproject/address": "^5.0.9",
-                "@ethersproject/bignumber": "^5.0.13",
-                "@ethersproject/bytes": "^5.0.9",
-                "@ethersproject/constants": "^5.0.8",
-                "@ethersproject/keccak256": "^5.0.7",
-                "@ethersproject/logger": "^5.0.8",
-                "@ethersproject/properties": "^5.0.7",
-                "@ethersproject/rlp": "^5.0.7",
-                "@ethersproject/signing-key": "^5.0.8"
-              },
-              "dependencies": {
-                "@ethersproject/keccak256": {
-                  "version": "5.0.8",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.8.tgz",
-                  "integrity": "sha512-zoGbwXcWWs9MX4NOAZ7N0hhgIRl4Q/IO/u9c/RHRY4WqDy3Ywm0OLamEV53QDwhjwn3YiiVwU1Ve5j7yJ0a/KQ==",
-                  "requires": {
-                    "@ethersproject/bytes": "^5.0.9",
-                    "js-sha3": "0.5.7"
-                  }
-                },
-                "@ethersproject/logger": {
-                  "version": "5.0.9",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-                  "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
-                },
-                "@ethersproject/properties": {
-                  "version": "5.0.8",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.8.tgz",
-                  "integrity": "sha512-zEnLMze2Eu2VDPj/05QwCwMKHh506gpT9PP9KPVd4dDB+5d6AcROUYVLoIIQgBYK7X/Gw0UJmG3oVtnxOQafAw==",
-                  "requires": {
-                    "@ethersproject/logger": "^5.0.8"
-                  }
-                },
-                "@ethersproject/signing-key": {
-                  "version": "5.0.10",
-                  "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.10.tgz",
-                  "integrity": "sha512-w5it3GbFOvN6e0mTd5gDNj+bwSe6L9jqqYjU+uaYS8/hAEp4qYLk5p8ZjbJJkNn7u1p0iwocp8X9oH/OdK8apA==",
-                  "requires": {
-                    "@ethersproject/bytes": "^5.0.9",
-                    "@ethersproject/logger": "^5.0.8",
-                    "@ethersproject/properties": "^5.0.7",
-                    "elliptic": "6.5.4"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          }
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
     "streamr-client-protocol": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-5.3.1.tgz",
-      "integrity": "sha512-wEUlP/OCcmWv1A6e9xcd62Kyi8DkdLySuiHZlvETNsRzfQy6+c0C4C3avT04/dLdcvyD4B7zkvpMQCIKPrXRDQ==",
+      "version": "8.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-8.0.0-beta.2.tgz",
+      "integrity": "sha512-TwNkaBIQCyarkkTxpQuMBCu7Uqs0sH5CUK+/g6751J3ZL7VenZgv/dPRuQaatFDP5LboyRTo/qJxD+75TBfZBw==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.11.2",
-        "core-js": "^3.6.5",
-        "debug": "^4.2.0",
-        "ethers": "^5.0.14",
+        "@babel/runtime-corejs3": "^7.12.13",
+        "debug": "^4.3.1",
+        "ethers": "^5.0.24",
         "eventemitter3": "^4.0.7",
-        "hashring": "^3.2.0",
         "heap": "^0.2.6",
         "promise-memoize": "^1.2.1",
         "secp256k1": "^4.0.2",
-        "sha3": "^2.1.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
+        "sha3": "^2.1.3",
+        "strict-event-emitter-types": "^2.0.0"
       }
+    },
+    "strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2631,6 +1905,14 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -2707,6 +1989,11 @@
         }
       }
     },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -2720,9 +2007,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -2742,21 +2029,35 @@
         "punycode": "^2.1.0"
       }
     },
+    "utf-8-validate": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "webcrypto-core": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.1.8.tgz",
-      "integrity": "sha512-hKnFXsqh0VloojNeTfrwFoRM4MnaWzH6vtXcaFcGjPEu+8HmBdQZnps3/2ikOFqS8bJN1RYr6mI2P/FJzyZnXg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
+      "integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
       "requires": {
-        "@peculiar/asn1-schema": "^2.0.12",
+        "@peculiar/asn1-schema": "^2.0.27",
         "@peculiar/json-schema": "^1.1.12",
         "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.11",
-        "tslib": "^2.0.1"
+        "pvtsutils": "^1.1.2",
+        "tslib": "^2.1.0"
       }
     },
     "webpack-node-externals": {
@@ -2852,9 +2153,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -25,7 +25,7 @@
     "mocha": "8.2.1",
     "node-fetch": "2.6.1",
     "sleep-promise": "8.0.1",
-    "streamr-client": "4.2.0-alpha.9",
+    "streamr-client": "5.1.0",
     "ts-mocha": "8.0.0",
     "typescript": "4.1.5"
   },

--- a/rest-e2e-tests/permissions-api.stress-test.ts
+++ b/rest-e2e-tests/permissions-api.stress-test.ts
@@ -1,13 +1,13 @@
 import { assert } from 'chai'
 import Streamr from './streamr-api-clients'
-const StreamrClient = require('streamr-client')
+import { StreamrClient, Stream } from 'streamr-client'
 import { getStreamrClient } from './test-utilities'
 
 describe('POST /api/v1/streams/{id}/permissions', function() {
 
 	this.timeout(200 * 1000)
 
-	let stream: any
+	let stream: Stream
 	const me = StreamrClient.generateEthereumAccount()
 
 	before(async () => {

--- a/rest-e2e-tests/permissions-api.test.ts
+++ b/rest-e2e-tests/permissions-api.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import Streamr from './streamr-api-clients'
-const StreamrClient = require('streamr-client')
+import { StreamrClient, Stream, StreamPermision } from 'streamr-client'
 import { getSessionToken, getStreamrClient } from './test-utilities'
 
 describe('Permissions API', () => {
@@ -13,7 +13,7 @@ describe('Permissions API', () => {
     })
 
     describe('POST /api/v1/streams/{id}/permissions', () => {
-        let stream: any
+        let stream: Stream
 
         before(async () => {
             stream = await getStreamrClient(me).createStream({
@@ -55,7 +55,7 @@ describe('Permissions API', () => {
     })
 
     describe('DELETE /api/v1/streams/{streamId}/permissions/{permissionId}', function() {
-        let stream: any
+        let stream: Stream
 
         before(async function() {
             stream = await getStreamrClient(me).createStream({
@@ -85,7 +85,7 @@ describe('Permissions API', () => {
                 .call()
             const ownPermissions = await ownPermissionsResponse.json()
             assert.equal(ownPermissionsResponse.status, 200)
-            const sharePermission = ownPermissions.filter((permission: any) => permission.operation === 'stream_share')[0]
+            const sharePermission = ownPermissions.filter((permission: StreamPermision) => permission.operation === 'stream_share')[0]
 
             const response = await Streamr.api.v1.streams
                 .delete(stream.id, sharePermission.id)
@@ -101,9 +101,9 @@ describe('Permissions API', () => {
                 .call()
             const ownPermissions = await ownPermissionsResponse.json()
             assert.equal(ownPermissionsResponse.status, 200)
-            const permissionsToDelete = ownPermissions.filter((permission: any) => permission.operation !== 'stream_share')
+            const permissionsToDelete = ownPermissions.filter((permission: StreamPermision) => permission.operation !== 'stream_share')
 
-            permissionsToDelete.forEach(async function(permission: any) {
+            permissionsToDelete.forEach(async function(permission: StreamPermision) {
                 const response = await Streamr.api.v1.streams
                     .delete(stream.id, permission.id)
                     .withAuthenticatedUser(me)

--- a/rest-e2e-tests/products-api.test.ts
+++ b/rest-e2e-tests/products-api.test.ts
@@ -5,7 +5,8 @@ import Streamr from './streamr-api-clients'
 import { SchemaValidator } from './schema-validator'
 import { assertResponseIsError, getStreamrClient, testUsers } from './test-utilities'
 import { EthereumAccount } from './EthereumAccount'
-const StreamrClient = require('streamr-client')
+import { StreamrClient } from 'streamr-client'
+import { Response } from 'node-fetch'
 
 const schemaValidator = new SchemaValidator()
 
@@ -163,7 +164,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
 
             before(async () => {
                 response = await Streamr.api.v1.products
@@ -269,7 +270,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -363,7 +364,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -463,7 +464,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -561,7 +562,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -677,7 +678,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -774,7 +775,7 @@ describe('Products API', function() {
         })
 
         context('given Product in DEPLOYED state and having DevOps permission', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -896,7 +897,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -1000,7 +1001,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -1110,7 +1111,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
 
             before(async () => {
                 response = await Streamr.api.v1.products
@@ -1170,7 +1171,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
 
             before(async () => {
                 response = await Streamr.api.v1.products
@@ -1210,7 +1211,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, and headers', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -1291,7 +1292,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {
@@ -1390,7 +1391,7 @@ describe('Products API', function() {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {

--- a/rest-e2e-tests/storagenode-api.test.ts
+++ b/rest-e2e-tests/storagenode-api.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai'
 import Streamr from './streamr-api-clients'
 import _ from 'lodash';
-const StreamrClient = require('streamr-client')
+import { StreamrClient } from 'streamr-client'
 import { getStreamrClient, assertEqualEthereumAddresses } from './test-utilities'
 import { EthereumAccount } from './EthereumAccount';
 

--- a/rest-e2e-tests/streamr-api-clients.ts
+++ b/rest-e2e-tests/streamr-api-clients.ts
@@ -290,10 +290,10 @@ class Streams {
             .endpoint('streams', id, 'permissions', 'me')
     }
 
-    delete(streamId: string, permissionId: string) {
+    delete(streamId: string, permissionId: number) {
         return new StreamrApiRequest(this.options)
             .method('DELETE')
-            .endpoint('streams', streamId, 'permissions', permissionId)
+            .endpoint('streams', streamId, 'permissions', String(permissionId))
     }
 
     list(queryParams: any) {

--- a/rest-e2e-tests/streams-api.test.ts
+++ b/rest-e2e-tests/streams-api.test.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai'
 import Streamr from './streamr-api-clients'
 import { assertResponseIsError, assertStreamrClientResponseError, getStreamrClient, testUsers } from './test-utilities'
-const StreamrClient = require('streamr-client')
+import { StreamrClient } from 'streamr-client'
+import { Response } from 'node-fetch'
 
 describe('Streams API', () => {
 
@@ -40,7 +41,7 @@ describe('Streams API', () => {
                     fields: [
                         {
                             name: 'mock-field',
-                            type: 'string',
+                            type: <const> 'string',
                         },
                     ],
                 },
@@ -281,7 +282,7 @@ describe('Streams API', () => {
         })
 
         context('when called with valid body and permissions', () => {
-            let response: any
+            let response: Response
 
             before(async () => {
                 response = await Streamr.api.v1.streams

--- a/rest-e2e-tests/subscriptions-api.test.ts
+++ b/rest-e2e-tests/subscriptions-api.test.ts
@@ -3,7 +3,8 @@ import Streamr from './streamr-api-clients'
 import { SchemaValidator } from './schema-validator'
 import { assertResponseIsError, testUsers} from './test-utilities'
 import { EthereumAccount } from './EthereumAccount'
-const StreamrClient = require('streamr-client')
+import { StreamrClient } from 'streamr-client'
+import { Response } from 'node-fetch'
 
 const schemaValidator = new SchemaValidator()
 
@@ -194,7 +195,7 @@ describe('Subscriptions API', () => {
         })
 
         context('when called with valid params, body, headers, and permissions', () => {
-            let response: any
+            let response: Response
             let json: any
 
             before(async () => {


### PR DESCRIPTION
Updated test to be compatible with JS-client v5.x

Small fix to swagger documentation about permission.id