### PR TITLE
BACK-139: Use Ubuntu 18.04 on GitHub Actions CI and CD build

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -21,7 +21,7 @@ jobs:
 
   test:
     name: Build, lint and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-java@v1.4.3
@@ -57,7 +57,7 @@ jobs:
 
   e2e:
     name: End to end test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -119,7 +119,7 @@ jobs:
     needs:
       - test
       - e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Docker meta


### PR DESCRIPTION
Use specific version of Ubuntu. Tag `ubuntu-latest` just got updated to `ubuntu-20.04` which causes unit test JVM to crash.