### PR TITLE
NET-193: Manual storage config in tests

### DIFF
--- a/rest-e2e-tests/canvas-api.stress-test.ts
+++ b/rest-e2e-tests/canvas-api.stress-test.ts
@@ -12,6 +12,9 @@ const WS_URL = 'ws://localhost/api/v1/ws'
 const TIMEOUT = 130 * 1000
 const NUM_MESSAGES = 50
 const WAIT_TIME = 15000
+// DEV storage node ("broker-node-storage-1" on streamr-docker-dev environment)
+const DEV_STORAGE_NODE_ADDRESS = '0xde1112f631486CfC759A50196853011528bC5FA0'
+const DEV_STORAGE_NODE_URL = 'http://10.200.10.1:8891'
 
 const pollCondition = async (condition: () => Promise<any>, timeout = TIMEOUT, interval = 100) => {
     let timeElapsed = 0
@@ -30,6 +33,10 @@ async function createStreamrClient(user: EthereumAccount) {
         restUrl: REST_URL,
         auth: {
             privateKey: user.privateKey,
+        },
+        storageNode: {
+            address: DEV_STORAGE_NODE_ADDRESS,
+            url: DEV_STORAGE_NODE_URL,
         },
     })
     await client.connect()
@@ -82,6 +89,10 @@ describe('Canvas API', function() {
 
         canvas = await canvasResponse.json()
         assert.equal(canvasResponse.status, 200, JSON.stringify(canvas))
+
+        const table = canvas.modules.find(({ name }: any) => name === 'Table')
+        const uiChannelStream = await streamrClient.getStream(table.uiChannel.id)
+        await uiChannelStream.addToStorageNode(DEV_STORAGE_NODE_ADDRESS)
     })
 
     after(async () => {

--- a/rest-e2e-tests/package-lock.json
+++ b/rest-e2e-tests/package-lock.json
@@ -22,45 +22,59 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.13.tgz",
-      "integrity": "sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.1.0.tgz",
+      "integrity": "sha512-N/W9Sbn1/C6Kh2kuHRjf/hX6euMK4+9zdJRBB8sDWmihVntjUAfxbusGZKzDQD8i3szAHhTz8K7XADV5iFNfJw==",
       "requires": {
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/hash": "^5.1.0",
+        "@ethersproject/keccak256": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        }
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz",
-      "integrity": "sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz",
+      "integrity": "sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/networks": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/web": "^5.0.12"
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/networks": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/transactions": "^5.1.0",
+        "@ethersproject/web": "^5.1.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz",
-      "integrity": "sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.1.0.tgz",
+      "integrity": "sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/abstract-provider": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0"
       }
     },
     "@ethersproject/address": {
@@ -119,183 +133,238 @@
       }
     },
     "@ethersproject/base64": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.9.tgz",
-      "integrity": "sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.1.0.tgz",
+      "integrity": "sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9"
+        "@ethersproject/bytes": "^5.1.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.9.tgz",
-      "integrity": "sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.1.0.tgz",
+      "integrity": "sha512-vBKr39bum7DDbOvkr1Sj19bRMEPA4FnST6Utt6xhDzI7o7L6QNkDn2yrCfP+hnvJGhZFKtLygWwqlTBZoBXYLg==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
-      "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.0.tgz",
+      "integrity": "sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
         "bn.js": "^4.4.0"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
-      "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
+      "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
-      "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
+      "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13"
+        "@ethersproject/bignumber": "^5.1.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.12.tgz",
-      "integrity": "sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.1.0.tgz",
+      "integrity": "sha512-dvTMs/4XGSc57cYOW0KjgX1NdTujUu7mNb6PQdJWg08m9ULzPyGZuBkFJnijBcp6vTOCQ59RwjboWgNWw393og==",
       "requires": {
-        "@ethersproject/abi": "^5.0.10",
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/abi": "^5.1.0",
+        "@ethersproject/abstract-provider": "^5.1.0",
+        "@ethersproject/abstract-signer": "^5.1.0",
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/transactions": "^5.1.0"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        }
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.12.tgz",
-      "integrity": "sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
+      "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/abstract-signer": "^5.1.0",
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/keccak256": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        }
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.10.tgz",
-      "integrity": "sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.1.0.tgz",
+      "integrity": "sha512-obIWdlujloExPHWJGmhJO/sETOOo7SEb6qemV4f8kyFoXg+cJK+Ta9SvBrj7hsUK85n3LZeZJZRjjM7oez3Clg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/basex": "^5.0.7",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/pbkdf2": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/signing-key": "^5.0.8",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/wordlists": "^5.0.8"
+        "@ethersproject/abstract-signer": "^5.1.0",
+        "@ethersproject/basex": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/pbkdf2": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/sha2": "^5.1.0",
+        "@ethersproject/signing-key": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0",
+        "@ethersproject/transactions": "^5.1.0",
+        "@ethersproject/wordlists": "^5.1.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz",
-      "integrity": "sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.1.0.tgz",
+      "integrity": "sha512-00n2iBy27w8zrGZSiU762UOVuzCQZxUZxopsZC47++js6xUFuI74DHcJ5K/2pddlF1YBskvmMuboEu1geK8mnA==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/hdnode": "^5.0.8",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/pbkdf2": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/random": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/abstract-signer": "^5.1.0",
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/hdnode": "^5.1.0",
+        "@ethersproject/keccak256": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/pbkdf2": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/random": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0",
+        "@ethersproject/transactions": "^5.1.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        }
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
-      "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
+      "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/bytes": "^5.1.0",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
-      "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
+      "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
     },
     "@ethersproject/networks": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.9.tgz",
-      "integrity": "sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.1.0.tgz",
+      "integrity": "sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz",
-      "integrity": "sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.1.0.tgz",
+      "integrity": "sha512-B8cUbHHTgs8OtgJIafrRcz/YPDobVd5Ru8gTnShOiM9EBuFpYHQpq3+8iQJ6pyczDu6HP/oc/njAsIBhwFZYew==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/sha2": "^5.0.7"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/sha2": "^5.1.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
-      "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
+      "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.24",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.24.tgz",
-      "integrity": "sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.1.0.tgz",
+      "integrity": "sha512-FjpZL2lSXrYpQDg2fMjugZ0HjQD9a+2fOOoRhhihh+Z+qi/xZ8vIlPoumrEP1DzIG4DBV6liUqLNqnX2C6FIAA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/basex": "^5.0.7",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/networks": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/random": "^5.0.7",
-        "@ethersproject/rlp": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/web": "^5.0.12",
+        "@ethersproject/abstract-provider": "^5.1.0",
+        "@ethersproject/abstract-signer": "^5.1.0",
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/basex": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/hash": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/networks": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/random": "^5.1.0",
+        "@ethersproject/rlp": "^5.1.0",
+        "@ethersproject/sha2": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0",
+        "@ethersproject/transactions": "^5.1.0",
+        "@ethersproject/web": "^5.1.0",
         "bech32": "1.1.4",
         "ws": "7.2.3"
       },
       "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        },
         "ws": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -304,30 +373,30 @@
       }
     },
     "@ethersproject/random": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.9.tgz",
-      "integrity": "sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.1.0.tgz",
+      "integrity": "sha512-+uuczLQZ4+no9cP6TCoCktXx0u2YbNaRT7lRkSt12d8263e702f0u+4JnnRO8Qmv5nylWJebnqCHzyxP+6mLqw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
-      "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
+      "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.9.tgz",
-      "integrity": "sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.1.0.tgz",
+      "integrity": "sha512-+fNSeZRstOpdRJpdGUkRONFCaiAqWkc91zXgg76Nlp5ndBQE25Kk5yK8gCPG1aGnCrbariiPr5j9DmrYH78JCA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
         "hash.js": "1.1.3"
       },
       "dependencies": {
@@ -343,62 +412,77 @@
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.11.tgz",
-      "integrity": "sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.1.0.tgz",
+      "integrity": "sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "bn.js": "^4.4.0",
         "elliptic": "6.5.4"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.10.tgz",
-      "integrity": "sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.1.0.tgz",
+      "integrity": "sha512-kPodsGyo9zg1g9XSXp1lGhFaezBAUUsAUB1Vf6OkppE5Wksg4Et+x3kG4m7J/uShDMP2upkJtHNsIBK2XkVpKQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/keccak256": "^5.1.0",
+        "@ethersproject/sha2": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
-      "integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
+      "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.11.tgz",
-      "integrity": "sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.1.0.tgz",
+      "integrity": "sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==",
       "requires": {
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/rlp": "^5.0.7",
-        "@ethersproject/signing-key": "^5.0.8"
+        "@ethersproject/address": "^5.1.0",
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/keccak256": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/rlp": "^5.1.0",
+        "@ethersproject/signing-key": "^5.1.0"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
+          }
+        }
       }
     },
     "@ethersproject/units": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.11.tgz",
-      "integrity": "sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.1.0.tgz",
+      "integrity": "sha512-isvJrx6qG0nKWfxsGORNjmOq/nh175fStfvRTA2xEKrGqx8JNJY83fswu4GkILowfriEM/eYpretfJnfzi7YhA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bignumber": "^5.1.0",
+        "@ethersproject/constants": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0"
       }
     },
     "@ethersproject/wallet": {
@@ -702,27 +786,27 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.14.tgz",
-      "integrity": "sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.1.0.tgz",
+      "integrity": "sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==",
       "requires": {
-        "@ethersproject/base64": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/base64": "^5.1.0",
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.10.tgz",
-      "integrity": "sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.1.0.tgz",
+      "integrity": "sha512-NsUCi/TpBb+oTFvMSccUkJGtp5o/84eOyqp5q5aBeiNBSLkYyw21znRn9mAmxZgySpxgruVgKbaapnYPgvctPQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/hash": "^5.1.0",
+        "@ethersproject/logger": "^5.1.0",
+        "@ethersproject/properties": "^5.1.0",
+        "@ethersproject/strings": "^5.1.0"
       }
     },
     "@peculiar/asn1-schema": {
@@ -754,6 +838,11 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
       "integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
       "dev": true
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -851,9 +940,9 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1js": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
-      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
+      "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
       "requires": {
         "pvutils": "^1.0.17"
       }
@@ -946,6 +1035,15 @@
       "optional": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "camelcase": {
@@ -1057,9 +1155,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js-pure": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
-      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A=="
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.10.1.tgz",
+      "integrity": "sha512-PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw=="
     },
     "debug": {
       "version": "4.3.2",
@@ -1122,74 +1220,74 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "ethers": {
-      "version": "5.0.32",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
-      "integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.1.0.tgz",
+      "integrity": "sha512-2L6Ge6wMBw02FlRoCLg4E0Elt3khMNlW6ULawa10mMeeZToYJ5+uCfiuTuB+XZ6om1Y7wuO9ZzezP8FsU2M/+g==",
       "requires": {
-        "@ethersproject/abi": "5.0.13",
-        "@ethersproject/abstract-provider": "5.0.10",
-        "@ethersproject/abstract-signer": "5.0.14",
-        "@ethersproject/address": "5.0.11",
-        "@ethersproject/base64": "5.0.9",
-        "@ethersproject/basex": "5.0.9",
-        "@ethersproject/bignumber": "5.0.15",
-        "@ethersproject/bytes": "5.0.11",
-        "@ethersproject/constants": "5.0.10",
-        "@ethersproject/contracts": "5.0.12",
-        "@ethersproject/hash": "5.0.12",
-        "@ethersproject/hdnode": "5.0.10",
-        "@ethersproject/json-wallets": "5.0.12",
-        "@ethersproject/keccak256": "5.0.9",
-        "@ethersproject/logger": "5.0.10",
-        "@ethersproject/networks": "5.0.9",
-        "@ethersproject/pbkdf2": "5.0.9",
-        "@ethersproject/properties": "5.0.9",
-        "@ethersproject/providers": "5.0.24",
-        "@ethersproject/random": "5.0.9",
-        "@ethersproject/rlp": "5.0.9",
-        "@ethersproject/sha2": "5.0.9",
-        "@ethersproject/signing-key": "5.0.11",
-        "@ethersproject/solidity": "5.0.10",
-        "@ethersproject/strings": "5.0.10",
-        "@ethersproject/transactions": "5.0.11",
-        "@ethersproject/units": "5.0.11",
-        "@ethersproject/wallet": "5.0.12",
-        "@ethersproject/web": "5.0.14",
-        "@ethersproject/wordlists": "5.0.10"
+        "@ethersproject/abi": "5.1.0",
+        "@ethersproject/abstract-provider": "5.1.0",
+        "@ethersproject/abstract-signer": "5.1.0",
+        "@ethersproject/address": "5.1.0",
+        "@ethersproject/base64": "5.1.0",
+        "@ethersproject/basex": "5.1.0",
+        "@ethersproject/bignumber": "5.1.0",
+        "@ethersproject/bytes": "5.1.0",
+        "@ethersproject/constants": "5.1.0",
+        "@ethersproject/contracts": "5.1.0",
+        "@ethersproject/hash": "5.1.0",
+        "@ethersproject/hdnode": "5.1.0",
+        "@ethersproject/json-wallets": "5.1.0",
+        "@ethersproject/keccak256": "5.1.0",
+        "@ethersproject/logger": "5.1.0",
+        "@ethersproject/networks": "5.1.0",
+        "@ethersproject/pbkdf2": "5.1.0",
+        "@ethersproject/properties": "5.1.0",
+        "@ethersproject/providers": "5.1.0",
+        "@ethersproject/random": "5.1.0",
+        "@ethersproject/rlp": "5.1.0",
+        "@ethersproject/sha2": "5.1.0",
+        "@ethersproject/signing-key": "5.1.0",
+        "@ethersproject/solidity": "5.1.0",
+        "@ethersproject/strings": "5.1.0",
+        "@ethersproject/transactions": "5.1.0",
+        "@ethersproject/units": "5.1.0",
+        "@ethersproject/wallet": "5.1.0",
+        "@ethersproject/web": "5.1.0",
+        "@ethersproject/wordlists": "5.1.0"
       },
       "dependencies": {
         "@ethersproject/address": {
-          "version": "5.0.11",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
-          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
+          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
           "requires": {
-            "@ethersproject/bignumber": "^5.0.13",
-            "@ethersproject/bytes": "^5.0.9",
-            "@ethersproject/keccak256": "^5.0.7",
-            "@ethersproject/logger": "^5.0.8",
-            "@ethersproject/rlp": "^5.0.7"
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/rlp": "^5.1.0"
           }
         },
         "@ethersproject/wallet": {
-          "version": "5.0.12",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.12.tgz",
-          "integrity": "sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.1.0.tgz",
+          "integrity": "sha512-ULmUtiYQLTUS+y3DgkLzRhFEK10zMwmjOthnjiZxee3Q/MVwr3rnmuAnXIUZrPjna6hvUPnyRIdW5XuF0Ld0YQ==",
           "requires": {
-            "@ethersproject/abstract-provider": "^5.0.8",
-            "@ethersproject/abstract-signer": "^5.0.10",
-            "@ethersproject/address": "^5.0.9",
-            "@ethersproject/bignumber": "^5.0.13",
-            "@ethersproject/bytes": "^5.0.9",
-            "@ethersproject/hash": "^5.0.10",
-            "@ethersproject/hdnode": "^5.0.8",
-            "@ethersproject/json-wallets": "^5.0.10",
-            "@ethersproject/keccak256": "^5.0.7",
-            "@ethersproject/logger": "^5.0.8",
-            "@ethersproject/properties": "^5.0.7",
-            "@ethersproject/random": "^5.0.7",
-            "@ethersproject/signing-key": "^5.0.8",
-            "@ethersproject/transactions": "^5.0.9",
-            "@ethersproject/wordlists": "^5.0.8"
+            "@ethersproject/abstract-provider": "^5.1.0",
+            "@ethersproject/abstract-signer": "^5.1.0",
+            "@ethersproject/address": "^5.1.0",
+            "@ethersproject/bignumber": "^5.1.0",
+            "@ethersproject/bytes": "^5.1.0",
+            "@ethersproject/hash": "^5.1.0",
+            "@ethersproject/hdnode": "^5.1.0",
+            "@ethersproject/json-wallets": "^5.1.0",
+            "@ethersproject/keccak256": "^5.1.0",
+            "@ethersproject/logger": "^5.1.0",
+            "@ethersproject/properties": "^5.1.0",
+            "@ethersproject/random": "^5.1.0",
+            "@ethersproject/signing-key": "^5.1.0",
+            "@ethersproject/transactions": "^5.1.0",
+            "@ethersproject/wordlists": "^5.1.0"
           }
         }
       }
@@ -1252,6 +1350,11 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1261,6 +1364,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1288,10 +1401,23 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "hash.js": {
       "version": "1.1.7",
@@ -1445,9 +1571,9 @@
       }
     },
     "mem": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
-      "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.0.tgz",
+      "integrity": "sha512-FIkgXo0kTi3XpvaznV5Muk6Y6w8SkdmRXcY7ZLonQesuYezp59UooLxAVBcGuN6PH2tXN84mR3vyzSc6oSMUfA==",
       "requires": {
         "map-age-cleaner": "^0.1.3",
         "mimic-fn": "^3.1.0"
@@ -1557,9 +1683,9 @@
       "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "node-abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.1.0.tgz",
-      "integrity": "sha512-dEYmUqjtbivotqjraOe8UvhT/poFfog1BQRNsZm/MSEDDESk2cQ1tvD8kGyuN07TM/zoW+n42odL8zTeJupYdQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+      "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -1592,6 +1718,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "once": {
       "version": "1.4.0",
@@ -1713,9 +1844,12 @@
       "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
     },
     "qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "quick-lru": {
       "version": "6.0.0",
@@ -1804,6 +1938,16 @@
         "buffer": "6.0.3"
       }
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "sleep-promise": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
@@ -1829,9 +1973,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "streamr-client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-5.1.0.tgz",
-      "integrity": "sha512-+RltKvWFF702V+gxzoS+MklAANBcGcURiR9DzHefBBy6H6++EBD8tSAML2qrGr2vBiLYIsYGRSQrlaNefNL33g==",
+      "version": "5.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-5.3.0-beta.0.tgz",
+      "integrity": "sha512-KGz9KpgDMIeGr3MIf++3Gu+3M8Jg28mABsMWaW7Ssl5Ak6i1CR8Tov1tzIXwr+2tD9TxzqmSigcswc5hC7ijgQ==",
       "requires": {
         "@babel/runtime": "^7.12.18",
         "@babel/runtime-corejs3": "^7.12.18",
@@ -1863,6 +2007,7 @@
         "quick-lru": "^6.0.0",
         "readable-stream": "^3.6.0",
         "streamr-client-protocol": "^8.0.0-beta.2",
+        "streamr-test-utils": "^1.3.1",
         "ts-toolbelt": "^9.3.12",
         "utf-8-validate": "^5.0.4",
         "uuid": "^8.3.2",
@@ -1878,20 +2023,26 @@
       }
     },
     "streamr-client-protocol": {
-      "version": "8.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-8.0.0-beta.2.tgz",
-      "integrity": "sha512-TwNkaBIQCyarkkTxpQuMBCu7Uqs0sH5CUK+/g6751J3ZL7VenZgv/dPRuQaatFDP5LboyRTo/qJxD+75TBfZBw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-8.0.2.tgz",
+      "integrity": "sha512-L8BYYkffM3DOqpQ+mMHvmnMAFuF0Qk/Fgn3gZykiRRDFA9urNqlr/MvPWGQbK/1q2/RC4czy9Xsa6l5MZVT4YA==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.12.13",
+        "@babel/runtime-corejs3": "^7.13.10",
+        "@types/debug": "^4.1.5",
         "debug": "^4.3.1",
-        "ethers": "^5.0.24",
+        "ethers": "^5.0.32",
         "eventemitter3": "^4.0.7",
         "heap": "^0.2.6",
         "promise-memoize": "^1.2.1",
         "secp256k1": "^4.0.2",
-        "sha3": "^2.1.3",
+        "sha3": "^2.1.4",
         "strict-event-emitter-types": "^2.0.0"
       }
+    },
+    "streamr-test-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/streamr-test-utils/-/streamr-test-utils-1.3.1.tgz",
+      "integrity": "sha512-3ol+bRQOSUz6Qjso0/VDBNzTxD9msizCOtsHgx7YqGYkxtIUSlGbsVtZh3JhBnnm53BNyaNHS74+N7Mjoa+w5Q=="
     },
     "strict-event-emitter-types": {
       "version": "2.0.0",
@@ -2007,9 +2158,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/rest-e2e-tests/package.json
+++ b/rest-e2e-tests/package.json
@@ -25,7 +25,7 @@
     "mocha": "8.2.1",
     "node-fetch": "2.6.1",
     "sleep-promise": "8.0.1",
-    "streamr-client": "5.1.0",
+    "streamr-client": "5.3.0-beta.0",
     "ts-mocha": "8.0.0",
     "typescript": "4.1.5"
   },


### PR DESCRIPTION
Update tests to be compatible with manual storage node configuration (https://github.com/streamr-dev/broker/pull/211) by explicitly adding a stream to the storage node if it needs historical data.