### PR TITLE
NET-187: Notify storage node assignment in background

### DIFF
--- a/grails-app/domain/com/unifina/domain/Stream.groovy
+++ b/grails-app/domain/com/unifina/domain/Stream.groovy
@@ -204,4 +204,8 @@ class Stream implements Comparable {
 		}
 		throw new IllegalArgumentException("UI Channel path doesn't contain module id.")
 	}
+
+	public Integer getPartitions() {
+		return this.partitions
+	}
 }

--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -12,6 +12,36 @@ enum AssigmentEvent {
 	STREAM_REMOVED
 }
 
+class NotifyStorageNodeTask extends Thread {
+	EthereumAddress storageNodeAddress
+	String streamId
+	AssigmentEvent eventType
+	StreamService streamService
+	StreamrClientService streamrClientService
+
+	NotifyStorageNodeTask(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType, StreamService streamService, StreamrClientService streamrClientService) {
+		super("NotifyStorageNodeTask-" + System.currentTimeMillis())
+		this.storageNodeAddress = storageNodeAddress
+		this.streamId = streamId
+		this.eventType = eventType
+		this.streamService = streamService;
+		this.streamrClientService = streamrClientService
+	}
+
+	void run() {
+		Map<String,Object> message = new LinkedHashMap([
+			event: eventType.name(),
+			stream: [
+				id: streamId,
+				partitions: streamService.getStream(streamId).partitions
+			]
+		])
+		StreamrClient client = streamrClientService.getInstanceForThisEngineNode()
+		com.streamr.client.rest.Stream assignmentStream = client.getStream(StorageNodeService.createAssignmentStreamId())
+		client.publish(assignmentStream, message)
+	}
+}
+
 @GrailsCompileStatic
 class StorageNodeService {
 
@@ -41,7 +71,7 @@ class StorageNodeService {
 				storageNodeAddress: storageNodeAddress.toString()
 			)
 			StreamStorageNode saved = instance.save(validate: true)
-			notifyStorageNode(storageNodeAddress, streamId, AssigmentEvent.STREAM_ADDED)
+			new NotifyStorageNodeTask(storageNodeAddress, streamId, AssigmentEvent.STREAM_ADDED, streamService, streamrClientService).start()
 			return saved;
 		} else {
 			throw new DuplicateNotAllowedException("StorageNode", storageNodeAddress.toString())
@@ -52,7 +82,7 @@ class StorageNodeService {
 		StreamStorageNode instance = StreamStorageNode.findByStorageNodeAddressAndStreamId(storageNodeAddress.toString(), streamId)
 		if (instance != null) {
 			instance.delete()
-			notifyStorageNode(storageNodeAddress, streamId, AssigmentEvent.STREAM_REMOVED)
+			new NotifyStorageNodeTask(storageNodeAddress, streamId, AssigmentEvent.STREAM_REMOVED, streamService, streamrClientService).start()
 		} else {
 			throw new NotFoundException("StorageNode", storageNodeAddress.toString())
 		}
@@ -61,18 +91,5 @@ class StorageNodeService {
 	public static String createAssignmentStreamId() {
 		EthereumAddress nodeAddress = EthereumAddress.fromPrivateKey(ApplicationConfig.getString("streamr.ethereum.nodePrivateKey"))
 		return nodeAddress.toString() + "/storage-node-assignments"
-	}
-
-	private notifyStorageNode(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType) {
-		Map<String,Object> message = new LinkedHashMap([
-			event: eventType.name(),
-			stream: [
-				id: streamId,
-				partitions: streamService.getStream(streamId).partitions
-			]
-		])
-		StreamrClient client = streamrClientService.getInstanceForThisEngineNode()
-		com.streamr.client.rest.Stream assignmentStream = client.getStream(StorageNodeService.createAssignmentStreamId())
-		client.publish(assignmentStream, message)
 	}
 }

--- a/src/java/com/unifina/service/NotifyStorageNodeTask.java
+++ b/src/java/com/unifina/service/NotifyStorageNodeTask.java
@@ -1,0 +1,54 @@
+package com.unifina.service;
+
+import com.streamr.client.StreamrClient;
+import com.unifina.domain.Stream;
+import com.unifina.domain.StreamStorageNode;
+import com.unifina.domain.EthereumAddress;
+import org.apache.log4j.Logger;
+import java.util.Map;
+import java.util.HashMap;
+
+public class NotifyStorageNodeTask extends Thread {
+
+    private static final Logger log = Logger.getLogger(NotifyStorageNodeTask.class);
+
+    public enum AssigmentEvent {
+	    STREAM_ADDED,
+	    STREAM_REMOVED
+    }
+
+	EthereumAddress storageNodeAddress;
+	String streamId;
+	AssigmentEvent eventType;
+	StreamService streamService;
+	StreamrClientService streamrClientService;
+
+	public NotifyStorageNodeTask(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType, StreamService streamService, StreamrClientService streamrClientService) {
+		super("NotifyStorageNodeTask-" + System.currentTimeMillis());
+		this.storageNodeAddress = storageNodeAddress;
+		this.streamId = streamId;
+		this.eventType = eventType;
+		this.streamService = streamService;
+		this.streamrClientService = streamrClientService;
+	}
+
+	public void run() {
+		StreamrClient client = streamrClientService.getInstanceForThisEngineNode();
+        try {
+			com.streamr.client.rest.Stream assignmentStream = client.getStream(StorageNodeService.createAssignmentStreamId());
+		    client.publish(assignmentStream, createMessage());
+        } catch (Exception e) {
+            log.warn("Unable to notify StorageNode: streamId=" + streamId + ", event=" + eventType);
+        }
+	}
+
+    private Map<String,Object> createMessage() {
+		Map<String,Object> message = new HashMap();
+        message.put("event", eventType.name());
+        Map<String,Object> stream = new HashMap();
+        stream.put("id", streamId);
+        stream.put("partitions", streamService.getStream(streamId).getPartitions());
+		message.put("stream", stream);
+        return message;
+    }
+}

--- a/src/java/com/unifina/service/NotifyStorageNodeTask.java
+++ b/src/java/com/unifina/service/NotifyStorageNodeTask.java
@@ -8,20 +8,20 @@ import org.apache.log4j.Logger;
 import java.util.Map;
 import java.util.HashMap;
 
-public class NotifyStorageNodeTask extends Thread {
+final class NotifyStorageNodeTask extends Thread {
 
-    private static final Logger log = Logger.getLogger(NotifyStorageNodeTask.class);
+	private static final Logger log = Logger.getLogger(NotifyStorageNodeTask.class);
 
-    public enum AssigmentEvent {
-	    STREAM_ADDED,
-	    STREAM_REMOVED
-    }
+	public enum AssigmentEvent {
+		STREAM_ADDED,
+		STREAM_REMOVED
+	}
 
-	EthereumAddress storageNodeAddress;
-	String streamId;
-	AssigmentEvent eventType;
-	StreamService streamService;
-	StreamrClientService streamrClientService;
+	final EthereumAddress storageNodeAddress;
+	final String streamId;
+	final AssigmentEvent eventType;
+	final StreamService streamService;
+	final StreamrClientService streamrClientService;
 
 	public NotifyStorageNodeTask(EthereumAddress storageNodeAddress, String streamId, AssigmentEvent eventType, StreamService streamService, StreamrClientService streamrClientService) {
 		super("NotifyStorageNodeTask-" + System.currentTimeMillis());
@@ -34,21 +34,21 @@ public class NotifyStorageNodeTask extends Thread {
 
 	public void run() {
 		StreamrClient client = streamrClientService.getInstanceForThisEngineNode();
-        try {
+		try {
 			com.streamr.client.rest.Stream assignmentStream = client.getStream(StorageNodeService.createAssignmentStreamId());
-		    client.publish(assignmentStream, createMessage());
-        } catch (Exception e) {
-            log.warn("Unable to notify StorageNode: streamId=" + streamId + ", event=" + eventType);
-        }
+			client.publish(assignmentStream, createMessage());
+		} catch (Exception e) {
+			log.warn("Unable to notify StorageNode: streamId=" + streamId + ", event=" + eventType);
+		}
 	}
 
-    private Map<String,Object> createMessage() {
+	private Map<String,Object> createMessage() {
 		Map<String,Object> message = new HashMap();
-        message.put("event", eventType.name());
-        Map<String,Object> stream = new HashMap();
-        stream.put("id", streamId);
-        stream.put("partitions", streamService.getStream(streamId).getPartitions());
+		message.put("event", eventType.name());
+		Map<String,Object> stream = new HashMap();
+		stream.put("id", streamId);
+		stream.put("partitions", streamService.getStream(streamId).getPartitions());
 		message.put("stream", stream);
-        return message;
-    }
+		return message;
+	}
 }


### PR DESCRIPTION
When stream is added to storage node or removed from it, the E&E notifies the broker by publishing event to `0xFCAd0B19bB29D4674531d6f115237E16AfCE377c/storage-node-assignments` stream. Changed that publish task to be asynchronous background operation. 

The add/remove operation doesn't need to wait for the notification task to complete. E&E can respond with a success status even if the notification fails from some reason.